### PR TITLE
feat: enforce company location metadata

### DIFF
--- a/docs/ADR/ADR-0008-company-location-metadata.md
+++ b/docs/ADR/ADR-0008-company-location-metadata.md
@@ -1,0 +1,29 @@
+# ADR-0008: Company headquarters location metadata
+
+## Status
+Accepted
+
+## Context
+The Simulation Engine Contract (SEC v0.2.1) is preparing logistics and
+regional compliance features that rely on knowing where a company operates. The
+existing domain model lacked explicit location metadata, preventing forthcoming
+work from resolving tariff rules, localisation, and spatial planning defaults.
+Without a canonical default the façade cannot bootstrap scenarios until the UI
+collects the new fields.
+
+## Decision
+- Extend the `Company` entity with a mandatory `location` object containing
+  longitude, latitude, city, and country metadata.
+- Guard the new shape at both schema (Zod) and business-validation layers so
+  integrations receive deterministic feedback for missing/invalid data.
+- Introduce Hamburg defaults in `simConstants` that seed newly generated worlds
+  until the UI surfaces headquarters capture.
+
+## Consequences
+- Engine, façade, and documentation updates now assume `company.location`
+  exists; existing fixtures and tests were migrated to provide valid metadata.
+- Future logistics features can rely on the presence of location data without
+  introducing further breaking changes.
+- Integrations must supply non-empty locality data and coordinates within the
+  [-180, 180]/[-90, 90] ranges or risk validation failures, improving data
+  quality ahead of downstream consumption.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### #23 WB-018 company headquarters location metadata
+- Added Hamburg-backed default company location constants to `simConstants` and
+  documented them in the canonical constants reference for interim UI coverage.
+- Extended the domain model, schemas, and business validation to require
+  `company.location` with strict coordinate bounds and non-empty locality data.
+- Updated unit/integration coverage across engine and façade packages to supply
+  the new location metadata and assert detailed error reporting for invalid
+  coordinates.
+
 ### #22 WB-017 light schedule grid constant centralisation
 - Added the SEC-mandated `LIGHT_SCHEDULE_GRID_HOURS` export to the canonical
   `simConstants` module so photoperiod validators share the same 15 minute grid

--- a/docs/constants/simConstants.md
+++ b/docs/constants/simConstants.md
@@ -19,6 +19,10 @@ normalisation mandated by the SEC.
 | `MONTHS_PER_YEAR` | `12` | months | Months per in-game year. |
 | `HOURS_PER_MONTH` | `720` | h | Derived: `HOURS_PER_DAY × DAYS_PER_MONTH`. |
 | `HOURS_PER_YEAR` | `8 640` | h | Derived: `HOURS_PER_MONTH × MONTHS_PER_YEAR`. |
+| `DEFAULT_COMPANY_LOCATION_LON` | `9.9937` | ° | Default headquarters longitude (Hamburg) until UI capture lands. |
+| `DEFAULT_COMPANY_LOCATION_LAT` | `53.5511` | ° | Default headquarters latitude (Hamburg) until UI capture lands. |
+| `DEFAULT_COMPANY_LOCATION_CITY` | `"Hamburg"` | — | Default headquarters city placeholder. |
+| `DEFAULT_COMPANY_LOCATION_COUNTRY` | `"Deutschland"` | — | Default headquarters country placeholder. |
 
 ## Usage guidelines
 

