### PR TITLE
feat(engine): add deterministic RNG utility

### DIFF
--- a/docs/ADR/ADR-0007-deterministic-rng.md
+++ b/docs/ADR/ADR-0007-deterministic-rng.md
@@ -1,0 +1,33 @@
+# ADR-0007: Deterministic RNG utility
+
+## Status
+Accepted
+
+## Context
+The Simulation Engine Contract (SEC §5) mandates a deterministic random number
+interface (`createRng(seed, streamId)`) so identical seeds and inputs yield the
+same simulation outcomes. The engine package lacked a canonical implementation,
+forcing downstream modules and tests to hand-roll RNG logic or temporarily rely
+on `Math.random`, which violates determinism guarantees and complicates
+reproducibility audits.
+
+## Decision
+- Add `createRng(seed, streamId)` under
+  `packages/engine/src/backend/src/util/rng.ts`, using the `xmur3` mixer to
+  expand the combined `{seed, streamId}` tuple into a 32-bit state that seeds a
+  `mulberry32` generator.
+- Enforce non-empty seed and stream identifiers so accidental blank inputs
+  surface immediately rather than silently sharing RNG sequences.
+- Re-export the utility from `packages/engine/src/index.ts` and rely on the
+  existing `@/backend` path alias so future engine modules and tests resolve the
+  generator through the public surface instead of duplicating hashing logic.
+- Provide Vitest coverage to guarantee reproducible sequences for matching
+  inputs and divergence between distinct stream identifiers.
+
+## Consequences
+- All stochastic engine code can adopt the shared utility, ensuring
+  reproducibility and simplifying audits against SEC determinism requirements.
+- The public export clarifies the preferred RNG entry point for downstream
+  packages, discouraging ad-hoc implementations or direct `Math.random` usage.
+- Tests now exercise the determinism contract, reducing the risk of accidental
+  regressions when evolving the hashing or generator strategy in the future.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### #19 WB-014 deterministic RNG utility
+- Introduced `createRng(seed, streamId)` in the engine backend util library so
+  all stochastic behaviour flows through a deterministic, stream-scoped
+  generator aligned with SEC §5.
+- Re-exported the utility from the engine package barrel and verified the
+  `@/backend` alias resolves the new module for future consumers and tests.
+- Added Vitest coverage that guarantees identical sequences for repeated
+  invocations and divergent sequences for distinct stream identifiers.
+- Captured the decision in ADR-0007 to document the deterministic RNG contract
+  and the chosen splitmix/mulberry implementation strategy.
+
 ### #18 WB-013 room validation helper extraction
 - Refactored `validateCompanyWorld` to delegate room, zone, plant, and device
   checks to a new `validateRoom` helper so hierarchy-specific invariants stay

--- a/packages/engine/src/backend/src/util/rng.ts
+++ b/packages/engine/src/backend/src/util/rng.ts
@@ -1,0 +1,61 @@
+/**
+ * Describes the shape of the deterministic pseudo-random number generator.
+ */
+export type RandomNumberGenerator = () => number;
+
+const UINT32_MAX = 0xffffffff;
+
+/**
+ * Creates a deterministic pseudo-random number generator scoped to a seed and stream.
+ *
+ * The implementation uses the xmur3 string mixer to expand the inputs into a 32-bit
+ * seed and feeds that into the mulberry32 generator. The generator is pure and will
+ * always emit the same sequence for identical `{seed, streamId}` pairs.
+ *
+ * @param seed - Shared simulation seed applied to all RNG streams.
+ * @param streamId - Stream identifier (e.g. `device:<uuid>`) that isolates RNG state.
+ * @returns A function that returns a reproducible floating-point number in the range [0, 1).
+ */
+export function createRng(seed: string, streamId: string): RandomNumberGenerator {
+  if (!seed) {
+    throw new Error('seed must be a non-empty string');
+  }
+
+  if (!streamId) {
+    throw new Error('streamId must be a non-empty string');
+  }
+
+  const combinedSeed = `${seed}:${streamId}`;
+  const seedMixer = xmur3(combinedSeed);
+  const initialState = seedMixer();
+
+  return mulberry32(initialState);
+}
+
+function xmur3(str: string): () => number {
+  let h = 1779033703 ^ str.length;
+
+  for (let i = 0; i < str.length; i += 1) {
+    h = Math.imul(h ^ str.charCodeAt(i), 3432918353);
+    h = (h << 13) | (h >>> 19);
+  }
+
+  return () => {
+    h = Math.imul(h ^ (h >>> 16), 2246822507);
+    h = Math.imul(h ^ (h >>> 13), 3266489909);
+    h ^= h >>> 16;
+    return h >>> 0;
+  };
+}
+
+function mulberry32(seed: number): RandomNumberGenerator {
+  let state = seed >>> 0;
+
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / (UINT32_MAX + 1);
+  };
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -36,3 +36,4 @@ export function createEngineBootstrapConfig(
 
 export * from './backend/src/constants/simConstants.js';
 export * from './backend/src/domain/world.js';
+export * from './backend/src/util/rng.js';

--- a/packages/engine/tests/unit/util/createRng.test.ts
+++ b/packages/engine/tests/unit/util/createRng.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { createRng } from '@/backend/src/util/rng.js';
+
+describe('createRng', () => {
+  it('produces identical sequences for the same seed and stream', () => {
+    const first = createRng('deterministic-seed', 'stream:quality');
+    const second = createRng('deterministic-seed', 'stream:quality');
+
+    const firstSequence = Array.from({ length: 16 }, () => first());
+    const secondSequence = Array.from({ length: 16 }, () => second());
+
+    expect(secondSequence).toStrictEqual(firstSequence);
+  });
+
+  it('isolates streams so different stream identifiers diverge', () => {
+    const baseSeed = 'deterministic-seed';
+    const qualityStream = createRng(baseSeed, 'stream:quality');
+    const deviceStream = createRng(baseSeed, 'stream:device');
+
+    const qualitySamples = Array.from({ length: 8 }, () => qualityStream());
+    const deviceSamples = Array.from({ length: 8 }, () => deviceStream());
+
+    expect(deviceSamples).not.toStrictEqual(qualitySamples);
+  });
+});


### PR DESCRIPTION
## Summary
- add a deterministic `createRng(seed, streamId)` helper seeded via xmur3 + mulberry32
- expose the RNG through the engine barrel and exercise determinism with Vitest coverage
- document the RNG utility in the changelog and a new ADR

## Testing
- pnpm --filter @wb/engine test

------
https://chatgpt.com/codex/tasks/task_e_68de2f2e55b083259d5d67312b3964c8