### PR TITLE
issue-0003 align economy price map docs

### DIFF
--- a/docs/ADR/ADR-0004-issue-0003-economy-price-map-alignment.md
+++ b/docs/ADR/ADR-0004-issue-0003-economy-price-map-alignment.md
@@ -1,0 +1,25 @@
+# ADR-0004: Issue-0003 economy price map alignment
+
+## Status
+Accepted
+
+## Context
+Issue-0003 tracked multiple violations of the SEC §3.6 pricing guidance:
+
+- Device blueprints and price maps were inconsistent about how recurring maintenance was represented, with drift between `maintenanceCostPerHour` fields and the intended base/increase split.
+- Grow room blueprints leaked a `baseRentPerTick` field that contradicted the per-hour economy standard and overlapped with facility economics handled elsewhere.
+- Utility pricing mixed electricity, water, and a stray `pricePerGramNutrients` knob, leaving ambiguity about which tariffs the engine should honor as the canonical configuration.
+
+These discrepancies made it impossible to resolve tariffs deterministically at simulation start and threatened future automation that depends on predictable maintenance curves.
+
+## Decision
+- Normalize `/data/prices/devicePrices.json` so every entry exposes **`capitalExpenditure`**, **`baseMaintenanceCostPerHour`**, and **`costIncreasePer1000Hours`**.
+- Remove the nonsensical `baseRentPerTick` field from the grow room blueprint.
+- Establish `/data/prices/utilityPrices.json` as the single source of truth for tariff configuration exposing **only** `price_electricity` (€/kWh) and `price_water` (€/m³); drop the nutrient price entry entirely.
+- Update SEC, DD, TDD, and Vision/Scope documentation to call out these canonical field names and the fact that nutrient costs come through irrigation/substrate consumption rather than a utility tariff.
+
+## Consequences
+- Maintenance scheduling and cost accrual can rely on the base/increase contract without guessing which field to read.
+- Room blueprints stay focused on spatial semantics; rent modelling will live in dedicated economy systems if/when needed.
+- Tariff resolution utilities can load `/data/prices/utilityPrices.json` as-is, confident that the map aligns with SEC policy and contains no unrelated knobs.
+- Tooling and validation must flag regressions if new tariff fields appear or if device maintenance schemas drift from the base/increase structure.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this repository will be documented in this file.
 
+## [2025-10-05] Issue-0003 economy price map alignment
+- Added ADR-0004 documenting the canonical maintenance and tariff price maps (device maintenance base/increase fields; utility tariffs limited to electricity & water).
+- Normalized `/data/prices/devicePrices.json` maintenance keys, confirmed grow room blueprints omit `baseRentPerTick`, and set `/data/prices/utilityPrices.json` as the single source of truth for `price_electricity`/`price_water`.
+- Updated SEC, DD, TDD, and Vision/Scope guidance to reflect the canonical field names and removal of the nutrient tariff knob.
+
 ## [2025-10-04] Canonical simulation constants alignment
 - Added ADR-0001 to capture the canonical simulation constants contract (`AREA_QUANTUM_M2 = 0.25`, `ROOM_DEFAULT_HEIGHT_M = 3`, calendar invariants) and document precedence across SEC, DD, TDD, AGENTS, and VISION_SCOPE.
 - Flagged exporter tooling drift that still referenced `AREA_QUANTUM_M2 = 0.5`, aligning it with the SEC baseline in the decision history.

--- a/docs/DD.md
+++ b/docs/DD.md
@@ -87,6 +87,11 @@ Hierarchy and constraints:
 
 **Blueprints are templates**; never mutated at runtime. **Prices are separated** from device blueprints.
 
