### PR TITLE
WB-002 canonical constants module

### DIFF
--- a/docs/ADR/ADR-0001-constants-alignment.md
+++ b/docs/ADR/ADR-0001-constants-alignment.md
@@ -18,3 +18,4 @@ The Simulation Engine Contract (SEC v0.2.1 §1.2) and downstream design document
 - Future modifications to canonical constants require updating this ADR plus the SEC/DD/TDD/AGENTS/VISION_SCOPE documents to preserve the documented precedence chain.
 - Tooling that assumed the `0.5 m²` area quantum must be adjusted to the `0.25 m²` baseline; export contracts and fixtures should align with the shared `simConstants` definitions.
 - The documentation set now has an authoritative historical record for why these constants are fixed, reducing the risk of silent drift across specs, code, and integrations.
+- The repository must expose the canonical constants exclusively through `src/backend/src/constants/simConstants.ts`, with linting guardrails preventing redeclarations elsewhere.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2025-10-09] WB-002 canonical constants module
+- Added the canonical `simConstants.ts` module under `src/backend/src/constants` with SEC-aligned values and helper accessors.
+- Documented the constants in `docs/constants/simConstants.md` and enforced single-source usage through a bespoke ESLint rule.
+- Expanded automated coverage with unit/integration tests verifying immutable exports and package re-exports.
+
 ## [2025-10-08] Tooling - pnpm 10.17.1 alignment
 - Harmonised the repository on pnpm 10.17.1 via package manager engines metadata.
 - Simplified CI pnpm setup to source the version from `package.json`, preventing action self-install conflicts.

--- a/docs/constants/simConstants.md
+++ b/docs/constants/simConstants.md
@@ -1,0 +1,29 @@
+# Canonical Simulation Constants
+
+> Source of truth: [Simulation Engine Contract (SEC) v0.2.1](../SEC.md) §1.2
+
+The Weed Breed simulation engine centralises all canonical constants in
+[`src/backend/src/constants/simConstants.ts`](../../packages/engine/src/backend/src/constants/simConstants.ts).
+Tooling and runtime code **must** import from this module instead of redefining
+values locally. The constants follow SI units and enforce the per-hour economic
+normalisation mandated by the SEC.
+
+| Identifier | Value | Unit | Description |
+| --- | --- | --- | --- |
+| `AREA_QUANTUM_M2` | `0.25` | m² | Minimal calculable floor area for placement, zoning, and area rounding. |
+| `ROOM_DEFAULT_HEIGHT_M` | `3` | m | Default room interior height when blueprints omit overrides. |
+| `HOURS_PER_TICK` | `1` | h | Duration represented by one simulation tick (one in-game hour). |
+| `HOURS_PER_DAY` | `24` | h | Hours per in-game day (calendar invariant). |
+| `DAYS_PER_MONTH` | `30` | d | Days per in-game month. |
+| `MONTHS_PER_YEAR` | `12` | months | Months per in-game year. |
+| `HOURS_PER_MONTH` | `720` | h | Derived: `HOURS_PER_DAY × DAYS_PER_MONTH`. |
+| `HOURS_PER_YEAR` | `8 640` | h | Derived: `HOURS_PER_MONTH × MONTHS_PER_YEAR`. |
+
+## Usage guidelines
+
+- Import constants via `@/backend/src/constants/simConstants` or re-exports from
+  `@wb/engine`.
+- Never redeclare the identifiers above in application code. A dedicated ESLint
+  rule (`wb-sim/no-duplicate-sim-constants`) enforces this guardrail.
+- Treat `SIM_CONSTANTS` as immutable; attempting to mutate the object will throw
+  at runtime.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,6 @@
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
+import { noDuplicateSimConstantsRule } from "./tools/eslint/rules/no-duplicate-sim-constants.js";
 
 export default tseslint.config(
   {
@@ -16,8 +17,16 @@ export default tseslint.config(
         tsconfigRootDir: import.meta.dirname
       }
     },
+    plugins: {
+      "wb-sim": {
+        rules: {
+          "no-duplicate-sim-constants": noDuplicateSimConstantsRule
+        }
+      }
+    },
     rules: {
-      "@typescript-eslint/explicit-module-boundary-types": "error"
+      "@typescript-eslint/explicit-module-boundary-types": "error",
+      "wb-sim/no-duplicate-sim-constants": "error"
     }
   }
 );

