### PR TITLE
feat: validate room purpose values

### DIFF
--- a/packages/engine/src/backend/src/domain/validation.ts
+++ b/packages/engine/src/backend/src/domain/validation.ts
@@ -8,7 +8,8 @@ import {
   type DeviceInstance,
   type DevicePlacementScope,
   type LightSchedule,
-  PLANT_LIFECYCLE_STAGES
+  PLANT_LIFECYCLE_STAGES,
+  ROOM_PURPOSES
 } from './entities.js';
 
 /**
@@ -16,6 +17,8 @@ import {
  * exact within the simulation.
  */
 const FLOAT_TOLERANCE = 1e-6;
+
+const VALID_ROOM_PURPOSES = new Set(ROOM_PURPOSES);
 
 /**
  * Validation issue emitted when the world tree violates SEC guardrails.
@@ -240,6 +243,14 @@ export function validateCompanyWorld(
 
     structure.rooms.forEach((room, roomIndex) => {
       const roomPath = `${structurePath}.rooms[${String(roomIndex)}]`;
+
+      if (!VALID_ROOM_PURPOSES.has(room.purpose)) {
+        issues.push({
+          path: `${roomPath}.purpose`,
+          message: `room purpose must be one of: ${ROOM_PURPOSES.join(', ')}`
+        });
+        return;
+      }
 
       if (!isValidArea(room.floorArea_m2)) {
         issues.push({

--- a/packages/engine/tests/integration/domain/worldValidation.integration.test.ts
+++ b/packages/engine/tests/integration/domain/worldValidation.integration.test.ts
@@ -8,6 +8,7 @@ import {
   type Company,
   type PhotoperiodPhase,
   type PlantLifecycleStage,
+  type Room,
   type RoomDeviceInstance,
   type StructureDeviceInstance,
   type Uuid,
@@ -43,6 +44,10 @@ describe('validateCompanyWorld (integration)', () => {
         }),
         expect.objectContaining({
           message: 'plant lifecycle stage is invalid'
+        }),
+        expect.objectContaining({
+          message:
+            'room purpose must be one of: growroom, breakroom, laboratory, storageroom, salesroom, workshop'
         })
       ])
     );
@@ -168,6 +173,16 @@ function buildInvalidCompany(): Company {
                 plants: []
               }
             ]
+          },
+          {
+            id: uuid('10000000-0000-0000-0000-000000000040'),
+            slug: 'mystery-room',
+            name: 'Mystery Room',
+            purpose: 'hangar' as unknown as Room['purpose'],
+            floorArea_m2: AREA_QUANTUM_M2,
+            height_m: ROOM_DEFAULT_HEIGHT_M,
+            devices: [],
+            zones: []
           }
         ]
       }

--- a/packages/engine/tests/unit/domain/validateCompanyWorld.test.ts
+++ b/packages/engine/tests/unit/domain/validateCompanyWorld.test.ts
@@ -59,6 +59,24 @@ describe('validateCompanyWorld (unit)', () => {
     );
   });
 
+  it('rejects rooms whose purpose is unsupported', () => {
+    const company = withRoomOverride(createCompany(), (room) => ({
+      ...room,
+      purpose: 'moonbase' as unknown as Room['purpose']
+    }));
+
+    const result = validateCompanyWorld(company);
+
+    expect(result.ok).toBe(false);
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({
+        path: 'company.structures[0].rooms[0].purpose',
+        message:
+          'room purpose must be one of: growroom, breakroom, laboratory, storageroom, salesroom, workshop'
+      })
+    );
+  });
+
   it('rejects devices whose placement scope conflicts with their host node', () => {
     const company = withRoomOverride(createCompany(), (room) => ({
       ...room,


### PR DESCRIPTION
## Summary
- ensure room validation rejects unsupported purposes before running other checks
- reuse the shared ROOM_PURPOSES constant for purpose validation
- add unit and integration coverage for rooms with invalid purposes

## Testing
- pnpm --filter engine test

------
https://chatgpt.com/codex/tasks/task_e_68de27230bb08325975cbac9d27d9f1a