### PR TITLE
chore: align pnpm tooling with 10.17.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2025-10-08] Tooling - pnpm 10.17.1 alignment
+- Harmonised the repository on pnpm 10.17.1 via package manager engines metadata.
+- Simplified CI pnpm setup to source the version from `package.json`, preventing action self-install conflicts.
+
 ## [2025-10-07] WB-001 pnpm workspace bootstrap
 - Initialised pnpm workspaces with shared TypeScript configuration and path aliases for engine, façade, transport, and monitoring packages.
 - Added base linting, formatting, and testing toolchain aligned with Node 23+ ESM requirements.

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "packageManager": "pnpm@9.0.0",
+  "packageManager": "pnpm@10.17.1",
   "engines": {
     "node": ">=23.0.0",
-    "pnpm": ">=9.0.0"
+    "pnpm": ">=10.17.1"
   },
   "scripts": {
     "dev": "pnpm -r --parallel dev",


### PR DESCRIPTION
### **User description**
## Summary
- bump the repository packageManager metadata and pnpm engine floor to 10.17.1
- let the CI pnpm setup read the version from package.json to avoid mismatched configuration
- document the tooling refresh in the changelog

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddf92db09c8325b38481db83b6303a


___

### **PR Type**
Other


___

### **Description**
- Update pnpm version from 9.0.0 to 10.17.1

- Simplify CI pnpm setup configuration

- Document tooling changes in changelog


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["package.json"] -- "update version" --> B["pnpm 10.17.1"]
  B -- "remove explicit version" --> C["CI workflow"]
  B -- "document changes" --> D["changelog"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Simplify CI pnpm version configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Remove explicit pnpm version specification from CI setup<br> <li> Allow pnpm action to read version from package.json</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/37/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document pnpm tooling update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/CHANGELOG.md

<ul><li>Add new entry for pnpm 10.17.1 alignment<br> <li> Document CI setup simplification changes</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/37/files#diff-2bfab3db5cc1baf4c6d3ff6b19901926e3bdf4411ec685dac973e5fcff1c723b">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Upgrade pnpm version specifications</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

<ul><li>Update packageManager field to pnpm@10.17.1<br> <li> Bump pnpm engine requirement to >=10.17.1</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/37/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

