### PR TITLE
refactor: consolidate company location validation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### #24 WB-019 company location validation consolidation
+- Updated the shared `nonEmptyString` schema to trim incoming values before
+  enforcing non-empty constraints so world tree strings remain normalised at
+  parse time.
+- Removed duplicate company location bounds and emptiness checks from
+  `validateCompanyWorld`, delegating structural enforcement to the Zod schema
+  layer to avoid divergent error reporting.
+- Recorded the consolidation here to highlight that business validation now
+  focuses on SEC-specific guardrails beyond baseline schema requirements.
+
 ### #23 WB-018 company headquarters location metadata
 - Added Hamburg-backed default company location constants to `simConstants` and
   documented them in the canonical constants reference for interim UI coverage.

--- a/packages/engine/src/backend/src/domain/schemas.ts
+++ b/packages/engine/src/backend/src/domain/schemas.ts
@@ -18,7 +18,10 @@ import {
 const [STRUCTURE_SCOPE, ROOM_SCOPE, ZONE_SCOPE] = DEVICE_PLACEMENT_SCOPES;
 
 const uuidSchema = z.string().uuid('Expected a UUID v4 identifier.').brand<'Uuid'>();
-const nonEmptyString = z.string().min(1, 'String fields must not be empty.');
+const nonEmptyString = z
+  .string()
+  .trim()
+  .min(1, 'String fields must not be empty.');
 const finiteNumber = z.number().finite('Value must be a finite number.');
 
 const domainEntitySchema = z.object({

--- a/packages/engine/src/backend/src/domain/validation.ts
+++ b/packages/engine/src/backend/src/domain/validation.ts
@@ -384,55 +384,6 @@ export function validateCompanyWorld(
 ): WorldValidationResult {
   const issues: WorldValidationIssue[] = [];
 
-  const locationPath = 'company.location';
-
-  if (!company.location) {
-    issues.push({
-      path: locationPath,
-      message: 'company must define a location'
-    });
-  } else {
-    const { lon, lat, cityName, countryName } = company.location;
-
-    if (!Number.isFinite(lon)) {
-      issues.push({
-        path: `${locationPath}.lon`,
-        message: 'longitude must be a finite number'
-      });
-    } else if (lon < -180 || lon > 180) {
-      issues.push({
-        path: `${locationPath}.lon`,
-        message: 'longitude must lie within [-180, 180]'
-      });
-    }
-
-    if (!Number.isFinite(lat)) {
-      issues.push({
-        path: `${locationPath}.lat`,
-        message: 'latitude must be a finite number'
-      });
-    } else if (lat < -90 || lat > 90) {
-      issues.push({
-        path: `${locationPath}.lat`,
-        message: 'latitude must lie within [-90, 90]'
-      });
-    }
-
-    if (!cityName || cityName.trim() === '') {
-      issues.push({
-        path: `${locationPath}.cityName`,
-        message: 'city name must not be empty'
-      });
-    }
-
-    if (!countryName || countryName.trim() === '') {
-      issues.push({
-        path: `${locationPath}.countryName`,
-        message: 'country name must not be empty'
-      });
-    }
-  }
-
   company.structures.forEach((structure, structureIndex) => {
     const structurePath = `company.structures[${String(structureIndex)}]`;
 


### PR DESCRIPTION
## Summary
- trim and normalize shared non-empty string schema for world tree payloads
- drop redundant company location checks from business validation in favour of the Zod schema
- document the validation consolidation in the changelog

## Testing
- pnpm --filter @wb/engine lint *(fails: workspace lacks @eslint/js dependency in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de40fbbd0083259c50b4049a070308