--- a/packages/engine/src/backend/src/constants/simConstants.ts
+++ b/packages/engine/src/backend/src/constants/simConstants.ts
@@ -1,0 +1,125 @@
+/**
+ * Canonical simulation constants mandated by the Simulation Engine Contract (SEC v0.2.1).
+ *
+ * @see https://github.com/rewired/weedbreed-2re-boot/docs/SEC.md
+ */
+export interface SimulationConstants {
+  /**
+   * Minimal calculable surface area that spatial calculations must respect.
+   *
+   * The SEC uses this quantum when rounding grow areas, capacity allocations,
+   * and surface-dependent device effects.
+   */
+  readonly AREA_QUANTUM_M2: number;
+  /**
+   * Default room interior height in metres whenever a blueprint does not
+   * provide an explicit override.
+   */
+  readonly ROOM_DEFAULT_HEIGHT_M: number;
+  /**
+   * Number of in-game hours contained in a single simulation tick.
+   */
+  readonly HOURS_PER_TICK: number;
+  /**
+   * Number of in-game hours per day.
+   */
+  readonly HOURS_PER_DAY: number;
+  /**
+   * Number of in-game days per calendar month.
+   */
+  readonly DAYS_PER_MONTH: number;
+  /**
+   * Number of in-game months per calendar year.
+   */
+  readonly MONTHS_PER_YEAR: number;
+  /**
+   * Convenience derived constant expressing the number of hours in an
+   * in-game month.
+   */
+  readonly HOURS_PER_MONTH: number;
+  /**
+   * Convenience derived constant expressing the number of hours in an
+   * in-game year.
+   */
+  readonly HOURS_PER_YEAR: number;
+}
+
+/**
+ * Canonical constant describing the minimal calculable floor area, expressed
+ * in square metres.
+ */
+export const AREA_QUANTUM_M2 = 0.25 as const;
+
+/**
+ * Canonical constant describing the default height of a room interior,
+ * expressed in metres.
+ */
+export const ROOM_DEFAULT_HEIGHT_M = 3 as const;
+
+/**
+ * Canonical constant describing the number of in-game hours represented by a
+ * single simulation tick.
+ */
+export const HOURS_PER_TICK = 1 as const;
+
+/**
+ * Canonical constant describing the number of in-game hours contained within a
+ * single day.
+ */
+export const HOURS_PER_DAY = 24 as const;
+
+/**
+ * Canonical constant describing the number of in-game days contained within a
+ * single month.
+ */
+export const DAYS_PER_MONTH = 30 as const;
+
+/**
+ * Canonical constant describing the number of in-game months contained within a
+ * single year.
+ */
+export const MONTHS_PER_YEAR = 12 as const;
+
+/**
+ * Canonical constant describing the number of in-game hours contained within a
+ * calendar month.
+ */
+export const HOURS_PER_MONTH = HOURS_PER_DAY * DAYS_PER_MONTH;
+
+/**
+ * Canonical constant describing the number of in-game hours contained within a
+ * calendar year.
+ */
+export const HOURS_PER_YEAR = HOURS_PER_MONTH * MONTHS_PER_YEAR;
+
+/**
+ * Frozen object literal bundling all canonical simulation constants for
+ * ergonomic bulk imports.
+ */
+export const SIM_CONSTANTS: Readonly<SimulationConstants> = Object.freeze({
+  AREA_QUANTUM_M2,
+  ROOM_DEFAULT_HEIGHT_M,
+  HOURS_PER_TICK,
+  HOURS_PER_DAY,
+  DAYS_PER_MONTH,
+  MONTHS_PER_YEAR,
+  HOURS_PER_MONTH,
+  HOURS_PER_YEAR
+});
+
+/**
+ * Exhaustive list of valid simulation constant identifiers.
+ */
+export type SimulationConstantName = keyof SimulationConstants;
+
+/**
+ * Returns the canonical value for a simulation constant by its identifier.
+ *
+ * @param name - Identifier of the canonical simulation constant.
+ * @returns The canonical value associated with {@link name}.
+ */
+export function getSimulationConstant(
+  name: SimulationConstantName
+): number {
+  return SIM_CONSTANTS[name];
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -33,3 +33,5 @@ export function createEngineBootstrapConfig(
     verbose
   } satisfies EngineBootstrapConfig;
 }
+
+export * from './backend/src/constants/simConstants.js';

--- a/packages/engine/tests/integration/simConstants.integration.test.ts
+++ b/packages/engine/tests/integration/simConstants.integration.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  SIM_CONSTANTS,
+  getSimulationConstant,
+  type SimulationConstantName
+} from '@wb/engine';
+
+describe('engine exports', () => {
+  it('re-exports canonical simulation constants', () => {
+    expect(SIM_CONSTANTS.AREA_QUANTUM_M2).toBe(0.25);
+    expect(SIM_CONSTANTS.ROOM_DEFAULT_HEIGHT_M).toBe(3);
+  });
+
+  it('ensures entry point and backend alias stay in sync', () => {
+    for (const [name, value] of Object.entries(SIM_CONSTANTS) as [
+      SimulationConstantName,
+      number
+    ][]) {
+      expect(getSimulationConstant(name)).toBe(value);
+    }
+  });
+});

