### PR TITLE
fix: align engine uuid schema branding

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### #21 WB-016 uuid schema branding alignment
+- Branded the shared `uuidSchema` in the engine domain schemas with Zod's
+  `.brand<'Uuid'>()` helper so parsed entities infer the branded `Uuid` type
+  expected by the domain model.
+- Unblocked strict TypeScript builds that previously reported `string` vs.
+  `Uuid` incompatibilities when the schemas were annotated with explicit
+  domain entity types.
+- Confirmed the runtime validation behaviour remains unchanged, keeping
+  existing schema unit coverage relevant without modification.
+
 ### #20 Tooling - engine lint guard compliance
 - Normalised template string usage in `@wb/engine` validation helpers so numeric
   segments are explicitly stringified, satisfying the strict `restrict-template-expressions`

--- a/packages/engine/src/backend/src/domain/schemas.ts
+++ b/packages/engine/src/backend/src/domain/schemas.ts
@@ -16,7 +16,7 @@ import {
 
 const [STRUCTURE_SCOPE, ROOM_SCOPE, ZONE_SCOPE] = DEVICE_PLACEMENT_SCOPES;
 
-const uuidSchema = z.string().uuid('Expected a UUID v4 identifier.');
+const uuidSchema = z.string().uuid('Expected a UUID v4 identifier.').brand<'Uuid'>();
 const nonEmptyString = z.string().min(1, 'String fields must not be empty.');
 const finiteNumber = z.number().finite('Value must be a finite number.');
 


### PR DESCRIPTION
### **User description**
## Summary
- brand the shared engine `uuidSchema` so it infers the `Uuid` phantom type expected by the domain entities
- document the branded schema update in the changelog

## Testing
- `pnpm --filter @wb/engine test`


------
https://chatgpt.com/codex/tasks/task_e_68de34646e288325906c08510759ad77


___

### **PR Type**
Bug fix


___

### **Description**
- Brand shared `uuidSchema` with Zod's `.brand<'Uuid'>()` helper

- Fix TypeScript incompatibilities between `string` and `Uuid` types

- Unblock strict TypeScript builds for domain entities

- Document schema branding update in changelog


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["uuidSchema"] -- "add .brand<'Uuid'>()" --> B["Branded UUID Schema"]
  B -- "fixes type compatibility" --> C["Domain Entities"]
  C -- "enables strict builds" --> D["TypeScript Compliance"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document UUID schema branding changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/CHANGELOG.md

<ul><li>Add changelog entry for UUID schema branding fix<br> <li> Document TypeScript compatibility improvements<br> <li> Note runtime validation behavior remains unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/57/files#diff-2bfab3db5cc1baf4c6d3ff6b19901926e3bdf4411ec685dac973e5fcff1c723b">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schemas.ts</strong><dd><code>Brand UUID schema with Zod helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/engine/src/backend/src/domain/schemas.ts

<ul><li>Add <code>.brand<'Uuid'>()</code> to <code>uuidSchema</code> definition<br> <li> Maintain existing UUID validation with type branding</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/57/files#diff-0ee28f42c004e466b2fd678b947e03d6b0bf2fb664dcab8d77226edc554b7ae9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

