### PR TITLE
Fix facade Vitest alias resolution for engine backend

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### #12 Tooling - facade Vitest alias parity
+- Added the `@/backend` path alias to the façade Vitest config so shared engine
+  modules resolve consistently during façade test runs.
+
 ### #11 WB-004 validation guard fixes
 - Hardened light schedule validation to reject non-finite values before range
   checks, preventing NaN/Infinity leakage into tick logic.

--- a/packages/facade/vitest.config.ts
+++ b/packages/facade/vitest.config.ts
@@ -19,7 +19,8 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@wb/engine': resolve(currentDir, '../engine/src/index.ts')
+      '@wb/engine': resolve(currentDir, '../engine/src/index.ts'),
+      '@/backend': resolve(currentDir, '../engine/src/backend')
     }
   }
 });


### PR DESCRIPTION
### **User description**
## Summary
- add the missing `@/backend` alias to the façade Vitest configuration so engine domain imports resolve during façade tests
- log the tooling change in the changelog for traceability

## Testing
- pnpm --filter facade test *(fails: vitest command unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de0fcaa9f88325a8833afc9963bc70


___

### **PR Type**
Tests


___

### **Description**
- Add missing `@/backend` alias to facade Vitest config

- Ensure engine backend imports resolve during facade tests

- Document tooling change in changelog for traceability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Facade Vitest Config"] --> B["Add @/backend Alias"]
  B --> C["Engine Backend Resolution"]
  D["Changelog"] --> E["Document Tooling Change"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vitest.config.ts</strong><dd><code>Add backend alias to Vitest config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/facade/vitest.config.ts

<ul><li>Add <code>@/backend</code> alias pointing to engine backend directory<br> <li> Maintain existing <code>@wb/engine</code> alias configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/42/files#diff-3cc3f227207e2eeb9e49156209a8d90d4fa828ce578d778c1a3ef10c08adf244">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document facade Vitest alias update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/CHANGELOG.md

<ul><li>Add entry for facade Vitest alias parity tooling change<br> <li> Document addition of <code>@/backend</code> path alias for consistent module <br>resolution</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/42/files#diff-2bfab3db5cc1baf4c6d3ff6b19901926e3bdf4411ec685dac973e5fcff1c723b">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

