### PR TITLE
feat(eslint): add rule banning Math.random usage

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -78,6 +78,8 @@
   `initializeFacade` so invalid payloads are rejected deterministically.
 - Expanded façade Vitest coverage with schema unit tests covering invalid zone
   payloads and placement scope enforcement.
+- Introduced the `wb-sim/no-math-random` ESLint rule to block `Math.random`
+  usage and keep all randomness routed through deterministic RNG utilities.
 
 ### #12 Tooling - facade Vitest alias parity
 - Added the `@/backend` path alias to the façade Vitest config so shared engine

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,7 @@
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import { noDuplicateSimConstantsRule } from "./tools/eslint/rules/no-duplicate-sim-constants.js";
+import { noMathRandomRule } from "./tools/eslint/rules/no-math-random.js";
 
 export default tseslint.config(
   {
@@ -20,13 +21,15 @@ export default tseslint.config(
     plugins: {
       "wb-sim": {
         rules: {
-          "no-duplicate-sim-constants": noDuplicateSimConstantsRule
+          "no-duplicate-sim-constants": noDuplicateSimConstantsRule,
+          "no-math-random": noMathRandomRule
         }
       }
     },
     rules: {
       "@typescript-eslint/explicit-module-boundary-types": "error",
-      "wb-sim/no-duplicate-sim-constants": "error"
+      "wb-sim/no-duplicate-sim-constants": "error",
+      "wb-sim/no-math-random": "error"
     }
   }
 );

--- a/tools/eslint/rules/no-math-random.js
+++ b/tools/eslint/rules/no-math-random.js
@@ -1,0 +1,62 @@
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
+export const noMathRandomRule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'disallow Math.random so deterministic RNG utilities remain the single source of randomness',
+      recommended: 'error'
+    },
+    schema: [],
+    messages: {
+      forbidden: 'Use the deterministic RNG utilities (e.g. createRng) instead of Math.random.'
+    }
+  },
+  create(context) {
+    const isMathIdentifier = (node) => node.type === 'Identifier' && node.name === 'Math';
+
+    const isRandomProperty = (node, computed) => {
+      if (!node) {
+        return false;
+      }
+
+      if (!computed && node.type === 'Identifier') {
+        return node.name === 'random';
+      }
+
+      if (computed) {
+        if (node.type === 'Literal') {
+          return node.value === 'random';
+        }
+
+        if (node.type === 'TemplateLiteral') {
+          return (
+            node.expressions.length === 0 &&
+            node.quasis.length === 1 &&
+            node.quasis[0]?.value?.cooked === 'random'
+          );
+        }
+      }
+
+      return false;
+    };
+
+    return {
+      MemberExpression(node) {
+        if (!isMathIdentifier(node.object)) {
+          return;
+        }
+
+        if (!isRandomProperty(node.property, node.computed)) {
+          return;
+        }
+
+        context.report({
+          node: node.property,
+          messageId: 'forbidden'
+        });
+      }
+    };
+  }
+};


### PR DESCRIPTION
### **User description**
## Summary
- add a wb-sim/no-math-random ESLint rule that reports any usage of Math.random
- register the custom rule in the flat config and enable it as an error alongside existing wb-sim guards
- document the new lint coverage for WB-006 in the changelog

## Testing
- pnpm --filter @wb/engine lint

------
https://chatgpt.com/codex/tasks/task_e_68de3537926883258bab67378a3e4404


___

### **PR Type**
Enhancement


___

### **Description**
- Add custom ESLint rule to ban `Math.random` usage

- Register and enable rule in flat config as error

- Document new lint coverage in changelog

- Enforce deterministic RNG utilities for all randomness


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Math.random detection"] --> B["ESLint rule creation"]
  B --> C["Rule registration"]
  C --> D["Error enforcement"]
  D --> E["Deterministic RNG routing"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>no-math-random.js</strong><dd><code>Implement Math.random detection ESLint rule</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/eslint/rules/no-math-random.js

<ul><li>Create new ESLint rule to detect <code>Math.random</code> usage<br> <li> Handle both dot notation and computed property access<br> <li> Support literal and template literal property names<br> <li> Report violations with helpful error message</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/58/files#diff-0b60a7e7e683645de1395e6d36c914f82870b4238868de26fbf6053b21b686e5">+62/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>eslint.config.js</strong><dd><code>Register and enable no-math-random rule</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

eslint.config.js

<ul><li>Import new <code>noMathRandomRule</code> from rules directory<br> <li> Register rule in <code>wb-sim</code> plugin configuration<br> <li> Enable rule as error in rules section</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/58/files#diff-a32a0887ed9d1d707bbb3b845b7df7fd40e673c47e7b60a3ebd896b68d3b8839">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document new ESLint rule coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/CHANGELOG.md

<ul><li>Document new <code>wb-sim/no-math-random</code> ESLint rule<br> <li> Explain purpose of blocking <code>Math.random</code> usage<br> <li> Reference deterministic RNG utilities routing</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/58/files#diff-2bfab3db5cc1baf4c6d3ff6b19901926e3bdf4411ec685dac973e5fcff1c723b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

