### PR TITLE
refactor: centralize world validation schemas in engine

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### #14 WB-010 engine-hosted world validation schemas
+- Moved the company world Zod schemas and `parseCompanyWorld` helper into
+  `@wb/engine` so validation logic ships with the canonical domain contracts.
+- Exported the schemas from the engine package and updated façade imports to
+  depend on the new public surface instead of a local copy.
+- Relocated the corresponding Vitest coverage into `@wb/engine` to keep
+  validation regression tests close to the source of truth.
+
 ### #13 WB-006 facade world schema validation
 - Added Zod-based world tree schemas in `@wb/facade` that reuse engine
   enumerations to guarantee SEC-aligned runtime validation of cultivation

--- a/docs/tasks/20251002-01.md
+++ b/docs/tasks/20251002-01.md
@@ -4,7 +4,7 @@ Move the Zod validation schemas from the @wb/facade package to the @wb/engine
 package. This collocates the schemas with the domain types they validate,
 creating a single source of truth and improving maintainability.
 Examples:
-packages/facade/src/schemas/world.ts
+packages/engine/src/backend/src/domain/schemas.ts
 
 Solution Walkthrough:
 Before:
@@ -17,7 +17,7 @@ export type Company = { ... };
 export type Room = { ... };
 // ... etc
 
-// packages/facade/src/schemas/world.ts
+// packages/engine/src/backend/src/domain/schemas.ts
 import { type Company, type Room } from '@wb/engine';
 import { z } from 'zod';
 
@@ -26,7 +26,7 @@ export const companySchema: z.ZodType<Company> = ...;
 export function parseCompanyWorld(input: unknown) { ... }
 
 // packages/facade/src/index.ts
