### PR TITLE
feat(engine): centralize light schedule grid constant

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### #22 WB-017 light schedule grid constant centralisation
+- Added the SEC-mandated `LIGHT_SCHEDULE_GRID_HOURS` export to the canonical
+  `simConstants` module so photoperiod validators share the same 15 minute grid
+  source of truth as the documentation.
+- Updated world validation helpers and the related unit/integration coverage to
+  import the shared constant instead of redefining the `0.25h` grid locally.
+- Documented the new constant in `docs/constants/simConstants.md` to signal the
+  centralised reference for photoperiod light schedules.
+
 ### #21 WB-016 uuid schema branding alignment
 - Branded the shared `uuidSchema` in the engine domain schemas with Zod's
   `.brand<'Uuid'>()` helper so parsed entities infer the branded `Uuid` type

--- a/docs/constants/simConstants.md
+++ b/docs/constants/simConstants.md
@@ -11,6 +11,7 @@ normalisation mandated by the SEC.
 | Identifier | Value | Unit | Description |
 | --- | --- | --- | --- |
 | `AREA_QUANTUM_M2` | `0.25` | m² | Minimal calculable floor area for placement, zoning, and area rounding. |
+| `LIGHT_SCHEDULE_GRID_HOURS` | `0.25` | h | Photoperiod grid resolution enforcing 15 minute scheduling steps. |
 | `ROOM_DEFAULT_HEIGHT_M` | `3` | m | Default room interior height when blueprints omit overrides. |
 | `HOURS_PER_TICK` | `1` | h | Duration represented by one simulation tick (one in-game hour). |
 | `HOURS_PER_DAY` | `24` | h | Hours per in-game day (calendar invariant). |

