### PR TITLE
docs: enforce currency-neutral terminology

### DIFF
--- a/docs/ADR/ADR-0004-issue-0003-economy-price-map-alignment.md
+++ b/docs/ADR/ADR-0004-issue-0003-economy-price-map-alignment.md
@@ -15,7 +15,7 @@ These discrepancies made it impossible to resolve tariffs deterministically at s
 ## Decision
 - Normalize `/data/prices/devicePrices.json` so every entry exposes **`capitalExpenditure`**, **`baseMaintenanceCostPerHour`**, and **`costIncreasePer1000Hours`**.
 - Remove the nonsensical `baseRentPerTick` field from the grow room blueprint.
-- Establish `/data/prices/utilityPrices.json` as the single source of truth for tariff configuration exposing **only** `price_electricity` (€/kWh) and `price_water` (€/m³); drop the nutrient price entry entirely.
+- Establish `/data/prices/utilityPrices.json` as the single source of truth for tariff configuration exposing **only** `price_electricity` (cost per kWh, currency-neutral) and `price_water` (cost per m³, currency-neutral); drop the nutrient price entry entirely.
 - Update SEC, DD, TDD, and Vision/Scope documentation to call out these canonical field names and the fact that nutrient costs come through irrigation/substrate consumption rather than a utility tariff.
 
 ## Consequences

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this repository will be documented in this file.
 
+## [2025-10-06] Currency-neutral terminology enforcement
+- Clarified across SEC, DD, TDD, and Vision Scope that monetary identifiers and UI copy must remain currency-neutral, forbidding baked-in codes/symbols (EUR, USD, GBP, etc.).
+- Updated reference docs and prompts to describe tariffs and KPIs using neutral cost phrasing instead of currency-specific notation.
+
 ## [2025-10-05] Issue-0003 economy price map alignment
 - Added ADR-0004 documenting the canonical maintenance and tariff price maps (device maintenance base/increase fields; utility tariffs limited to electricity & water).
 - Normalized `/data/prices/devicePrices.json` maintenance keys, confirmed grow room blueprints omit `baseRentPerTick`, and set `/data/prices/utilityPrices.json` as the single source of truth for `price_electricity`/`price_water`.

--- a/docs/DD.md
+++ b/docs/DD.md
@@ -90,7 +90,8 @@ Hierarchy and constraints:
 ### 4.2 Price Maps
 
 - `/data/prices/devicePrices.json` captures device **CapEx** (`capitalExpenditure`) and **maintenance** progression (`baseMaintenanceCostPerHour`, `costIncreasePer1000Hours`).
-- `/data/prices/utilityPrices.json` is the canonical tariff source exposing **`price_electricity` (€/kWh)** and **`price_water` (€/m³)** only; nutrient costs are derived from irrigation/substrate consumption, not a standalone utility price.
+- `/data/prices/utilityPrices.json` is the canonical tariff source exposing **`price_electricity` per kWh** and **`price_water` per m³** only; nutrient costs are derived from irrigation/substrate consumption, not a standalone utility price.
+    - **Decision:** Monetary field names stay currency-neutral — never encode `EUR`, `USD`, `GBP`, symbols, or locale-specific suffixes. Scenario configuration contextualizes the neutral cost values.
 
 ### 4.1 Cultivation Method (minimum shape)
 