+### 4.2 Price Maps
+
+- `/data/prices/devicePrices.json` captures device **CapEx** (`capitalExpenditure`) and **maintenance** progression (`baseMaintenanceCostPerHour`, `costIncreasePer1000Hours`).
+- `/data/prices/utilityPrices.json` is the canonical tariff source exposing **`price_electricity` (€/kWh)** and **`price_water` (€/m³)** only; nutrient costs are derived from irrigation/substrate consumption, not a standalone utility price.
+
 ### 4.1 Cultivation Method (minimum shape)
 
 ```json

--- a/docs/SEC.md
+++ b/docs/SEC.md
@@ -260,14 +260,15 @@ Validation occurs at load time; on failure, the engine must not start.
     
 - **Aggregation (SHOULD):** Reports integrate to day/week/month.
     
-- **Consistency (SHALL):** Resource prices use unit pricing (e.g., `price_per_kWh`, `price_per_m3`, `price_per_kg`).
+- **Consistency (SHALL):** Resource prices use unit pricing (e.g., `price_electricity` per kWh, `price_water` per m³, `price_per_kg`).
+- **Price maps (SHALL):** `/data/prices/devicePrices.json` enumerates device **CapEx** (`capitalExpenditure`) and **maintenance curve parameters** (`baseMaintenanceCostPerHour`, `costIncreasePer1000Hours`). `/data/prices/utilityPrices.json` is the canonical tariff source exposing **`price_electricity` (€/kWh)** and **`price_water` (€/m³)**. Nutrient inputs are costed via irrigation/substrate consumption — there is **no nutrient tariff entry** in the utility map.
     
 - **Legacy (MAY):** Migrate `per_tick → per_hour` via configured tick length.
     
 
 #### 3.6.1 Electricity Tariff Policy (STRICT)
 
-- **Backend tariff (SHALL):** The **electricity price is fixed and configured in backend settings** as `price_per_kWh` (currency per kWh).
+- **Backend tariff (SHALL):** The **electricity price is fixed and configured in backend settings** as `price_electricity` (currency per kWh) sourced from `/data/prices/utilityPrices.json`.
     
 - **Difficulty modifiers (SHALL):** Difficulty may **either**
     
@@ -278,7 +279,7 @@ Validation occurs at load time; on failure, the engine must not start.
         
 - **Determinism (SHALL):** The effective tariff **MUST** be fully determined by the loaded configuration at simulation start (including difficulty). Changing difficulty mid-run **SHALL** be disallowed or treated as an explicit administrative migration.
     
-- **Computation (SHALL):** Device energy use integrates **power (kW) × time (h) → kWh**, then multiplies by the **effective `price_per_kWh`** to accrue cost.
+- **Computation (SHALL):** Device energy use integrates **power (kW) × time (h) → kWh**, then multiplies by the **effective `price_electricity`** to accrue cost.
     
 - **Reporting (SHOULD):** Read-models expose both **consumption (kWh)** and **cost** per period.
     
@@ -515,7 +516,7 @@ Validation occurs at load time; on failure, the engine must not start.
 
 - **Consumption:** energy (kWh), water (m³ or L), nutrients (kg) aggregated per tick.
     
-- **Energy pricing:** costs computed using **effective `price_per_kWh`** per §3.6.1.
+- **Energy pricing:** costs computed using **effective `price_electricity`** per §3.6.1.
     
 - **Maintenance:** time-dependent maintenance curves per device; replacement suggestions to planning.
     

--- a/docs/TDD.md
+++ b/docs/TDD.md
@@ -184,11 +184,15 @@ it('executes fixed order', async () => {
 ## 8) Economy & Tariffs (SEC §3.6)
 
 - **Per‑hour units only** in all recurring costs.
-    
+
 - **Tariffs (hotfix):** backend config exposes **`price_electricity`** (per kWh) and **`price_water`** (per m³).
-    
+
+- **Source of truth:** `/data/prices/utilityPrices.json` is the canonical tariff map and **only** carries electricity and water prices; nutrient costs are covered by irrigation/substrate consumption flows.
+
+- **Device maintenance:** `/data/prices/devicePrices.json` provides `capitalExpenditure`, `baseMaintenanceCostPerHour`, and `costIncreasePer1000Hours`. Schema tests must guard these identifiers.
+
 - Difficulty layer may set **`energyPriceFactor`/`energyPriceOverride`** and **`waterPriceFactor`/`waterPriceOverride`**; **override wins**.
-    
+
 - Effective tariffs computed **once at sim start**.
     
 

--- a/docs/VISION_SCOPE.md
+++ b/docs/VISION_SCOPE.md
@@ -181,6 +181,8 @@
 - Recurring costs use **per‑hour** units; **no `*_per_tick`**.
     
 - **Tariffs:** Backend exposes **`price_electricity`** (€/kWh) and **`price_water`** (€/m³). Difficulty may set **`energyPriceFactor`/`energyPriceOverride`** and **`waterPriceFactor`/`waterPriceOverride`** (**override wins**). Effective tariffs are computed **once at simulation start**.
+- **Tariff source:** `/data/prices/utilityPrices.json` is the single source of truth for electricity & water tariffs; nutrient pricing flows through irrigation/substrate consumption instead of a utility entry.
+- **Device maintenance pricing:** `/data/prices/devicePrices.json` carries `capitalExpenditure`, `baseMaintenanceCostPerHour`, and `costIncreasePer1000Hours` for maintenance curves.
     
 - **Electric power → heat:** Non‑useful electrical power becomes **sensible heat** in the hosting zone unless exported.
     


### PR DESCRIPTION
### **User description**
## Summary
- document canonical maintenance and tariff price maps across SEC, DD, TDD, and Vision/Scope
- add ADR-0004 to capture the issue-0003 price map alignment decision
- update the changelog to log the resolution of issue-0003

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68ddecd66bc08325baeaed5d08a18455


___

### **PR Type**
Documentation


___

### **Description**
- Add ADR-0004 documenting economy price map alignment

- Standardize device maintenance fields across price maps

- Establish canonical utility tariff structure

- Update documentation to reflect pricing field changes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  ADR["ADR-0004 Decision"] --> DevicePrices["devicePrices.json standardization"]
  ADR --> UtilityPrices["utilityPrices.json canonical tariffs"]
  DevicePrices --> Maintenance["baseMaintenanceCostPerHour + costIncreasePer1000Hours"]
  UtilityPrices --> Tariffs["price_electricity + price_water only"]
  Maintenance --> Docs["SEC/DD/TDD/Vision updates"]
  Tariffs --> Docs
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ADR-0004-issue-0003-economy-price-map-alignment.md</strong><dd><code>Add ADR for economy price standardization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/ADR/ADR-0004-issue-0003-economy-price-map-alignment.md

<ul><li>Create new ADR documenting price map alignment decision<br> <li> Define canonical device maintenance fields structure<br> <li> Establish utility pricing as electricity and water only<br> <li> Remove nutrient pricing from utility tariffs</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/30/files#diff-b0943d95c28864504e82af149def0c1f2b9af105841cccfc725fbb623c056f06">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Log price map alignment changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/CHANGELOG.md

<ul><li>Add entry for issue-0003 price map alignment resolution<br> <li> Document ADR-0004 addition and price structure changes</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/30/files#diff-2bfab3db5cc1baf4c6d3ff6b19901926e3bdf4411ec685dac973e5fcff1c723b">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DD.md</strong><dd><code>Document canonical price map structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/DD.md

<ul><li>Add price maps section defining device and utility pricing<br> <li> Specify canonical field names for maintenance and tariffs</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/30/files#diff-4105e48a62a7da3f23c2358cac7ff538acd430e322a7444271b78e9b2210294a">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SEC.md</strong><dd><code>Standardize pricing field references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/SEC.md

<ul><li>Update electricity tariff field names to <code>price_electricity</code><br> <li> Add price maps specification with canonical field names<br> <li> Define utility pricing structure excluding nutrients</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/30/files#diff-ea545a2382e40e0dca4108b37a31b9f012fc494d137177e29a59c034f2fc06e4">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TDD.md</strong><dd><code>Update economy testing requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/TDD.md

<ul><li>Add utility pricing source of truth specification<br> <li> Define device maintenance pricing field requirements<br> <li> Update tariff field naming consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/30/files#diff-c63c42f48fafc730ffe37944d96bcb50e147434901be8b1d3dbc50fc36573fc3">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>VISION_SCOPE.md</strong><dd><code>Update vision scope pricing details</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/VISION_SCOPE.md

<ul><li>Add tariff source specification for utility pricing<br> <li> Define device maintenance pricing field structure</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/30/files#diff-97dbfc617ba23df4588158125bdbc8cdb16da87d172e0f0e90fdfe2c22137f02">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

