### PR TITLE
feat(facade): add world schema validation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### #13 WB-006 facade world schema validation
+- Added Zod-based world tree schemas in `@wb/facade` that reuse engine
+  enumerations to guarantee SEC-aligned runtime validation of cultivation
+  methods, irrigation, containers, and substrates before engine bootstrap.
+- Introduced `parseCompanyWorld` to normalise façade inputs and wire it into
+  `initializeFacade` so invalid payloads are rejected deterministically.
+- Expanded façade Vitest coverage with schema unit tests covering invalid zone
+  payloads and placement scope enforcement.
+
 ### #12 Tooling - facade Vitest alias parity
 - Added the `@/backend` path alias to the façade Vitest config so shared engine
   modules resolve consistently during façade test runs.

--- a/packages/facade/package.json
+++ b/packages/facade/package.json
@@ -18,6 +18,7 @@
     "node": ">=23.0.0"
   },
   "dependencies": {
-    "@wb/engine": "workspace:*"
+    "@wb/engine": "workspace:*",
+    "zod": "^3.23.8"
   }
 }

--- a/packages/facade/src/index.ts
+++ b/packages/facade/src/index.ts
@@ -1,4 +1,8 @@
 import { createEngineBootstrapConfig, type EngineBootstrapConfig } from '@wb/engine';
+import { parseCompanyWorld, type ParsedCompanyWorld } from './schemas/world.js';
+
+export type { ParsedCompanyWorld } from './schemas/world.js';
+export { parseCompanyWorld } from './schemas/world.js';
 
 /**
  * Parameters required to initialise the façade layer that brokers between the engine and clients.
@@ -13,6 +17,11 @@ export interface FacadeInitOptions {
    * When true, the façade mirrors verbose diagnostics emitted by the engine.
    */
   readonly verbose?: boolean;
+
+  /**
+   * Company-centric world tree that should be validated before the engine boots.
+   */
+  readonly world: unknown;
 }
 
 /**
@@ -23,6 +32,11 @@ export interface FacadeInitResult {
    * The deterministic engine bootstrap configuration derived from façade inputs.
    */
   readonly engineConfig: EngineBootstrapConfig;
+
+  /**
+   * Strongly typed company world tree validated against SEC invariants.
+   */
+  readonly companyWorld: ParsedCompanyWorld;
 }
 
 /**
@@ -32,7 +46,8 @@ export interface FacadeInitResult {
  * @returns {@link FacadeInitResult} referencing the engine bootstrap configuration.
  */
 export function initializeFacade(options: FacadeInitOptions): FacadeInitResult {
+  const companyWorld = parseCompanyWorld(options.world);
   const engineConfig = createEngineBootstrapConfig(options.scenarioId, options.verbose ?? false);
 
-  return { engineConfig } satisfies FacadeInitResult;
+  return { engineConfig, companyWorld } satisfies FacadeInitResult;
 }

