### PR TITLE
Enforce growroom zone cardinality in engine schemas

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### #16 WB-011 growroom zone cardinality validation
+- Enforced the room schema to reject growrooms that do not declare at least one
+  zone, maintaining SEC hierarchy invariants.
+- Added regression coverage ensuring `companySchema.safeParse` reports a zones
+  path issue when a growroom omits its zone list.
+- Documented the tightened validation to alert integrators that empty
+  growrooms now fail schema checks.
+
 ### #15 Tooling - align engine runtime dependencies
 - Declared `zod@^3.23.8` as an explicit runtime dependency for `@wb/engine`
   so schema validation helpers resolve consistently during builds and tests.

--- a/packages/engine/src/backend/src/domain/schemas.ts
+++ b/packages/engine/src/backend/src/domain/schemas.ts
@@ -103,6 +103,14 @@ export const roomSchema: z.ZodType<Room> = domainEntitySchema
         path: ['zones']
       });
     }
+
+    if (room.purpose === 'growroom' && room.zones.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Growrooms must define at least one zone.',
+        path: ['zones']
+      });
+    }
   });
 
 export const structureSchema: z.ZodType<Structure> = domainEntitySchema

--- a/packages/engine/tests/unit/domain/schemas.test.ts
+++ b/packages/engine/tests/unit/domain/schemas.test.ts
@@ -166,6 +166,26 @@ describe('companySchema', () => {
     ]);
   });
 
+  it('rejects growrooms that omit zones', () => {
+    const invalidWorld = cloneWorld();
+    const targetRoom = invalidWorld.structures[0]?.rooms[0];
+    if (!targetRoom) {
+      throw new Error('Expected a room in the base world fixture.');
+    }
+    targetRoom.zones = [];
+
+    const result = companySchema.safeParse(invalidWorld);
+
+    expect(result.success).toBe(false);
+    expect(result.success ? [] : result.error.issues.map((issue) => issue.path)).toContainEqual([
+      'structures',
+      0,
+      'rooms',
+      0,
+      'zones'
+    ]);
+  });
+
   it('rejects non-growroom purposes that still contain zones', () => {
     const invalidWorld = cloneWorld();
     const targetRoom = invalidWorld.structures[0]?.rooms[0];


### PR DESCRIPTION
### **User description**
## Summary
- ensure the room schema reports a validation issue when a growroom omits zones
- extend the engine unit tests to cover growroom zone cardinality enforcement
- document the tightened invariant in the changelog for downstream consumers

## Testing
- pnpm --filter @wb/engine test *(fails: `vitest` binary is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de23a3b1548325a36296a576523f57


___

### **PR Type**
Enhancement


___

### **Description**
- Enforce growrooms must declare at least one zone

- Add validation test for empty growroom zones

- Document schema validation changes in changelog


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Room Schema"] --> B["Growroom Validation"]
  B --> C["Zone Cardinality Check"]
  C --> D["Error if Empty Zones"]
  E["Unit Tests"] --> F["Empty Zone Test"]
  G["Documentation"] --> H["Changelog Entry"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document growroom validation enhancement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/CHANGELOG.md

<ul><li>Added changelog entry for growroom zone cardinality validation<br> <li> Documented schema validation tightening for integrators<br> <li> Described regression test coverage addition</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/49/files#diff-2bfab3db5cc1baf4c6d3ff6b19901926e3bdf4411ec685dac973e5fcff1c723b">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schemas.ts</strong><dd><code>Add growroom zone cardinality validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/engine/src/backend/src/domain/schemas.ts

<ul><li>Added validation rule for growrooms with empty zones<br> <li> Enforces growrooms must define at least one zone<br> <li> Uses custom Zod issue with descriptive error message</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/49/files#diff-0ee28f42c004e466b2fd678b947e03d6b0bf2fb664dcab8d77226edc554b7ae9">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schemas.test.ts</strong><dd><code>Add empty growroom zones test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/engine/tests/unit/domain/schemas.test.ts

<ul><li>Added test case for growrooms with empty zones<br> <li> Verifies schema validation rejects growrooms without zones<br> <li> Checks error path points to zones field</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/49/files#diff-acf33303198b38272620d7ad564395887e5142ef38da611b87274b98a20be169">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