--- a/packages/engine/src/backend/src/constants/simConstants.ts
+++ b/packages/engine/src/backend/src/constants/simConstants.ts
@@ -12,6 +12,11 @@ export interface SimulationConstants {
    */
   readonly AREA_QUANTUM_M2: number;
   /**
+   * Canonical grid resolution for light schedule photoperiod definitions,
+   * expressed in in-game hours.
+   */
+  readonly LIGHT_SCHEDULE_GRID_HOURS: number;
+  /**
    * Default room interior height in metres whenever a blueprint does not
    * provide an explicit override.
    */
@@ -49,6 +54,12 @@ export interface SimulationConstants {
  * in square metres.
  */
 export const AREA_QUANTUM_M2 = 0.25 as const;
+
+/**
+ * Canonical constant describing the light schedule grid resolution, expressed
+ * in in-game hours (15 minutes per step).
+ */
+export const LIGHT_SCHEDULE_GRID_HOURS = 0.25 as const;
 
 /**
  * Canonical constant describing the default height of a room interior,
@@ -98,6 +109,7 @@ export const HOURS_PER_YEAR = HOURS_PER_MONTH * MONTHS_PER_YEAR;
  */
 export const SIM_CONSTANTS: Readonly<SimulationConstants> = Object.freeze({
   AREA_QUANTUM_M2,
+  LIGHT_SCHEDULE_GRID_HOURS,
   ROOM_DEFAULT_HEIGHT_M,
   HOURS_PER_TICK,
   HOURS_PER_DAY,

--- a/packages/engine/src/backend/src/domain/validation.ts
+++ b/packages/engine/src/backend/src/domain/validation.ts
@@ -1,6 +1,7 @@
 import {
   AREA_QUANTUM_M2,
-  HOURS_PER_DAY
+  HOURS_PER_DAY,
+  LIGHT_SCHEDULE_GRID_HOURS
 } from '@/backend/src/constants/simConstants.js';
 
 import {
@@ -76,11 +77,6 @@ function isValidArea(area: number): boolean {
  * @param schedule - Light schedule to evaluate.
  * @returns Optional validation issue when a constraint is violated.
  */
-/**
- * Light schedule grid resolution expressed in hours (15 minutes per step).
- */
-const FIFTEEN_MINUTE_GRID_HOURS = 0.25 as const;
-
 function validateLightSchedule(
   schedule: LightSchedule
 ): WorldValidationIssue | undefined {
@@ -137,12 +133,12 @@ function validateLightSchedule(
   }
 
   const onMod = Math.abs(
-    schedule.onHours / FIFTEEN_MINUTE_GRID_HOURS -
-      Math.round(schedule.onHours / FIFTEEN_MINUTE_GRID_HOURS)
+    schedule.onHours / LIGHT_SCHEDULE_GRID_HOURS -
+      Math.round(schedule.onHours / LIGHT_SCHEDULE_GRID_HOURS)
   );
   const offMod = Math.abs(
-    schedule.offHours / FIFTEEN_MINUTE_GRID_HOURS -
-      Math.round(schedule.offHours / FIFTEEN_MINUTE_GRID_HOURS)
+    schedule.offHours / LIGHT_SCHEDULE_GRID_HOURS -
+      Math.round(schedule.offHours / LIGHT_SCHEDULE_GRID_HOURS)
   );
 
   if (onMod > FLOAT_TOLERANCE || offMod > FLOAT_TOLERANCE) {

--- a/packages/engine/tests/integration/simConstants.integration.test.ts
+++ b/packages/engine/tests/integration/simConstants.integration.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  LIGHT_SCHEDULE_GRID_HOURS,
   SIM_CONSTANTS,
   getSimulationConstant,
   type SimulationConstantName
@@ -8,7 +9,10 @@ import {
 
 describe('engine exports', () => {
   it('re-exports canonical simulation constants', () => {
-    expect(SIM_CONSTANTS.AREA_QUANTUM_M2).toBe(0.25);
+    expect(SIM_CONSTANTS.AREA_QUANTUM_M2).toBe(LIGHT_SCHEDULE_GRID_HOURS);
+    expect(SIM_CONSTANTS.LIGHT_SCHEDULE_GRID_HOURS).toBe(
+      LIGHT_SCHEDULE_GRID_HOURS
+    );
     expect(SIM_CONSTANTS.ROOM_DEFAULT_HEIGHT_M).toBe(3);
   });
 

--- a/packages/engine/tests/unit/simConstants.test.ts
+++ b/packages/engine/tests/unit/simConstants.test.ts
@@ -7,6 +7,7 @@ import {
   HOURS_PER_MONTH,
   HOURS_PER_TICK,
   HOURS_PER_YEAR,
+  LIGHT_SCHEDULE_GRID_HOURS,
   MONTHS_PER_YEAR,
   ROOM_DEFAULT_HEIGHT_M,
   SIM_CONSTANTS
@@ -14,7 +15,8 @@ import {
 
 describe('simConstants', () => {
   it('exposes canonical SEC values', () => {
-    expect(AREA_QUANTUM_M2).toBe(0.25);
+    expect(AREA_QUANTUM_M2).toBe(LIGHT_SCHEDULE_GRID_HOURS);
+    expect(LIGHT_SCHEDULE_GRID_HOURS).toBeCloseTo(1 / 4);
     expect(ROOM_DEFAULT_HEIGHT_M).toBe(3);
     expect(HOURS_PER_TICK).toBe(1);
     expect(HOURS_PER_DAY).toBe(24);
@@ -28,6 +30,9 @@ describe('simConstants', () => {
     expect(Object.isFrozen(SIM_CONSTANTS)).toBe(true);
     expect(Reflect.set(SIM_CONSTANTS, 'AREA_QUANTUM_M2', 1)).toBe(false);
     expect(SIM_CONSTANTS.AREA_QUANTUM_M2).toBe(AREA_QUANTUM_M2);
+    expect(SIM_CONSTANTS.LIGHT_SCHEDULE_GRID_HOURS).toBe(
+      LIGHT_SCHEDULE_GRID_HOURS
+    );
   });
 
 });


### PR DESCRIPTION
### **User description**
## Summary
- add the SEC-aligned LIGHT_SCHEDULE_GRID_HOURS export to simConstants and include it in the aggregate map
- reuse the shared light schedule grid constant inside validation logic and supporting tests
- document the canonical grid value and changelog entry for the new constant

## Testing
- pnpm --filter @wb/engine test

------
https://chatgpt.com/codex/tasks/task_e_68de364275bc8325b05d2f5007e0b2eb


___

### **PR Type**
Enhancement


___

### **Description**
- Centralize light schedule grid constant to eliminate duplication

- Update validation logic to use shared constant

- Add documentation for new constant

- Update tests to use centralized value


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Local constant"] --> B["Centralized LIGHT_SCHEDULE_GRID_HOURS"]
  B --> C["Validation logic"]
  B --> D["Test files"]
  B --> E["Documentation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document light schedule grid constant changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/CHANGELOG.md

<ul><li>Add changelog entry for light schedule grid constant centralization<br> <li> Document the SEC-mandated constant addition and usage updates</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/59/files#diff-2bfab3db5cc1baf4c6d3ff6b19901926e3bdf4411ec685dac973e5fcff1c723b">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>simConstants.md</strong><dd><code>Add light schedule grid constant documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/constants/simConstants.md

<ul><li>Add <code>LIGHT_SCHEDULE_GRID_HOURS</code> constant to documentation table<br> <li> Document 15 minute scheduling step resolution</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/59/files#diff-81a86ae7504eab9458b1fcea092878278d4b53bcdefb378f727ee85b83520bc7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>simConstants.ts</strong><dd><code>Add centralized light schedule grid constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/engine/src/backend/src/constants/simConstants.ts

<ul><li>Add <code>LIGHT_SCHEDULE_GRID_HOURS</code> constant with 0.25 value<br> <li> Include new constant in <code>SimulationConstants</code> interface<br> <li> Add constant to <code>SIM_CONSTANTS</code> aggregate object</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/59/files#diff-b32e4e060d9e9a14401a78ea0d8330c75e14df62f4f81a4f5ed9549cf77339c8">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>validation.ts</strong><dd><code>Use centralized constant in validation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/engine/src/backend/src/domain/validation.ts

<ul><li>Import <code>LIGHT_SCHEDULE_GRID_HOURS</code> from simConstants<br> <li> Replace local <code>FIFTEEN_MINUTE_GRID_HOURS</code> with shared constant<br> <li> Update validation logic to use centralized value</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/59/files#diff-d1c48f777ff7d59be6761c099716d202db59ac19e1a4ac7de94937ba0fbaaaf3">+6/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>simConstants.integration.test.ts</strong><dd><code>Update integration tests for new constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/engine/tests/integration/simConstants.integration.test.ts

<ul><li>Import <code>LIGHT_SCHEDULE_GRID_HOURS</code> constant<br> <li> Update test assertions to use shared constant<br> <li> Add test for new constant in aggregate object</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/59/files#diff-8f74f4b18b212f4d44ec4cff0238b2610ae2285d3edd436854d5c9dcae612d76">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>simConstants.test.ts</strong><dd><code>Update unit tests for new constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/engine/tests/unit/simConstants.test.ts

<ul><li>Import <code>LIGHT_SCHEDULE_GRID_HOURS</code> constant<br> <li> Update test assertions to compare constants<br> <li> Add immutability test for new constant</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/59/files#diff-2c3943cee4bc9ddcc20633d565a65cd82526d952914cc6c3e0671f90bc9438bb">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