--- a/packages/facade/src/schemas/world.ts
+++ b/packages/facade/src/schemas/world.ts
@@ -1,0 +1,126 @@
+import { z } from 'zod';
+import {
+  DEVICE_PLACEMENT_SCOPES,
+  PLANT_LIFECYCLE_STAGES,
+  ROOM_PURPOSES,
+  type Company,
+  type LightSchedule,
+  type Plant,
+  type Room,
+  type RoomDeviceInstance,
+  type Structure,
+  type StructureDeviceInstance,
+  type Zone,
+  type ZoneDeviceInstance
+} from '@wb/engine';
+
+const [STRUCTURE_SCOPE, ROOM_SCOPE, ZONE_SCOPE] = DEVICE_PLACEMENT_SCOPES;
+
+const uuidSchema = z.string().uuid('Expected a UUID v4 identifier.');
+const nonEmptyString = z.string().min(1, 'String fields must not be empty.');
+const finiteNumber = z.number().finite('Value must be a finite number.');
+
+const domainEntitySchema = z.object({
+  id: uuidSchema,
+  name: nonEmptyString
+});
+
+const sluggedEntitySchema = z.object({
+  slug: nonEmptyString
+});
+
+const spatialEntitySchema = z.object({
+  floorArea_m2: finiteNumber.positive('floorArea_m2 must be positive.'),
+  height_m: finiteNumber.positive('height_m must be positive.')
+});
+
+export const lightScheduleSchema: z.ZodType<LightSchedule> = z.object({
+  onHours: finiteNumber.min(0, 'onHours cannot be negative.'),
+  offHours: finiteNumber.min(0, 'offHours cannot be negative.'),
+  startHour: finiteNumber.min(0, 'startHour cannot be negative.')
+});
+
+const baseDeviceSchema = domainEntitySchema
+  .merge(sluggedEntitySchema)
+  .extend({
+    blueprintId: uuidSchema,
+    quality01: finiteNumber.min(0, 'quality01 must be >= 0.').max(1, 'quality01 must be <= 1.'),
+    condition01: finiteNumber.min(0, 'condition01 must be >= 0.').max(1, 'condition01 must be <= 1.'),
+    powerDraw_W: finiteNumber.min(0, 'powerDraw_W cannot be negative.')
+  });
+
+const structureDeviceSchema: z.ZodType<StructureDeviceInstance> = baseDeviceSchema.extend({
+  placementScope: z.literal(STRUCTURE_SCOPE)
+});
+
+const roomDeviceSchema: z.ZodType<RoomDeviceInstance> = baseDeviceSchema.extend({
+  placementScope: z.literal(ROOM_SCOPE)
+});
+
+const zoneDeviceSchema: z.ZodType<ZoneDeviceInstance> = baseDeviceSchema.extend({
+  placementScope: z.literal(ZONE_SCOPE)
+});
+
+const plantSchema: z.ZodType<Plant> = domainEntitySchema
+  .merge(sluggedEntitySchema)
+  .extend({
+    strainId: uuidSchema,
+    lifecycleStage: z.enum([...PLANT_LIFECYCLE_STAGES]),
+    ageHours: finiteNumber.min(0, 'ageHours cannot be negative.'),
+    health01: finiteNumber.min(0, 'health01 must be >= 0.').max(1, 'health01 must be <= 1.'),
+    biomass_g: finiteNumber.min(0, 'biomass_g cannot be negative.'),
+    containerId: uuidSchema,
+    substrateId: uuidSchema
+  });
+
+export const zoneSchema: z.ZodType<Zone> = domainEntitySchema
+  .merge(sluggedEntitySchema)
+  .merge(spatialEntitySchema)
+  .extend({
+    cultivationMethodId: uuidSchema,
+    irrigationMethodId: uuidSchema,
+    containerId: uuidSchema,
+    substrateId: uuidSchema,
+    lightSchedule: lightScheduleSchema,
+    photoperiodPhase: z.enum(['vegetative', 'flowering']),
+    plants: z.array(plantSchema).readonly(),
+    devices: z.array(zoneDeviceSchema).readonly()
+  });
+
+export const roomSchema: z.ZodType<Room> = domainEntitySchema
+  .merge(sluggedEntitySchema)
+  .merge(spatialEntitySchema)
+  .extend({
+    purpose: z.enum([...ROOM_PURPOSES]),
+    zones: z.array(zoneSchema).readonly(),
+    devices: z.array(roomDeviceSchema).readonly()
+  })
+  .superRefine((room, ctx) => {
+    if (room.purpose !== 'growroom' && room.zones.length > 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Only growrooms may contain zones.',
+        path: ['zones']
+      });
+    }
+  });
+
+export const structureSchema: z.ZodType<Structure> = domainEntitySchema
+  .merge(sluggedEntitySchema)
+  .merge(spatialEntitySchema)
+  .extend({
+    rooms: z.array(roomSchema).readonly(),
+    devices: z.array(structureDeviceSchema).readonly()
+  });
+
+export const companySchema: z.ZodType<Company> = domainEntitySchema
+  .merge(sluggedEntitySchema)
+  .extend({
+    structures: z.array(structureSchema).readonly()
+  });
+
+export type ParsedCompanyWorld = z.infer<typeof companySchema>;
+
+export function parseCompanyWorld(input: unknown): ParsedCompanyWorld {
+  return companySchema.parse(input);
+}