--- a/packages/engine/tests/unit/simConstants.test.ts
+++ b/packages/engine/tests/unit/simConstants.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AREA_QUANTUM_M2,
+  DAYS_PER_MONTH,
+  HOURS_PER_DAY,
+  HOURS_PER_MONTH,
+  HOURS_PER_TICK,
+  HOURS_PER_YEAR,
+  MONTHS_PER_YEAR,
+  ROOM_DEFAULT_HEIGHT_M,
+  SIM_CONSTANTS
+} from '@/backend/src/constants/simConstants.js';
+
+describe('simConstants', () => {
+  it('exposes canonical SEC values', () => {
+    expect(AREA_QUANTUM_M2).toBe(0.25);
+    expect(ROOM_DEFAULT_HEIGHT_M).toBe(3);
+    expect(HOURS_PER_TICK).toBe(1);
+    expect(HOURS_PER_DAY).toBe(24);
+    expect(DAYS_PER_MONTH).toBe(30);
+    expect(MONTHS_PER_YEAR).toBe(12);
+    expect(HOURS_PER_MONTH).toBe(24 * 30);
+    expect(HOURS_PER_YEAR).toBe(24 * 30 * 12);
+  });
+
+  it('provides immutable aggregate exports', () => {
+    expect(Object.isFrozen(SIM_CONSTANTS)).toBe(true);
+    expect(Reflect.set(SIM_CONSTANTS, 'AREA_QUANTUM_M2', 1)).toBe(false);
+    expect(SIM_CONSTANTS.AREA_QUANTUM_M2).toBe(AREA_QUANTUM_M2);
+  });
+
+});

--- a/packages/engine/vitest.config.ts
+++ b/packages/engine/vitest.config.ts
@@ -1,6 +1,17 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { defineConfig } from 'vitest/config';
 
+const packageDir = fileURLToPath(new URL('.', import.meta.url));
+
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@wb/engine': path.resolve(packageDir, 'src/index.ts'),
+      '@/backend': path.resolve(packageDir, 'src/backend')
+    }
+  },
   test: {
     environment: 'node',
     globals: true,

--- a/tools/eslint/rules/no-duplicate-sim-constants.js
+++ b/tools/eslint/rules/no-duplicate-sim-constants.js
@@ -1,0 +1,81 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const CANONICAL_RELATIVE_PATH = path.posix.join(
+  'packages',
+  'engine',
+  'src',
+  'backend',
+  'src',
+  'constants',
+  'simConstants.ts'
+);
+
+const CANONICAL_ABSOLUTE_PATH = path.normalize(
+  fileURLToPath(new URL('../../../' + CANONICAL_RELATIVE_PATH, import.meta.url))
+);
+
+const CANONICAL_CONSTANT_NAMES = new Set([
+  'AREA_QUANTUM_M2',
+  'ROOM_DEFAULT_HEIGHT_M',
+  'HOURS_PER_TICK',
+  'HOURS_PER_DAY',
+  'DAYS_PER_MONTH',
+  'MONTHS_PER_YEAR',
+  'HOURS_PER_MONTH',
+  'HOURS_PER_YEAR'
+]);
+
+/** @type {import('eslint').Rule.RuleModule} */
+export const noDuplicateSimConstantsRule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'forbid redeclaring canonical simulation constants outside simConstants.ts',
+      recommended: 'error'
+    },
+    schema: [],
+    messages: {
+      duplicate:
+        'Simulation constant "{{name}}" must only be declared in {{canonicalPath}}.'
+    }
+  },
+  create(context) {
+    const filename = context.getFilename();
+
+    if (!filename || filename === '<input>') {
+      return {};
+    }
+
+    const normalizedFilename = path.normalize(filename);
+    const isCanonicalFile = normalizedFilename === CANONICAL_ABSOLUTE_PATH;
+
+    return {
+      VariableDeclarator(node) {
+        if (isCanonicalFile) {
+          return;
+        }
+
+        if (node.id.type !== 'Identifier') {
+          return;
+        }
+
+        const identifierName = node.id.name;
+
+        if (!CANONICAL_CONSTANT_NAMES.has(identifierName)) {
+          return;
+        }
+
+        context.report({
+          node: node.id,
+          messageId: 'duplicate',
+          data: {
+            name: identifierName,
+            canonicalPath: CANONICAL_RELATIVE_PATH
+          }
+        });
+      }
+    };
+  }
+};

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -40,6 +40,9 @@
       ],
       "@wb/tools-monitor": [
         "packages/tools-monitor/src/index.ts"
+      ],
+      "@/backend/*": [
+        "packages/engine/src/backend/*"
       ]
     }
   },


### PR DESCRIPTION
## Summary
- introduce `src/backend/src/constants/simConstants.ts` as the SEC-aligned source of truth with aggregate helpers and re-export it via `@wb/engine`
- add unit/integration coverage plus Vitest path aliases so the new module and entrypoint wiring stay verifiable
- enforce single-source usage with a bespoke ESLint rule and document the contract (changelog, ADR note, `/docs/constants/simConstants.md`)

## Testing
- `pnpm --filter @wb/engine exec eslint "src/**/*.ts" "tests/**/*.ts"`
- `pnpm --filter @wb/engine test`

## Documentation
- Added `/docs/constants/simConstants.md`, changelog entry, and ADR consequence note describing the canonical module and lint guardrail.


------
https://chatgpt.com/codex/tasks/task_e_68ddfb08169c8325abb9ce5bd6a28f10