### PR TITLE
Fix engine lint guard regressions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### #20 Tooling - engine lint guard compliance
+- Normalised template string usage in `@wb/engine` validation helpers so numeric
+  segments are explicitly stringified, satisfying the strict `restrict-template-expressions`
+  guard enforced by the workspace ESLint profile.
+- Refactored engine schema tests to operate on typed clones without optional
+  chaining or `any`, leaning on precise aliases to clear `no-unnecessary-condition`
+  and `no-explicit-any` lint violations in CI.
+- Documented the guard alignment here to signal that future schema fixtures must
+  continue operating on deterministic, fully typed clones of the base world tree.
+
 ### #19 WB-014 deterministic RNG utility
 - Introduced `createRng(seed, streamId)` in the engine backend util library so
   all stochastic behaviour flows through a deterministic, stream-scoped

--- a/packages/engine/src/backend/src/domain/validation.ts
+++ b/packages/engine/src/backend/src/domain/validation.ts
@@ -236,7 +236,7 @@ function validateRoom(
     validateDevice(
       device,
       'room',
-      `${path}.devices[${deviceIndex}]`,
+      `${path}.devices[${String(deviceIndex)}]`,
       issues
     );
   });
@@ -261,7 +261,7 @@ function validateRoom(
   }
 
   room.zones.forEach((zone, zoneIndex) => {
-    const zonePath = `${path}.zones[${zoneIndex}]`;
+    const zonePath = `${path}.zones[${String(zoneIndex)}]`;
 
     if (!isValidArea(zone.floorArea_m2)) {
       issues.push({
@@ -324,13 +324,13 @@ function validateRoom(
       validateDevice(
         device,
         'zone',
-        `${zonePath}.devices[${deviceIndex}]`,
+        `${zonePath}.devices[${String(deviceIndex)}]`,
         issues
       );
     });
 
     zone.plants.forEach((plant, plantIndex) => {
-      const plantPath = `${zonePath}.plants[${plantIndex}]`;
+      const plantPath = `${zonePath}.plants[${String(plantIndex)}]`;
 
       if (!PLANT_LIFECYCLE_STAGES.includes(plant.lifecycleStage)) {
         issues.push({
@@ -389,7 +389,7 @@ export function validateCompanyWorld(
   const issues: WorldValidationIssue[] = [];
 
   company.structures.forEach((structure, structureIndex) => {
-    const structurePath = `company.structures[${structureIndex}]`;
+    const structurePath = `company.structures[${String(structureIndex)}]`;
 
     if (!isValidArea(structure.floorArea_m2)) {
       issues.push({
@@ -409,7 +409,7 @@ export function validateCompanyWorld(
       validateDevice(
         device,
         'structure',
-        `${structurePath}.devices[${deviceIndex}]`,
+        `${structurePath}.devices[${String(deviceIndex)}]`,
         issues
       );
     });
@@ -429,7 +429,7 @@ export function validateCompanyWorld(
     structure.rooms.forEach((room, roomIndex) => {
       validateRoom(
         room,
-        `${structurePath}.rooms[${roomIndex}]`,
+        `${structurePath}.rooms[${String(roomIndex)}]`,
         issues
       );
     });


### PR DESCRIPTION
## Summary
- stringified numeric segments when building validation paths in @wb/engine to satisfy the strict template-expression rule
- rewrote schema unit tests to mutate typed clones without optional chaining or `any`, keeping lint clean
- documented the lint guard alignment in the changelog

## Testing
- pnpm --filter @wb/engine lint
- pnpm --filter @wb/engine test

------
https://chatgpt.com/codex/tasks/task_e_68de310ac49c8325ae02248388223d00