### PR TITLE
refactor: simplify zone placement scope mutation in schema test

### DIFF
--- a/packages/engine/tests/unit/domain/schemas.test.ts
+++ b/packages/engine/tests/unit/domain/schemas.test.ts
@@ -148,7 +148,7 @@ describe('companySchema', () => {
     if (!targetDevice) {
       throw new Error('Expected a zone-level device in the base world fixture.');
     }
-    Reflect.set(targetDevice as Record<string, unknown>, 'placementScope', 'room');
+    (targetDevice as any).placementScope = 'room';
 
     const result = companySchema.safeParse(invalidWorld);
 


### PR DESCRIPTION
### **User description**
## Summary
- update the zone-level placement scope mutation to use direct property assignment for consistency with other tests

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de260f0300832581c663f9e7e61106


___

### **PR Type**
Other


___

### **Description**
- Replace `Reflect.set()` with direct property assignment in test


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schemas.test.ts</strong><dd><code>Simplify property mutation approach</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/engine/tests/unit/domain/schemas.test.ts

<ul><li>Replace <code>Reflect.set()</code> call with direct property assignment using type <br>assertion<br> <li> Maintain same functionality while simplifying the code approach</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/51/files#diff-acf33303198b38272620d7ad564395887e5142ef38da611b87274b98a20be169">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

