### PR TITLE
Improve zone photoperiod validation type safety

### DIFF
--- a/packages/engine/src/backend/src/domain/validation.ts
+++ b/packages/engine/src/backend/src/domain/validation.ts
@@ -8,6 +8,7 @@ import {
   type DeviceInstance,
   type DevicePlacementScope,
   type LightSchedule,
+  type PhotoperiodPhase,
   type Room,
   PLANT_LIFECYCLE_STAGES,
   ROOM_PURPOSES
@@ -20,6 +21,10 @@ import {
 const FLOAT_TOLERANCE = 1e-6;
 
 const VALID_ROOM_PURPOSES = new Set(ROOM_PURPOSES);
+const VALID_PHOTOPERIOD_PHASES = new Set<PhotoperiodPhase>([
+  'vegetative',
+  'flowering'
+]);
 
 /**
  * Validation issue emitted when the world tree violates SEC guardrails.
@@ -231,7 +236,7 @@ function validateRoom(
     validateDevice(
       device,
       'room',
-      `${path}.devices[${String(deviceIndex)}]`,
+      `${path}.devices[${deviceIndex}]`,
       issues
     );
   });
@@ -256,7 +261,7 @@ function validateRoom(
   }
 
   room.zones.forEach((zone, zoneIndex) => {
-    const zonePath = `${path}.zones[${String(zoneIndex)}]`;
+    const zonePath = `${path}.zones[${zoneIndex}]`;
 
     if (!isValidArea(zone.floorArea_m2)) {
       issues.push({
@@ -308,8 +313,7 @@ function validateRoom(
       });
     }
 
-    const phase = zone.photoperiodPhase as string;
-    if (phase !== 'vegetative' && phase !== 'flowering') {
+    if (!VALID_PHOTOPERIOD_PHASES.has(zone.photoperiodPhase)) {
       issues.push({
         path: `${zonePath}.photoperiodPhase`,
         message: 'photoperiod phase must be either "vegetative" or "flowering"'
@@ -320,13 +324,13 @@ function validateRoom(
       validateDevice(
         device,
         'zone',
-        `${zonePath}.devices[${String(deviceIndex)}]`,
+        `${zonePath}.devices[${deviceIndex}]`,
         issues
       );
     });
 
     zone.plants.forEach((plant, plantIndex) => {
-      const plantPath = `${zonePath}.plants[${String(plantIndex)}]`;
+      const plantPath = `${zonePath}.plants[${plantIndex}]`;
 
       if (!PLANT_LIFECYCLE_STAGES.includes(plant.lifecycleStage)) {
         issues.push({
@@ -385,7 +389,7 @@ export function validateCompanyWorld(
   const issues: WorldValidationIssue[] = [];
 
   company.structures.forEach((structure, structureIndex) => {
-    const structurePath = `company.structures[${String(structureIndex)}]`;
+    const structurePath = `company.structures[${structureIndex}]`;
 
     if (!isValidArea(structure.floorArea_m2)) {
       issues.push({
@@ -405,7 +409,7 @@ export function validateCompanyWorld(
       validateDevice(
         device,
         'structure',
-        `${structurePath}.devices[${String(deviceIndex)}]`,
+        `${structurePath}.devices[${deviceIndex}]`,
         issues
       );
     });
@@ -425,7 +429,7 @@ export function validateCompanyWorld(
     structure.rooms.forEach((room, roomIndex) => {
       validateRoom(
         room,
-        `${structurePath}.rooms[${String(roomIndex)}]`,
+        `${structurePath}.rooms[${roomIndex}]`,
         issues
       );
     });


### PR DESCRIPTION
### **User description**
## Summary
- ensure zone photoperiod phase validation uses a typed Set for acceptable values
- remove redundant String() conversions when formatting device, zone, and plant indices in validation paths

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de2ca336b083258f1598b22e1d205a


___

### **PR Type**
Enhancement


___

### **Description**
- Improve photoperiod validation with typed Set for acceptable values

- Remove redundant String() conversions in validation path formatting

- Add PhotoperiodPhase type import for better type safety


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Import PhotoperiodPhase type"] --> B["Create typed VALID_PHOTOPERIOD_PHASES Set"]
  B --> C["Replace string comparison with Set.has()"]
  D["Remove String() conversions"] --> E["Cleaner path formatting"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>validation.ts</strong><dd><code>Enhance validation type safety and formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/engine/src/backend/src/domain/validation.ts

<ul><li>Import <code>PhotoperiodPhase</code> type for better type safety<br> <li> Create typed <code>VALID_PHOTOPERIOD_PHASES</code> Set with vegetative/flowering <br>values<br> <li> Replace string casting and comparison with typed Set validation<br> <li> Remove redundant <code>String()</code> conversions in array index formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/54/files#diff-d1c48f777ff7d59be6761c099716d202db59ac19e1a4ac7de94937ba0fbaaaf3">+13/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

