### PR TITLE
Remove substrate irrigation method linkage

### DIFF
--- a/data/blueprints/substrates/coco_coir.json
+++ b/data/blueprints/substrates/coco_coir.json
@@ -4,12 +4,6 @@
   "kind": "Substrate",
   "name": "Coco Coir",
   "type": "coco",
-  "supportedIrrigationMethodIds": [
-    "b7a5d5fa-6561-4a1c-93c8-2d3f9a11c201",
-    "c8f3a2b1-7d4e-4c9a-b5e6-3f8a9c1d2e4f",
-    "d9e4b3c2-8e5f-5d0b-c6f7-4g9b0d2e3f5g",
-    "e0f5c4d3-9f6g-6e1c-d7g8-5h0c1e3f4g6h"
-  ],
   "maxCycles": 4,
   "meta": {
     "description": "Buffered coco coir blend optimized for drain-to-waste or recirculating fertigation systems with multiple reuse cycles.",

--- a/data/blueprints/substrates/soil_multi_cycle.json
+++ b/data/blueprints/substrates/soil_multi_cycle.json
@@ -4,11 +4,6 @@
   "kind": "Substrate",
   "name": "Multi-Cycle Soil Mix",
   "type": "soil",
-  "supportedIrrigationMethodIds": [
-    "b7a5d5fa-6561-4a1c-93c8-2d3f9a11c201",
-    "c8f3a2b1-7d4e-4c9a-b5e6-3f8a9c1d2e4f",
-    "e0f5c4d3-9f6g-6e1c-d7g8-5h0c1e3f4g6h"
-  ],
   "maxCycles": 2,
   "meta": {
     "description": "Reconditionable soil blend that survives two full runs with proper amendment and sterilization between crops.",

--- a/data/blueprints/substrates/soil_single_cycle.json
+++ b/data/blueprints/substrates/soil_single_cycle.json
@@ -4,10 +4,6 @@
   "kind": "Substrate",
   "name": "Single-Cycle Soil Mix",
   "type": "soil",
-  "supportedIrrigationMethodIds": [
-    "b7a5d5fa-6561-4a1c-93c8-2d3f9a11c201",
-    "c8f3a2b1-7d4e-4c9a-b5e6-3f8a9c1d2e4f"
-  ],
   "maxCycles": 1,
   "meta": {
     "description": "Pre-charged soil mix formulated for one-and-done harvests; ideal when designers prefer a fresh medium each run.",

--- a/docs/ADR/ADR-0002-cultivation-method-irrigation-link.md
+++ b/docs/ADR/ADR-0002-cultivation-method-irrigation-link.md
@@ -1,7 +1,7 @@
 # ADR-0002: Cultivation method irrigation compatibility via substrates
 
 ## Status
-Accepted
+Superseded by [ADR-0003](ADR-0003-irrigation-compatibility-source-of-truth.md)
 
 ## Context
 Simulation Engine Contract (SEC) §7.5 previously required cultivation methods to list compatible irrigation methods directly. ISSUE-0002 remediation work revealed that blueprints also need richer substrate metadata. To reduce duplication and keep irrigation compatibility tied to physical media behavior, we want substrates to declare which irrigation methods they support. Cultivation methods should therefore inherit irrigation compatibility through the substrates they offer rather than duplicating lists.

--- a/docs/ADR/ADR-0003-irrigation-compatibility-source-of-truth.md
+++ b/docs/ADR/ADR-0003-irrigation-compatibility-source-of-truth.md
@@ -1,0 +1,18 @@
+# ADR-0003: Irrigation compatibility source of truth anchored at irrigation methods
+
+## Status
+Accepted
+
+## Context
+ADR-0002 shifted irrigation compatibility metadata from cultivation methods to substrates via a `supportedIrrigationMethodIds` array. In practice this duplicated the compatibility mapping already present on irrigation method blueprints (`compatibility.substrates`) and introduced drift risks whenever substrate files were updated without touching irrigation methods. The duplication also forced chore updates across every substrate blueprint when a new irrigation method was introduced or renamed. We need a single authoritative place to express which substrates an irrigation method can service.
+
+## Decision
+- Remove `supportedIrrigationMethodIds` from substrate blueprints entirely.
+- Treat irrigation method blueprints as the canonical source of irrigation/substrate compatibility by continuing to require `compatibility.substrates`.
+- Update SEC, DD, and TDD guidance so cultivation methods infer irrigation support by cross-referencing the substrate slug against irrigation methods that list it, avoiding redundant arrays on substrate definitions.
+- Mark ADR-0002 as superseded by this decision to preserve historical context.
+
+## Consequences
+- Substrate blueprints no longer need updates when irrigation methods change; compatibility management happens in one place.
+- Validation logic must ensure that any cultivation method or zone pairing between substrates and irrigation methods checks the irrigation blueprint compatibility list.
+- Tooling that previously read `supportedIrrigationMethodIds` from substrates must migrate to query irrigation methods instead.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 All notable changes to this repository will be documented in this file.
 
+## [2025-10-03] Irrigation compatibility source of truth correction
+- Removed `supportedIrrigationMethodIds` from substrate blueprints; irrigation compatibility is now resolved from irrigation method blueprints that list compatible substrates under `compatibility.substrates`.
+- Superseded ADR-0002 with ADR-0003 to document the irrigation-method-driven compatibility model and refreshed SEC/DD/TDD guidance accordingly.
+
 ## [2025-10-02] Cultivation method blueprint field alignment
 - Renamed cultivation method planting density to `areaPerPlant_m2` and updated container/substrate references to concrete blueprint slugs.
-- Shifted irrigation compatibility to substrate blueprints via `supportedIrrigationMethodIds`, removing direct `irrigationMethodIds` from cultivation methods (see ADR-0002).
+- Shifted irrigation compatibility to substrate blueprints via `supportedIrrigationMethodIds`, removing direct `irrigationMethodIds` from cultivation methods (see ADR-0002, superseded by ADR-0003).
 - Added ADR-0002 documenting the substrate-driven irrigation compatibility decision and refreshed SEC/DD/AGENTS guidance.
 
 ## [2025-10-01] Data audit groundwork

--- a/docs/DD.md
+++ b/docs/DD.md
@@ -96,12 +96,12 @@ Hierarchy and constraints:
   "name": "Screen of Green",
   "areaPerPlant_m2": 0.20,
   "containers": [ { "id": "uuid", "slug": "pot-10l", "capex_per_unit": 2.0, "serviceLife_cycles": 8 } ],
-  "substrates": [ { "id": "uuid", "slug": "soil-basic", "unitPrice_per_L": 0.15, "densityFactor_L_per_kg": 0.7, "reusePolicy": { "maxCycles": 1, "sterilizationTaskCode": "sterilize_substrate" }, "supportedIrrigationMethodIds": ["hand-watering", "drip-emitters"] } ],
+  "substrates": [ { "id": "uuid", "slug": "soil-basic", "unitPrice_per_L": 0.15, "densityFactor_L_per_kg": 0.7, "reusePolicy": { "maxCycles": 1, "sterilizationTaskCode": "sterilize_substrate" } } ],
   "notes": "SEC §7.5 compliant"
 }
 ```
 
-> **Irrigation compatibility note:** Cultivation methods no longer list irrigation method IDs directly; compatibility is inherited from the selected substrate option's `supportedIrrigationMethodIds`.
+> **Irrigation compatibility note:** Cultivation methods no longer list irrigation method IDs directly. Instead, irrigation method blueprints enumerate the substrates they support via `compatibility.substrates`, and methods inherit compatibility from whichever substrate option a zone selects.
 
 ---
 

--- a/docs/SEC.md
+++ b/docs/SEC.md
@@ -435,7 +435,7 @@ Validation occurs at load time; on failure, the engine must not start.
         
     - **Substrate:** one or more **substrate options** with **purchase unit** (e.g., per L or per kg), **density factor** to convert L↔kg if needed, and **unit price**; optional **re-use/sterilization policy**.
         
-    - **Irrigation compatibility:** determined indirectly through substrate options. Each substrate blueprint referenced by the cultivation method **SHALL** declare its supported irrigation methods (ids) and any scheduling constraints; the cultivation method inherits compatibility from the selected substrate.
+    - **Irrigation compatibility:** determined indirectly through substrate options. Irrigation method blueprints **SHALL** declare the substrate slugs they support under `compatibility.substrates`; cultivation methods inherit compatibility from the irrigation methods that list their chosen substrate.
         
 - **Costs (SHALL):**
     

--- a/docs/TDD.md
+++ b/docs/TDD.md
@@ -219,6 +219,7 @@ it('hourly cost derives from power draw (W) and tariff (kWh)', () => {
 ## 9) Cultivation Methods on Zones (SEC §7.5)
 
 - Zone **must** reference a `cultivationMethod` defining **containers**, **substrates** (incl. `densityFactor_L_per_kg`), **irrigation** compatibility, and **planting density**.
+  - Irrigation compatibility is derived from irrigation method blueprints that list the substrate slug under `compatibility.substrates`; zones selecting a substrate without matching irrigation support should fail validation.
     
 
 ```ts


### PR DESCRIPTION
## Summary
- remove the deprecated supportedIrrigationMethodIds property from substrate blueprints
- document irrigation compatibility as irrigation-method driven across SEC, DD, TDD, and changelog updates
- add ADR-0003 to supersede ADR-0002 and record the new single-source-of-truth decision

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dde78099d8832595da3a53857ff071