--- a/packages/engine/src/backend/src/constants/simConstants.ts
+++ b/packages/engine/src/backend/src/constants/simConstants.ts
@@ -47,6 +47,24 @@ export interface SimulationConstants {
    * in-game year.
    */
   readonly HOURS_PER_YEAR: number;
+  /**
+   * Default longitude (decimal degrees) for company headquarters metadata
+   * until the UI allows customisation.
+   */
+  readonly DEFAULT_COMPANY_LOCATION_LON: number;
+  /**
+   * Default latitude (decimal degrees) for company headquarters metadata
+   * until the UI allows customisation.
+   */
+  readonly DEFAULT_COMPANY_LOCATION_LAT: number;
+  /**
+   * Default city name used for company headquarters metadata.
+   */
+  readonly DEFAULT_COMPANY_LOCATION_CITY: string;
+  /**
+   * Default country name used for company headquarters metadata.
+   */
+  readonly DEFAULT_COMPANY_LOCATION_COUNTRY: string;
 }
 
 /**
@@ -104,6 +122,28 @@ export const HOURS_PER_MONTH = HOURS_PER_DAY * DAYS_PER_MONTH;
 export const HOURS_PER_YEAR = HOURS_PER_MONTH * MONTHS_PER_YEAR;
 
 /**
+ * Temporary default longitude for company headquarters metadata. Anchored to
+ * Hamburg (Germany) until SEC-compliant UI capture is available.
+ */
+export const DEFAULT_COMPANY_LOCATION_LON = 9.9937 as const;
+
+/**
+ * Temporary default latitude for company headquarters metadata. Anchored to
+ * Hamburg (Germany) until SEC-compliant UI capture is available.
+ */
+export const DEFAULT_COMPANY_LOCATION_LAT = 53.5511 as const;
+
+/**
+ * Temporary default city name for company headquarters metadata.
+ */
+export const DEFAULT_COMPANY_LOCATION_CITY = 'Hamburg' as const;
+
+/**
+ * Temporary default country name for company headquarters metadata.
+ */
+export const DEFAULT_COMPANY_LOCATION_COUNTRY = 'Deutschland' as const;
+
+/**
  * Frozen object literal bundling all canonical simulation constants for
  * ergonomic bulk imports.
  */
