### PR TITLE
Reference ADR-0005 for data contract validation schemas

### DIFF
--- a/docs/SEC.md
+++ b/docs/SEC.md
@@ -230,7 +230,7 @@ The world is a tree with typed nodes and bounded geometry.
 
 ## 3. Data Contracts (from DD + /data/**)
 
-Validation occurs at load time; on failure, the engine must not start.
+Validation occurs at load time; on failure, the engine must not start. Validation schemas live with the engine domain types so the engine remains the single source of truth; see [ADR-0005](ADR/ADR-0005-validation-schema-centralization.md) for implementation details.
 
 ### 3.1 Device Placement & Eligibility (STRICT)
 


### PR DESCRIPTION
### **User description**
## Summary
- note that the SEC data contracts section now points to ADR-0005 and reiterates that validation schemas live beside engine domain types

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de1f2a58808325b9c9d5b8a3b58078


___

### **PR Type**
Documentation


___

### **Description**
- Reference ADR-0005 for validation schema implementation details

- Clarify engine as single source of truth for data contracts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  SEC["SEC Documentation"] -- "references" --> ADR["ADR-0005"]
  ADR -- "defines" --> Schema["Validation Schema Location"]
  Schema -- "centralizes in" --> Engine["Engine Domain Types"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SEC.md</strong><dd><code>Add ADR-0005 reference for validation schemas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/SEC.md

<ul><li>Added reference to ADR-0005 for validation schema implementation<br> <li> Clarified that validation schemas live with engine domain types<br> <li> Reinforced engine as single source of truth principle</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/48/files#diff-ea545a2382e40e0dca4108b37a31b9f012fc494d137177e29a59c034f2fc06e4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

