### PR TITLE
feat: add deterministic tariff resolver and memoized bootstrap

### DIFF
--- a/data/configs/difficulty.json
+++ b/data/configs/difficulty.json
@@ -15,7 +15,11 @@
         "itemPriceMultiplier": 0.9,
         "harvestPriceMultiplier": 1.1,
         "rentPerSqmStructurePerTick": 0.1,
-        "rentPerSqmRoomPerTick": 0.2
+        "rentPerSqmRoomPerTick": 0.2,
+        "energyPriceFactor": 0.85,
+        "energyPriceOverride": 0.25,
+        "waterPriceFactor": 0.8,
+        "waterPriceOverride": 1.5
       }
     }
   },
@@ -35,7 +39,9 @@
         "itemPriceMultiplier": 1.0,
         "harvestPriceMultiplier": 1.0,
         "rentPerSqmStructurePerTick": 0.15,
-        "rentPerSqmRoomPerTick": 0.3
+        "rentPerSqmRoomPerTick": 0.3,
+        "energyPriceFactor": 1.0,
+        "waterPriceFactor": 1.0
       }
     }
   },
@@ -55,7 +61,9 @@
         "itemPriceMultiplier": 1.1,
         "harvestPriceMultiplier": 0.9,
         "rentPerSqmStructurePerTick": 0.2,
-        "rentPerSqmRoomPerTick": 0.4
+        "rentPerSqmRoomPerTick": 0.4,
+        "energyPriceFactor": 1.25,
+        "waterPriceOverride": 2.5
       }
     }
   }

--- a/docs/ADR/ADR-0004-issue-0003-economy-price-map-alignment.md
+++ b/docs/ADR/ADR-0004-issue-0003-economy-price-map-alignment.md
@@ -23,3 +23,6 @@ These discrepancies made it impossible to resolve tariffs deterministically at s
 - Room blueprints stay focused on spatial semantics; rent modelling will live in dedicated economy systems if/when needed.
 - Tariff resolution utilities can load `/data/prices/utilityPrices.json` as-is, confident that the map aligns with SEC policy and contains no unrelated knobs.
 - Tooling and validation must flag regressions if new tariff fields appear or if device maintenance schemas drift from the base/increase structure.
+- Introduced a memoised `resolveTariffs` helper in the engine bootstrap path to
+  enforce override-before-factor precedence and keep resolved electricity and
+  water tariffs immutable for the lifetime of a scenario run.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### #25 WB-020 deterministic tariff resolution helper
+- Added `resolveTariffs(config)` to the engine backend utilities so scenarios
+  deterministically derive electricity and water tariffs with override-first
+  precedence before multiplicative difficulty factors.
+- Wired the bootstrap pipeline to memoise resolved tariffs per difficulty,
+  exposing the immutable tariff map on `EngineBootstrapConfig` and the façade
+  integration surface for downstream consumers.
+- Enriched `data/configs/difficulty.json` with the documented tariff override
+  and factor knobs and expanded Vitest unit/integration coverage to exercise
+  base-only, factor-only, override-only, and mixed configurations.
+
 ### #24 WB-019 company location validation consolidation
 - Updated the shared `nonEmptyString` schema to trim incoming values before
   enforcing non-empty constraints so world tree strings remain normalised at