@@ -116,7 +156,11 @@ export const SIM_CONSTANTS: Readonly<SimulationConstants> = Object.freeze({
   DAYS_PER_MONTH,
   MONTHS_PER_YEAR,
   HOURS_PER_MONTH,
-  HOURS_PER_YEAR
+  HOURS_PER_YEAR,
+  DEFAULT_COMPANY_LOCATION_LON,
+  DEFAULT_COMPANY_LOCATION_LAT,
+  DEFAULT_COMPANY_LOCATION_CITY,
+  DEFAULT_COMPANY_LOCATION_COUNTRY
 });
 
 /**

--- a/packages/engine/src/backend/src/domain/entities.ts
+++ b/packages/engine/src/backend/src/domain/entities.ts
@@ -91,6 +91,21 @@ export interface SpatialEntity {
 }
 
 /**
+ * Geographic location metadata associated with a company headquarters.
+ * Essential for SEC-aligned logistics, localisation, and compliance features.
+ */
+export interface CompanyLocation {
+  /** Longitude coordinate expressed in decimal degrees within [-180, 180]. */
+  readonly lon: number;
+  /** Latitude coordinate expressed in decimal degrees within [-90, 90]. */
+  readonly lat: number;
+  /** City name describing the headquarters locality. */
+  readonly cityName: string;
+  /** Country name describing the headquarters locality. */
+  readonly countryName: string;
+}
+
+/**
  * Canonical device instance model shared across placement scopes.
  */
 export interface DeviceInstance extends DomainEntity, SluggedEntity {
@@ -195,6 +210,8 @@ export interface Structure extends DomainEntity, SluggedEntity, SpatialEntity {
  * Canonical representation of the company operating the simulation world.
  */
 export interface Company extends DomainEntity, SluggedEntity {
+  /** Geographic location of the company headquarters. */
+  readonly location: CompanyLocation;
   /** Structures owned and operated by the company. */
   readonly structures: readonly Structure[];
 }

--- a/packages/engine/src/backend/src/domain/schemas.ts
+++ b/packages/engine/src/backend/src/domain/schemas.ts
@@ -4,6 +4,7 @@ import {
   PLANT_LIFECYCLE_STAGES,
   ROOM_PURPOSES,
   type Company,
+  type CompanyLocation,
   type LightSchedule,
   type Plant,
   type Room,
@@ -32,6 +33,17 @@ const sluggedEntitySchema = z.object({
 const spatialEntitySchema = z.object({
   floorArea_m2: finiteNumber.positive('floorArea_m2 must be positive.'),
   height_m: finiteNumber.positive('height_m must be positive.')
+});
+
+export const companyLocationSchema: z.ZodType<CompanyLocation> = z.object({
+  lon: finiteNumber
+    .min(-180, 'lon must be >= -180')
+    .max(180, 'lon must be <= 180'),
+  lat: finiteNumber
+    .min(-90, 'lat must be >= -90')
+    .max(90, 'lat must be <= 90'),
+  cityName: nonEmptyString,
+  countryName: nonEmptyString
 });
 
 export const lightScheduleSchema: z.ZodType<LightSchedule> = z
@@ -134,6 +146,7 @@ export const structureSchema: z.ZodType<Structure> = domainEntitySchema
 export const companySchema: z.ZodType<Company> = domainEntitySchema
   .merge(sluggedEntitySchema)
   .extend({
+    location: companyLocationSchema,
     structures: z.array(structureSchema).readonly()
   });
 

--- a/packages/engine/src/backend/src/domain/validation.ts
+++ b/packages/engine/src/backend/src/domain/validation.ts
@@ -384,6 +384,55 @@ export function validateCompanyWorld(
 ): WorldValidationResult {
   const issues: WorldValidationIssue[] = [];
 
+  const locationPath = 'company.location';
+
+  if (!company.location) {
+    issues.push({
+      path: locationPath,
+      message: 'company must define a location'
+    });
+  } else {
+    const { lon, lat, cityName, countryName } = company.location;
+
+    if (!Number.isFinite(lon)) {
+      issues.push({
+        path: `${locationPath}.lon`,
+        message: 'longitude must be a finite number'
+      });
+    } else if (lon < -180 || lon > 180) {
+      issues.push({
+        path: `${locationPath}.lon`,
+        message: 'longitude must lie within [-180, 180]'
+      });
+    }
+
+    if (!Number.isFinite(lat)) {
+      issues.push({
+        path: `${locationPath}.lat`,
+        message: 'latitude must be a finite number'
+      });
+    } else if (lat < -90 || lat > 90) {
+      issues.push({
+        path: `${locationPath}.lat`,
+        message: 'latitude must lie within [-90, 90]'
+      });
+    }
+
+    if (!cityName || cityName.trim() === '') {
+      issues.push({
+        path: `${locationPath}.cityName`,
+        message: 'city name must not be empty'
+      });
+    }
+
+    if (!countryName || countryName.trim() === '') {
+      issues.push({
+        path: `${locationPath}.countryName`,
+        message: 'country name must not be empty'
+      });
+    }
+  }
+
   company.structures.forEach((structure, structureIndex) => {
     const structurePath = `company.structures[${String(structureIndex)}]`;
 

--- a/packages/engine/tests/integration/domain/worldValidation.integration.test.ts
+++ b/packages/engine/tests/integration/domain/worldValidation.integration.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import {
   AREA_QUANTUM_M2,
-  ROOM_DEFAULT_HEIGHT_M
+  ROOM_DEFAULT_HEIGHT_M,
+  DEFAULT_COMPANY_LOCATION_LON,
+  DEFAULT_COMPANY_LOCATION_LAT,
+  DEFAULT_COMPANY_LOCATION_CITY,
+  DEFAULT_COMPANY_LOCATION_COUNTRY
 } from '@/backend/src/constants/simConstants.js';
 import {
   type Company,
@@ -66,6 +70,12 @@ function buildInvalidCompany(): Company {
     id: uuid('10000000-0000-0000-0000-000000000001'),
     slug: 'invalid-company',
     name: 'Invalid Company',
+    location: {
+      lon: DEFAULT_COMPANY_LOCATION_LON,
+      lat: DEFAULT_COMPANY_LOCATION_LAT,
+      cityName: DEFAULT_COMPANY_LOCATION_CITY,
+      countryName: DEFAULT_COMPANY_LOCATION_COUNTRY
+    },
     structures: [
       {
         id: uuid('10000000-0000-0000-0000-000000000010'),

--- a/packages/engine/tests/unit/domain/schemas.test.ts
+++ b/packages/engine/tests/unit/domain/schemas.test.ts
@@ -26,6 +26,12 @@ const BASE_WORLD = {
   id: '00000000-0000-0000-0000-000000000001',
   slug: 'acme-cultivation',
   name: 'ACME Cultivation',
+  location: {
+    lon: 9.9937,
+    lat: 53.5511,
+    cityName: 'Hamburg',
+    countryName: 'Deutschland'
+  },
   structures: [
     {
       id: '00000000-0000-0000-0000-000000000010',
@@ -231,6 +237,85 @@ describe('companySchema', () => {
       0,
       'zones'
     ]);
+  });
+
+  it('rejects companies missing location metadata', () => {
+    const invalidWorld = cloneWorld();
+    Reflect.deleteProperty(invalidWorld, 'location');
+
+    const result = companySchema.safeParse(invalidWorld);
+
+    expect(result.success).toBe(false);
+    expect(result.success ? [] : result.error.issues.map((issue) => issue.path)).toContainEqual([
+      'location'
+    ]);
+  });
+
+  it('rejects longitude coordinates outside the valid range', () => {
+    const invalidWorld = cloneWorld();
+    invalidWorld.location.lon = 200;
+
+    const result = companySchema.safeParse(invalidWorld);
+
+    expect(result.success).toBe(false);
+    expect(result.success ? [] : result.error.issues.map((issue) => issue.path)).toContainEqual([
+      'location',
+      'lon'
+    ]);
+  });
+
+  it('rejects latitude coordinates outside the valid range', () => {
+    const invalidWorld = cloneWorld();
+    invalidWorld.location.lat = -100;
+
+    const result = companySchema.safeParse(invalidWorld);
+
+    expect(result.success).toBe(false);
+    expect(result.success ? [] : result.error.issues.map((issue) => issue.path)).toContainEqual([
+      'location',
+      'lat'
+    ]);
+  });
+
+  it('rejects empty location city names', () => {
+    const invalidWorld = cloneWorld();
+    invalidWorld.location.cityName = '';
+
+    const result = companySchema.safeParse(invalidWorld);
+
+    expect(result.success).toBe(false);
+    expect(result.success ? [] : result.error.issues.map((issue) => issue.path)).toContainEqual([
+      'location',
+      'cityName'
+    ]);
+  });
+
+  it('rejects empty location country names', () => {
+    const invalidWorld = cloneWorld();
+    invalidWorld.location.countryName = '';
+
+    const result = companySchema.safeParse(invalidWorld);
+
+    expect(result.success).toBe(false);
+    expect(result.success ? [] : result.error.issues.map((issue) => issue.path)).toContainEqual([
+      'location',
+      'countryName'
+    ]);
+  });
+
+  it('accepts coordinates located on the boundary values', () => {
+    const boundaryWorld = cloneWorld();
+    boundaryWorld.location.lon = -180;
+    boundaryWorld.location.lat = -90;
+
+    let result = companySchema.safeParse(boundaryWorld);
+    expect(result.success).toBe(true);
+
+    boundaryWorld.location.lon = 180;
+    boundaryWorld.location.lat = 90;
+
+    result = companySchema.safeParse(boundaryWorld);
+    expect(result.success).toBe(true);
   });
 });
 

--- a/packages/facade/tests/integration/initializeFacade.integration.test.ts
+++ b/packages/facade/tests/integration/initializeFacade.integration.test.ts
@@ -7,6 +7,12 @@ describe('initializeFacade', () => {
       id: '30bd7f5e-1c8d-4f5f-9a5b-8b9e5821fd52',
       slug: 'integration-company',
       name: 'Integration Company',
+      location: {
+        lon: 9.9937,
+        lat: 53.5511,
+        cityName: 'Hamburg',
+        countryName: 'Deutschland'
+      },
       structures: []
     } as const;
 


### PR DESCRIPTION
### **User description**
## Summary
- add Hamburg-backed default company location constants to the shared simulation constants module and documentation
- require `company.location` across the engine domain model, schemas, validation, and supporting ADR guidance
- refresh engine/facade fixtures and tests to cover location validation scenarios and keep integration flows green

## Testing
- pnpm --filter @wb/engine test
- pnpm --filter @wb/facade test

------
https://chatgpt.com/codex/tasks/task_e_68de3e047848832598fb6f2d525e672b


___

### **PR Type**
Enhancement


___

### **Description**
- Add mandatory `company.location` metadata with coordinates validation

- Introduce Hamburg-based default location constants for bootstrapping

- Update domain model, schemas, and validation layers

- Refresh fixtures and tests across engine/facade packages


___

### Diagram Walkthrough


```mermaid
flowchart LR
  constants["simConstants"] --> entity["Company Entity"]
  entity --> schema["Zod Schema"]
  schema --> validation["Business Validation"]
  validation --> tests["Test Coverage"]
  constants --> docs["Documentation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>ADR-0008-company-location-metadata.md</strong><dd><code>Document company location metadata decision</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/60/files#diff-175759f55c9053eb8c5e5bc98101e3034959bca0634779131794d6f299f5fc6f">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Add changelog entry for location metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/60/files#diff-2bfab3db5cc1baf4c6d3ff6b19901926e3bdf4411ec685dac973e5fcff1c723b">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>simConstants.md</strong><dd><code>Document Hamburg default location constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/60/files#diff-81a86ae7504eab9458b1fcea092878278d4b53bcdefb378f727ee85b83520bc7">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>simConstants.ts</strong><dd><code>Add Hamburg default location constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/60/files#diff-b32e4e060d9e9a14401a78ea0d8330c75e14df62f4f81a4f5ed9549cf77339c8">+45/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>entities.ts</strong><dd><code>Add CompanyLocation interface and location property</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/60/files#diff-1f1b50a474645686374ec1a78ab764235095271115384c6c9adcc2c34562fc1e">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>schemas.ts</strong><dd><code>Add location schema with coordinate validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/60/files#diff-0ee28f42c004e466b2fd678b947e03d6b0bf2fb664dcab8d77226edc554b7ae9">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>validation.ts</strong><dd><code>Add business validation for location metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/60/files#diff-d1c48f777ff7d59be6761c099716d202db59ac19e1a4ac7de94937ba0fbaaaf3">+49/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>worldValidation.integration.test.ts</strong><dd><code>Update integration test with location metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/60/files#diff-9ec3791bc06c0aba2fa4033221f0d8db609445118f22120f3adc73b821c53a58">+11/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>schemas.test.ts</strong><dd><code>Add comprehensive location schema validation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/60/files#diff-acf33303198b38272620d7ad564395887e5142ef38da611b87274b98a20be169">+85/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>validateCompanyWorld.test.ts</strong><dd><code>Add location validation unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/60/files#diff-c1262ee2452e18ed6d3fb93d45c617494228e21bfbd3c8fa5d0fc0e58aca3b59">+141/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>initializeFacade.integration.test.ts</strong><dd><code>Update facade integration test fixtures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/60/files#diff-a76620405bcbb961efa0606b30c7c4891bcd287ddcf5980c256c4b3530ccd80e">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

