### PR TITLE
Add ADR for canonical simulation constants alignment

### DIFF
--- a/docs/ADR/ADR-0001-constants-alignment.md
+++ b/docs/ADR/ADR-0001-constants-alignment.md
@@ -1,0 +1,20 @@
+# ADR-0001: Canonical simulation constants alignment
+
+## Status
+Accepted
+
+## Context
+The Simulation Engine Contract (SEC v0.2.1 §1.2) and downstream design documentation already specify the canonical geometry and calendar constants the engine must honor, notably `AREA_QUANTUM_M2 = 0.25` and `ROOM_DEFAULT_HEIGHT_M = 3`. The same values are reiterated in the Design Document (DD §2), Testing & Diagnostics Document (TDD §1), AGENTS guardrails (§3), and the product vision (VISION_SCOPE §15). Without an Architecture Decision Record, the alignment only existed as repeated prose, and tooling proposals have begun to drift—`tasks.json` still advertises an exporter contract with `AREA_QUANTUM_M2 = 0.5`, contradicting the SEC baseline.
+
+## Decision
+- Affirm the SEC-defined canonical constants as normative for the entire stack:
+  - `AREA_QUANTUM_M2 = 0.25`
+  - `ROOM_DEFAULT_HEIGHT_M = 3`
+  - Calendar invariants `HOURS_PER_DAY = 24`, `DAYS_PER_MONTH = 30`, `MONTHS_PER_YEAR = 12`
+- Record the precedence order for simulation constants in this ADR to mirror the documentation contract hierarchy (SEC → DD → TDD → AGENTS → VISION_SCOPE) and ensure any change flows through all affected documents and the shared `simConstants` module.
+- Flag the legacy exporter specification advertising `AREA_QUANTUM_M2 = 0.5` for correction so downstream integrations are updated alongside the SEC-aligned constants.
+
+## Consequences
+- Future modifications to canonical constants require updating this ADR plus the SEC/DD/TDD/AGENTS/VISION_SCOPE documents to preserve the documented precedence chain.
+- Tooling that assumed the `0.5 m²` area quantum must be adjusted to the `0.25 m²` baseline; export contracts and fixtures should align with the shared `simConstants` definitions.
+- The documentation set now has an authoritative historical record for why these constants are fixed, reducing the risk of silent drift across specs, code, and integrations.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this repository will be documented in this file.
 
+## [2025-10-04] Canonical simulation constants alignment
+- Added ADR-0001 to capture the canonical simulation constants contract (`AREA_QUANTUM_M2 = 0.25`, `ROOM_DEFAULT_HEIGHT_M = 3`, calendar invariants) and document precedence across SEC, DD, TDD, AGENTS, and VISION_SCOPE.
+- Flagged exporter tooling drift that still referenced `AREA_QUANTUM_M2 = 0.5`, aligning it with the SEC baseline in the decision history.
+
 ## [2025-10-03] Irrigation compatibility source of truth correction
 - Removed `supportedIrrigationMethodIds` from substrate blueprints; irrigation compatibility is now resolved from irrigation method blueprints that list compatible substrates under `compatibility.substrates`.
 - Superseded ADR-0002 with ADR-0003 to document the irrigation-method-driven compatibility model and refreshed SEC/DD/TDD guidance accordingly.


### PR DESCRIPTION
## Summary
- add ADR-0001 to capture the canonical simulation constants contract, document precedence, and flag the lingering exporter drift
- update the changelog with a new entry referencing ADR-0001

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dde93c119483258a9f9f84bae92ae5