--- a/packages/engine/src/backend/src/domain/validation.ts
+++ b/packages/engine/src/backend/src/domain/validation.ts
@@ -384,6 +384,53 @@ export function validateCompanyWorld(
 ): WorldValidationResult {
   const issues: WorldValidationIssue[] = [];
 
+  if (!company.location) {
+    issues.push({
+      path: 'company.location',
+      message: 'company must define a location'
+    });
+  } else {
+    const { lon, lat, cityName, countryName } = company.location;
+
+    if (!Number.isFinite(lon)) {
+      issues.push({
+        path: 'company.location.lon',
+        message: 'longitude must be a finite number'
+      });
+    } else if (lon < -180 || lon > 180) {
+      issues.push({
+        path: 'company.location.lon',
+        message: 'longitude must lie within [-180, 180]'
+      });
+    }
+
+    if (!Number.isFinite(lat)) {
+      issues.push({
+        path: 'company.location.lat',
+        message: 'latitude must be a finite number'
+      });
+    } else if (lat < -90 || lat > 90) {
+      issues.push({
+        path: 'company.location.lat',
+        message: 'latitude must lie within [-90, 90]'
+      });
+    }
+
+    if (typeof cityName !== 'string' || cityName.trim().length === 0) {
+      issues.push({
+        path: 'company.location.cityName',
+        message: 'city name must not be empty'
+      });
+    }
+
+    if (typeof countryName !== 'string' || countryName.trim().length === 0) {
+      issues.push({
+        path: 'company.location.countryName',
+        message: 'country name must not be empty'
+      });
+    }
+  }
+
   company.structures.forEach((structure, structureIndex) => {
     const structurePath = `company.structures[${String(structureIndex)}]`;
 

--- a/packages/engine/src/backend/src/util/tariffs.ts
+++ b/packages/engine/src/backend/src/util/tariffs.ts
@@ -1,0 +1,114 @@
+import { z } from 'zod';
+
+/**
+ * Describes difficulty-driven tariff modifiers extracted from scenario configuration.
+ */
+export interface TariffDifficultyModifiers {
+  /** Optional scalar that adjusts the base electricity price. */
+  readonly energyPriceFactor?: number;
+  /** Absolute override applied to the electricity tariff when provided. */
+  readonly energyPriceOverride?: number;
+  /** Optional scalar that adjusts the base water price. */
+  readonly waterPriceFactor?: number;
+  /** Absolute override applied to the water tariff when provided. */
+  readonly waterPriceOverride?: number;
+}
+
+/**
+ * Canonical tariff configuration consumed by the resolver.
+ */
+export interface TariffConfig {
+  /** Baseline electricity price sourced from the utility price map. */
+  readonly price_electricity: number;
+  /** Baseline water price sourced from the utility price map. */
+  readonly price_water: number;
+  /** Optional difficulty modifiers that may override or scale the base prices. */
+  readonly difficulty?: TariffDifficultyModifiers;
+}
+
+/**
+ * Immutable effective tariffs emitted by the resolver.
+ */
+export interface ResolvedTariffs {
+  /** Effective electricity price expressed per kWh. */
+  readonly price_electricity: number;
+  /** Effective water price expressed per m³. */
+  readonly price_water: number;
+}
+
+const nonNegativeNumberSchema = z
+  .number()
+  .finite('Tariff values must be finite numbers.')
+  .min(0, 'Tariff values must be non-negative.');
+
+const positiveNumberSchema = z
+  .number()
+  .finite('Tariff factors must be finite numbers.')
+  .positive('Tariff factors must be positive.');
+
+type MutableTariffDifficulty = {
+  energyPriceFactor?: number;
+  energyPriceOverride?: number;
+  waterPriceFactor?: number;
+  waterPriceOverride?: number;
+};
+
+/**
+ * Zod schema that sanitises tariff difficulty modifiers so overrides take precedence
+ * over multiplicative factors.
+ */
+export const tariffDifficultySchema: z.ZodType<TariffDifficultyModifiers> = z
+  .object({
+    energyPriceFactor: positiveNumberSchema.optional(),
+    energyPriceOverride: nonNegativeNumberSchema.optional(),
+    waterPriceFactor: positiveNumberSchema.optional(),
+    waterPriceOverride: nonNegativeNumberSchema.optional()
+  })
+  .transform((modifiers) => {
+    const sanitised: MutableTariffDifficulty = { ...modifiers };
+
+    if (sanitised.energyPriceOverride !== undefined) {
+      delete sanitised.energyPriceFactor;
+    }
+
+    if (sanitised.waterPriceOverride !== undefined) {
+      delete sanitised.waterPriceFactor;
+    }
+
+    return sanitised as TariffDifficultyModifiers;
+  });
+
+/**
+ * Zod schema validating the resolver input configuration before computing tariffs.
+ */
+export const tariffConfigSchema: z.ZodType<TariffConfig> = z.object({
+  price_electricity: nonNegativeNumberSchema,
+  price_water: nonNegativeNumberSchema,
+  difficulty: tariffDifficultySchema.optional()
+});
+
+/**
+ * Resolves effective electricity and water tariffs given baseline utility pricing and
+ * optional difficulty modifiers. Overrides win over multiplicative factors and the
+ * resolved object is frozen to guarantee deterministic identity semantics.
+ *
+ * @param input - Utility pricing configuration sourced from scenario bootstrap data.
+ * @returns Immutable tariffs ready to be injected into the runtime state.
+ */
+export function resolveTariffs(input: TariffConfig): ResolvedTariffs {
+  const config = tariffConfigSchema.parse(input);
+  const difficulty = config.difficulty;
+
+  const resolvedElectricity =
+    difficulty?.energyPriceOverride ??
+    config.price_electricity * (difficulty?.energyPriceFactor ?? 1);
+
+  const resolvedWater =
+    difficulty?.waterPriceOverride ??
+    config.price_water * (difficulty?.waterPriceFactor ?? 1);
+
+  return Object.freeze({
+    price_electricity: resolvedElectricity,
+    price_water: resolvedWater
+  });
+}

--- a/packages/engine/tests/integration/tariffs.integration.test.ts
+++ b/packages/engine/tests/integration/tariffs.integration.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { createEngineBootstrapConfig } from '../../src/index.js';
+
+describe('tariff resolution (integration)', () => {
+  it('memoises tariffs for identical scenario requests', () => {
+    const first = createEngineBootstrapConfig('easy');
+    const second = createEngineBootstrapConfig('easy');
+
+    expect(first.tariffs).toBe(second.tariffs);
+    expect(first.tariffs).toEqual({
+      price_electricity: 0.25,
+      price_water: 1.5
+    });
+  });
+
+  it('reuses the fallback difficulty for unknown scenarios', () => {
+    const fallback = createEngineBootstrapConfig('normal');
+    const unknown = createEngineBootstrapConfig('integration');
+
+    expect(unknown.tariffs).toBe(fallback.tariffs);
+    expect(unknown.tariffs).toEqual({
+      price_electricity: 0.35,
+      price_water: 2
+    });
+  });
+});

--- a/packages/engine/tests/unit/createEngineBootstrapConfig.test.ts
+++ b/packages/engine/tests/unit/createEngineBootstrapConfig.test.ts
@@ -7,7 +7,11 @@ describe('createEngineBootstrapConfig', () => {
 
     expect(config).toEqual({
       scenarioId: 'demo',
-      verbose: false
+      verbose: false,
+      tariffs: {
+        price_electricity: 0.35,
+        price_water: 2
+      }
     });
   });
 

--- a/packages/engine/tests/unit/tariffs.spec.ts
+++ b/packages/engine/tests/unit/tariffs.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  resolveTariffs,
+  tariffDifficultySchema
+} from '@/backend/src/util/tariffs.js';
+
+describe('resolveTariffs', () => {
+  it('returns base tariffs when no difficulty modifiers are provided', () => {
+    const tariffs = resolveTariffs({
+      price_electricity: 0.35,
+      price_water: 2
+    });
+
+    expect(tariffs).toEqual({
+      price_electricity: 0.35,
+      price_water: 2
+    });
+    expect(Object.isFrozen(tariffs)).toBe(true);
+  });
+
+  it('applies multiplicative factors when overrides are not specified', () => {
+    const tariffs = resolveTariffs({
+      price_electricity: 0.35,
+      price_water: 2,
+      difficulty: {
+        energyPriceFactor: 1.5,
+        waterPriceFactor: 2
+      }
+    });
+
+    expect(tariffs).toEqual({
+      price_electricity: 0.525,
+      price_water: 4
+    });
+  });
+
+  it('prefers overrides over base prices when provided without factors', () => {
+    const tariffs = resolveTariffs({
+      price_electricity: 0.35,
+      price_water: 2,
+      difficulty: {
+        energyPriceOverride: 0.42,
+        waterPriceOverride: 1.8
+      }
+    });
+
+    expect(tariffs).toEqual({
+      price_electricity: 0.42,
+      price_water: 1.8
+    });
+  });
+
+  it('ignores factors when overrides are also supplied', () => {
+    const modifiers = tariffDifficultySchema.parse({
+      energyPriceFactor: 1.5,
+      energyPriceOverride: 0.4,
+      waterPriceFactor: 2.2,
+      waterPriceOverride: 1.9
+    });
+
+    expect(modifiers.energyPriceFactor).toBeUndefined();
+    expect(modifiers.waterPriceFactor).toBeUndefined();
+
+    const tariffs = resolveTariffs({
+      price_electricity: 0.35,
+      price_water: 2,
+      difficulty: modifiers
+    });
+
+    expect(tariffs).toEqual({
+      price_electricity: 0.4,
+      price_water: 1.9
+    });
+  });
+});

--- a/packages/facade/tests/integration/initializeFacade.integration.test.ts
+++ b/packages/facade/tests/integration/initializeFacade.integration.test.ts
@@ -20,7 +20,11 @@ describe('initializeFacade', () => {
 
     expect(result.engineConfig).toEqual({
       scenarioId: 'integration',
-      verbose: true
+      verbose: true,
+      tariffs: {
+        price_electricity: 0.35,
+        price_water: 2
+      }
     });
     expect(result.companyWorld).toEqual(world);
   });


### PR DESCRIPTION
## Summary
- introduce a backend `resolveTariffs` helper with Zod schemas that freeze override-first electricity and water tariffs
- memoise tariff resolution during engine bootstrap, expose the immutable tariffs through the engine and façade configs, and tighten company location validation
- extend difficulty fixtures, docs, and Vitest coverage to exercise base/factor/override cases and the bootstrap memoisation guardrail

## Testing
- pnpm --filter engine test

------
https://chatgpt.com/codex/tasks/task_e_68de448a86ec83258bf50ad31b58aad8