--- a/packages/facade/tests/integration/initializeFacade.integration.test.ts
+++ b/packages/facade/tests/integration/initializeFacade.integration.test.ts
@@ -3,11 +3,19 @@ import { initializeFacade } from '../../src/index.js';
 
 describe('initializeFacade', () => {
   it('composes the engine bootstrap configuration using shared path aliases', () => {
-    const result = initializeFacade({ scenarioId: 'integration', verbose: true });
+    const world = {
+      id: '30bd7f5e-1c8d-4f5f-9a5b-8b9e5821fd52',
+      slug: 'integration-company',
+      name: 'Integration Company',
+      structures: []
+    } as const;
+
+    const result = initializeFacade({ scenarioId: 'integration', verbose: true, world });
 
     expect(result.engineConfig).toEqual({
       scenarioId: 'integration',
       verbose: true
     });
+    expect(result.companyWorld).toEqual(world);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       '@wb/engine':
         specifier: workspace:*
         version: link:../engine
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
 
   packages/tools-monitor: {}
 
@@ -1369,6 +1372,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
 snapshots:
 
   '@ampproject/remapping@2.3.0':
@@ -2581,3 +2587,5 @@ snapshots:
       strip-ansi: 7.1.2
 
   yocto-queue@0.1.0: {}
+
+  zod@3.25.76: {}


### PR DESCRIPTION
### **User description**
## Summary
- add zod runtime schemas for the company world tree that reuse engine enumerations and require cultivation/irrigation/container/substrate identifiers
- introduce a parseCompanyWorld helper and validate façade payloads before bootstrapping the engine
- expand façade test coverage for world schema validation and document the change in the changelog

## Testing
- pnpm --filter @wb/facade test

------
https://chatgpt.com/codex/tasks/task_e_68de1202c944832584ce94aea9486721


___

### **PR Type**
Enhancement


___

### **Description**
- Add Zod runtime schema validation for company world tree

- Integrate world validation into facade initialization

- Expand test coverage with schema validation tests

- Update changelog with validation feature documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Raw World Input"] --> B["parseCompanyWorld"]
  B --> C["Zod Schema Validation"]
  C --> D["ParsedCompanyWorld"]
  D --> E["initializeFacade"]
  E --> F["FacadeInitResult"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document facade world schema validation feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/CHANGELOG.md

<ul><li>Document new world schema validation feature<br> <li> Describe Zod-based validation and parseCompanyWorld helper<br> <li> Note expanded test coverage for schema validation</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/43/files#diff-2bfab3db5cc1baf4c6d3ff6b19901926e3bdf4411ec685dac973e5fcff1c723b">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add Zod dependency for schema validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/facade/package.json

- Add `zod` dependency for runtime schema validation


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/43/files#diff-8c8c99375ca711bb4b7ecf82e52172de642a2f14e3f56e19971af7a675ec3d0f">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pnpm-lock.yaml</strong><dd><code>Update lockfile for Zod dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pnpm-lock.yaml

- Add Zod dependency lock entries


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/43/files#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bb">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Integrate world validation into facade initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/facade/src/index.ts

<ul><li>Add <code>world</code> parameter to <code>FacadeInitOptions</code><br> <li> Export <code>parseCompanyWorld</code> function and <code>ParsedCompanyWorld</code> type<br> <li> Integrate world validation into <code>initializeFacade</code><br> <li> Return validated <code>companyWorld</code> in <code>FacadeInitResult</code></ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/43/files#diff-31578d5aae90b13b9e1b9a8c8aa95aeb39d536245986750f4946b802cd5afae7">+16/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>world.ts</strong><dd><code>Implement Zod schemas for world validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/facade/src/schemas/world.ts

<ul><li>Create comprehensive Zod schemas for company world tree<br> <li> Define schemas for structures, rooms, zones, plants, and devices<br> <li> Implement placement scope validation and business rules<br> <li> Export <code>parseCompanyWorld</code> helper function</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/43/files#diff-1ae5a1e85ced398c088f8ec8451615d676bbb262c8f9ca601df230f59721d568">+126/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>initializeFacade.integration.test.ts</strong><dd><code>Update integration test for world validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/facade/tests/integration/initializeFacade.integration.test.ts

<ul><li>Add world parameter to integration test<br> <li> Verify companyWorld is returned in result</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/43/files#diff-a76620405bcbb961efa0606b30c7c4891bcd287ddcf5980c256c4b3530ccd80e">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>worldSchema.test.ts</strong><dd><code>Add comprehensive world schema validation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/facade/tests/unit/schemas/worldSchema.test.ts

<ul><li>Add comprehensive unit tests for world schema validation<br> <li> Test valid world payload acceptance<br> <li> Test rejection of invalid cultivation methods, placement scopes<br> <li> Test business rule enforcement for room purposes</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/43/files#diff-a5b928090d437b78e65ae1032f38e676984a8434525501ceba9645a7ed542a49">+168/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

