### PR TITLE
Enforce 24-hour light schedule validation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### #17 WB-012 light schedule 24-hour enforcement
+- Enforced the light schedule schema to reject photoperiods that do not sum to
+  a full 24-hour cycle, aligning validation with the SEC light-cycle contract.
+- Added regression coverage ensuring valid 24-hour schedules parse successfully
+  while mismatched totals surface a `lightSchedule` path issue for integrators.
+- Documented the requirement so external integrations can normalise light
+  schedules before submitting company world payloads.
+
 ### #16 WB-011 growroom zone cardinality validation
 - Enforced the room schema to reject growrooms that do not declare at least one
   zone, maintaining SEC hierarchy invariants.

--- a/packages/engine/src/backend/src/domain/schemas.ts
+++ b/packages/engine/src/backend/src/domain/schemas.ts
@@ -34,11 +34,21 @@ const spatialEntitySchema = z.object({
   height_m: finiteNumber.positive('height_m must be positive.')
 });
 
-export const lightScheduleSchema: z.ZodType<LightSchedule> = z.object({
-  onHours: finiteNumber.min(0, 'onHours cannot be negative.'),
-  offHours: finiteNumber.min(0, 'offHours cannot be negative.'),
-  startHour: finiteNumber.min(0, 'startHour cannot be negative.')
-});
+export const lightScheduleSchema: z.ZodType<LightSchedule> = z
+  .object({
+    onHours: finiteNumber.min(0, 'onHours cannot be negative.'),
+    offHours: finiteNumber.min(0, 'offHours cannot be negative.'),
+    startHour: finiteNumber.min(0, 'startHour cannot be negative.')
+  })
+  .superRefine((schedule, ctx) => {
+    if (schedule.onHours + schedule.offHours !== 24) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Light schedules must allocate exactly 24 hours across on/off periods.',
+        path: []
+      });
+    }
+  });
 
 const baseDeviceSchema = domainEntitySchema
   .merge(sluggedEntitySchema)

--- a/packages/engine/tests/unit/domain/schemas.test.ts
+++ b/packages/engine/tests/unit/domain/schemas.test.ts
@@ -166,6 +166,43 @@ describe('companySchema', () => {
     ]);
   });
 
+  it('accepts light schedules that sum to 24 hours', () => {
+    const validWorld = cloneWorld();
+    const targetSchedule = validWorld.structures[0]?.rooms[0]?.zones[0]?.lightSchedule;
+    if (!targetSchedule) {
+      throw new Error('Expected a light schedule in the base world fixture.');
+    }
+    targetSchedule.onHours = 12;
+    targetSchedule.offHours = 12;
+
+    const result = companySchema.safeParse(validWorld);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects light schedules that do not cover a full 24-hour cycle', () => {
+    const invalidWorld = cloneWorld();
+    const targetSchedule = invalidWorld.structures[0]?.rooms[0]?.zones[0]?.lightSchedule;
+    if (!targetSchedule) {
+      throw new Error('Expected a light schedule in the base world fixture.');
+    }
+    targetSchedule.onHours = 20;
+    targetSchedule.offHours = 3;
+
+    const result = companySchema.safeParse(invalidWorld);
+
+    expect(result.success).toBe(false);
+    expect(result.success ? [] : result.error.issues.map((issue) => issue.path)).toContainEqual([
+      'structures',
+      0,
+      'rooms',
+      0,
+      'zones',
+      0,
+      'lightSchedule'
+    ]);
+  });
+
   it('rejects growrooms that omit zones', () => {
     const invalidWorld = cloneWorld();
     const targetRoom = invalidWorld.structures[0]?.rooms[0];


### PR DESCRIPTION
## Summary
- enforce the light schedule schema to surface a custom issue when on/off hours do not total 24
- add regression coverage for both valid and invalid light schedule payloads
- document the light-cycle constraint for integrator awareness in the changelog

## Testing
- pnpm --filter @wb/engine test *(fails: vitest executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de2430f6c48325883aa533e48f8dfc