-import { parseCompanyWorld } from './schemas/world.js';
+import { parseCompanyWorld } from '@wb/engine';
 initializeFacade(options) {
   const companyWorld = parseCompanyWorld(options.world);
   // ...
@@ -36,7 +36,7 @@ initializeFacade(options) {
 After:
 
 ```ts
-// packages/engine/src/schemas/world.ts
+// packages/engine/src/backend/src/domain/schemas.ts
 import { z } from 'zod';
 export type Company = { ... };
 export type Room = { ... };
@@ -63,7 +63,7 @@ Why: This is a strong architectural suggestion that correctly identifies that do
 Add a validation rule to the roomSchema to ensure that any room with the purpose
 'growroom' contains at least one zone.
 
-packages/facade/src/schemas/world.ts
+packages/engine/src/backend/src/domain/schemas.ts
 
 ```ts
  export const roomSchema: z.ZodType<Room> = domainEntitySchema
@@ -101,7 +101,7 @@ Why: The suggestion correctly identifies a missing validation rule that improves
 Replace JSON.parse(JSON.stringify()) with structuredClone() in the cloneWorld
 test helper for a more robust deep-cloning implementation.
 
-packages/facade/tests/unit/schemas/worldSchema.test.ts [98]
+packages/engine/tests/unit/domain/schemas.test.ts [98]
 
 ```ts
 -const cloneWorld = () => JSON.parse(JSON.stringify(BASE_WORLD));
@@ -117,7 +117,7 @@ Why: The suggestion improves test code robustness by replacing a fragile cloning
 Refactor the test to create invalid data immutably using object spreading
 instead of directly mutating a cloned object, making the test less brittle.
 
-packages/facade/tests/unit/schemas/worldSchema.test.ts
+packages/engine/tests/unit/domain/schemas.test.ts
 
 ```ts
  it('rejects devices that declare an incorrect placement scope for the zone level', () => {
@@ -177,7 +177,7 @@ Create invalid test data immutably
 Add a superRefine check to the lightScheduleSchema to ensure that the sum of
 onHours and offHours is exactly 24.
 
-packages/facade/src/schemas/world.ts
+packages/engine/src/backend/src/domain/schemas.ts
 
 ```ts
 -export const lightScheduleSchema: z.ZodType<LightSchedule> = z.object({
@@ -211,7 +211,7 @@ Enforce a 24-hour light cycle
 In the test file, replace Reflect.set with a direct property assignment using an
 any type cast to simplify how invalid data is created for testing.
 
-packages/facade/tests/unit/schemas/worldSchema.test.ts
+packages/engine/tests/unit/domain/schemas.test.ts
 
 ```ts
 -Reflect.set(targetDevice as Record<string, unknown>, 'placementScope', 'room');

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -14,5 +14,8 @@
   },
   "engines": {
     "node": ">=23.0.0"
+  },
+  "dependencies": {
+    "zod": "^3.23.8"
   }
 }

--- a/packages/engine/src/backend/src/domain/schemas.ts
+++ b/packages/engine/src/backend/src/domain/schemas.ts
@@ -12,7 +12,7 @@ import {
   type StructureDeviceInstance,
   type Zone,
   type ZoneDeviceInstance
-} from '@wb/engine';
+} from './entities.js';
 
 const [STRUCTURE_SCOPE, ROOM_SCOPE, ZONE_SCOPE] = DEVICE_PLACEMENT_SCOPES;
 

--- a/packages/engine/src/backend/src/domain/world.ts
+++ b/packages/engine/src/backend/src/domain/world.ts
@@ -1,2 +1,3 @@
 export * from './entities.js';
+export * from './schemas.js';
 export * from './validation.js';

--- a/packages/engine/tests/unit/domain/schemas.test.ts
+++ b/packages/engine/tests/unit/domain/schemas.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { companySchema, parseCompanyWorld, type ParsedCompanyWorld } from '../../../src/schemas/world.js';
+import {
+  companySchema,
+  parseCompanyWorld,
+  type ParsedCompanyWorld
+} from '@wb/engine';
 
 type DeepMutable<T> = T extends (...args: unknown[]) => unknown
   ? T

--- a/packages/facade/package.json
+++ b/packages/facade/package.json
@@ -16,9 +16,5 @@
   },
   "engines": {
     "node": ">=23.0.0"
-  },
-  "dependencies": {
-    "@wb/engine": "workspace:*",
-    "zod": "^3.23.8"
   }
 }

--- a/packages/facade/src/index.ts
+++ b/packages/facade/src/index.ts
@@ -1,8 +1,12 @@
-import { createEngineBootstrapConfig, type EngineBootstrapConfig } from '@wb/engine';
-import { parseCompanyWorld, type ParsedCompanyWorld } from './schemas/world.js';
+import {
+  createEngineBootstrapConfig,
+  parseCompanyWorld,
+  type EngineBootstrapConfig,
+  type ParsedCompanyWorld
+} from '@wb/engine';
 
-export type { ParsedCompanyWorld } from './schemas/world.js';
-export { parseCompanyWorld } from './schemas/world.js';
+export type { ParsedCompanyWorld } from '@wb/engine';
+export { parseCompanyWorld } from '@wb/engine';
 
 /**
  * Parameters required to initialise the façade layer that brokers between the engine and clients.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,16 +36,13 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@20.19.19)
 
-  packages/engine: {}
-
-  packages/facade:
+  packages/engine:
     dependencies:
-      '@wb/engine':
-        specifier: workspace:*
-        version: link:../engine
       zod:
         specifier: ^3.23.8
         version: 3.25.76
+
+  packages/facade: {}
 
   packages/tools-monitor: {}
 


### PR DESCRIPTION
## Summary
- move the company world Zod schemas and parse helper into the engine domain layer and re-export them for consumers
- update facade imports and dependencies to rely on the engine-hosted schemas and remove the redundant local copy
- relocate validation tests and refresh documentation to reflect the new source of truth

## Testing
- pnpm --filter @wb/engine test


------
https://chatgpt.com/codex/tasks/task_e_68de1b9ae570832590bd937589c90aba