@@ -259,8 +260,8 @@ Fixed order per tick:
 ```ts
 // src/backend/src/config/runtime.ts (facade)
 export interface BackendConfig {
-  price_electricity: number; // €/kWh
-  price_water: number;       // €/m^3
+  price_electricity: number; // cost per kWh (currency-neutral)
+  price_water: number;       // cost per m^3 (currency-neutral)
   difficulty?: {
     energyPriceFactor?: number;
     energyPriceOverride?: number;

--- a/docs/SEC.md
+++ b/docs/SEC.md
@@ -261,14 +261,15 @@ Validation occurs at load time; on failure, the engine must not start.
 - **Aggregation (SHOULD):** Reports integrate to day/week/month.
     
 - **Consistency (SHALL):** Resource prices use unit pricing (e.g., `price_electricity` per kWh, `price_water` per m³, `price_per_kg`).
-- **Price maps (SHALL):** `/data/prices/devicePrices.json` enumerates device **CapEx** (`capitalExpenditure`) and **maintenance curve parameters** (`baseMaintenanceCostPerHour`, `costIncreasePer1000Hours`). `/data/prices/utilityPrices.json` is the canonical tariff source exposing **`price_electricity` (€/kWh)** and **`price_water` (€/m³)**. Nutrient inputs are costed via irrigation/substrate consumption — there is **no nutrient tariff entry** in the utility map.
+- **Neutral terminology (SHALL):** Monetary fields **MUST NOT** embed currency symbols or codes (e.g., `*_EUR`, `*_USD`, `€`); values are interpreted as neutral costs that scenarios contextualize.
+- **Price maps (SHALL):** `/data/prices/devicePrices.json` enumerates device **CapEx** (`capitalExpenditure`) and **maintenance curve parameters** (`baseMaintenanceCostPerHour`, `costIncreasePer1000Hours`). `/data/prices/utilityPrices.json` is the canonical tariff source exposing **`price_electricity` per kWh** and **`price_water` per m³**. Nutrient inputs are costed via irrigation/substrate consumption — there is **no nutrient tariff entry** in the utility map.
     
 - **Legacy (MAY):** Migrate `per_tick → per_hour` via configured tick length.
     
 
 #### 3.6.1 Electricity Tariff Policy (STRICT)
 
-- **Backend tariff (SHALL):** The **electricity price is fixed and configured in backend settings** as `price_electricity` (currency per kWh) sourced from `/data/prices/utilityPrices.json`.
+- **Backend tariff (SHALL):** The **electricity price is fixed and configured in backend settings** as `price_electricity` (neutral cost per kWh) sourced from `/data/prices/utilityPrices.json`.
     
 - **Difficulty modifiers (SHALL):** Difficulty may **either**
     

--- a/docs/TDD.md
+++ b/docs/TDD.md
@@ -186,6 +186,7 @@ it('executes fixed order', async () => {
 - **Per‑hour units only** in all recurring costs.
 
 - **Tariffs (hotfix):** backend config exposes **`price_electricity`** (per kWh) and **`price_water`** (per m³).
+- **Decision:** Monetary identifiers are currency-neutral — tests reject fields or literals that bake `EUR`, `USD`, `GBP`, or symbol suffixes into names/strings.
 
 - **Source of truth:** `/data/prices/utilityPrices.json` is the canonical tariff map and **only** carries electricity and water prices; nutrient costs are covered by irrigation/substrate consumption flows.
 
@@ -202,7 +203,7 @@ import { expect, it } from 'vitest';
 import { resolveTariffs } from '@/backend/src/util/tariffs';
 
 it('override beats factor (electricity & water)', () => {
-  const cfg = { price_electricity: 0.32, price_water: 4.0 };
+  const cfg = { price_electricity: 0.32, price_water: 4.0 }; // neutral costs
   const diff = { energyPriceFactor: 1.5, energyPriceOverride: 0.5, waterPriceFactor: 2.0 };
   const t = resolveTariffs(cfg, diff);
   expect(t.kWh).toBe(0.5);         // override

--- a/docs/VISION_SCOPE.md
+++ b/docs/VISION_SCOPE.md
@@ -47,7 +47,7 @@
 
 **Primary Personas.**
 
-- **The Optimizer** — spreadsheet mindset; chases PPFD, VPD, €/g KPIs.
+- **The Optimizer** — spreadsheet mindset; chases PPFD, VPD, cost-per-gram KPIs (currency-neutral).
     
 - **The Builder** — designs efficient, beautiful layouts & upgrades.
     
@@ -180,7 +180,8 @@
 
 - Recurring costs use **per‑hour** units; **no `*_per_tick`**.
     
-- **Tariffs:** Backend exposes **`price_electricity`** (€/kWh) and **`price_water`** (€/m³). Difficulty may set **`energyPriceFactor`/`energyPriceOverride`** and **`waterPriceFactor`/`waterPriceOverride`** (**override wins**). Effective tariffs are computed **once at simulation start**.
+- **Tariffs:** Backend exposes **`price_electricity`** (per kWh) and **`price_water`** (per m³). Difficulty may set **`energyPriceFactor`/`energyPriceOverride`** and **`waterPriceFactor`/`waterPriceOverride`** (**override wins**). Effective tariffs are computed **once at simulation start**.
+- **Decision:** Experience copy and UI labels adopt neutral monetary language — never surface currency symbols/codes (EUR, USD, GBP, etc.) in identifiers or baked-in text; localized presentation layers may add symbols contextually.
 - **Tariff source:** `/data/prices/utilityPrices.json` is the single source of truth for electricity & water tariffs; nutrient pricing flows through irrigation/substrate consumption instead of a utility entry.
 - **Device maintenance pricing:** `/data/prices/devicePrices.json` carries `capitalExpenditure`, `baseMaintenanceCostPerHour`, and `costIncreasePer1000Hours` for maintenance curves.
     
@@ -275,7 +276,7 @@ function salePrice(basePrice, quality01): number {
 
 ## 10. UX & Presentation Vision
 
-- **Key Screens:** Start (New/Load/Import), Dashboard (time/tick, energy/water/€), Structure Explorer (Company → Structure → Room → Zone → Plant), detail pane with KPIs & stress breakdown, Shop/Research, Logs/Audits.
+- **Key Screens:** Start (New/Load/Import), Dashboard (time/tick, energy/water/cost), Structure Explorer (Company → Structure → Room → Zone → Plant), detail pane with KPIs & stress breakdown, Shop/Research, Logs/Audits.
     
 - **Info Hierarchy:** Top: tick/time, daily costs, energy/water, balance; middle: active zone/plant KPIs; bottom: events/tasks.
     

--- a/docs/prompts/codex-issues.md
+++ b/docs/prompts/codex-issues.md
@@ -37,7 +37,7 @@ Bevor du Codex loslässt, mach einen 2-Min-Preflight und gib ihm dann den Start-
 > 4. **WB-006**: RNG utility + lint rule banning `Math.random`.
 > 5. **WB-008**: Light schedule validator (`onHours+offHours=24`, `startHour∈[0,24)`, 15-min grid).
 > 6. **WB-009**: Tick pipeline skeleton (7 Phases) with tracing hooks.
-> 7. **WB-018**: Economy accrual per-hour (kWh, m³, €), no `*_per_tick`.
+> 7. **WB-018**: Economy accrual per-hour (kWh, m³, neutral cost), no `*_per_tick`.
 > 8. **WB-015/024**: Socket.IO transport (telemetry read-only) + snapshots emission for zone/plant/economy.
 >
 > **DELIVERY PROTOCOL**


### PR DESCRIPTION
## Summary
- document a cross-cutting decision that monetary identifiers remain currency-neutral across SEC, DD, TDD, and vision guidance
- update tariff descriptions, prompts, and ADR wording to remove embedded EUR symbols while preserving unit expectations
- record the terminology change in the changelog for traceability

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ddeecd2d108325844434979bf73bed