### PR TITLE
feat: advance sim time during commit stage

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### #28 WB-022 tick commit advances simulation time
+- Implemented the `commitAndTelemetry` pipeline stage so each tick increments
+  `SimulationWorld.simTimeHours` by the SEC-mandated `HOURS_PER_TICK`, ensuring
+  downstream systems observe deterministic world time progression.
+- Added integration coverage in `packages/engine/tests/integration/pipeline/timeProgression.spec.ts`
+  that exercises repeated `runTick` invocations against the demo world and
+  asserts the cumulative hour count advances by one per stage cycle.
+
 ### #26 WB-009 tick orchestrator & perf harness
 - Implemented the SEC-ordered `runTick` pipeline in `packages/engine/src/backend/src/engine/Engine.ts`, wiring the seven phase modules through the shared `PIPELINE_ORDER` map so instrumentation hooks observe deterministic sequencing.
 - Added `createTickTraceCollector` and the `withPerfStage` sampling utility in `packages/engine/src/backend/src/engine/trace.ts` and `packages/engine/src/backend/src/util/perf.ts` to record per-stage timing and heap usage without leaking wall-clock state.

--- a/packages/engine/src/backend/src/engine/pipeline/commitAndTelemetry.ts
+++ b/packages/engine/src/backend/src/engine/pipeline/commitAndTelemetry.ts
@@ -1,7 +1,14 @@
+import { HOURS_PER_TICK } from '../../constants/simConstants.js';
 import type { SimulationWorld } from '../../domain/world.js';
 import type { EngineRunContext } from '../Engine.js';
 
+type MutableSimulationWorld = Omit<SimulationWorld, 'simTimeHours'> & {
+  simTimeHours: number;
+};
+
 export function commitAndTelemetry(world: SimulationWorld, ctx: EngineRunContext): void {
-  void world;
   void ctx;
+
+  const mutableWorld = world as MutableSimulationWorld;
+  mutableWorld.simTimeHours += HOURS_PER_TICK;
 }

--- a/packages/engine/tests/integration/pipeline/timeProgression.test.ts
+++ b/packages/engine/tests/integration/pipeline/timeProgression.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { HOURS_PER_TICK } from '@/backend/src/constants/simConstants.js';
+import { runTick } from '@/backend/src/engine/Engine.js';
+import { createDemoWorld } from '@/backend/src/engine/testHarness.js';
+
+describe('Tick pipeline — simulation time progression', () => {
+  it('advances simulation time by one tick per run', () => {
+    const world = createDemoWorld();
+    const ctx = {};
+
+    runTick(world, ctx);
+    expect(world.simTimeHours).toBe(HOURS_PER_TICK);
+
+    runTick(world, ctx);
+    expect(world.simTimeHours).toBe(2 * HOURS_PER_TICK);
+  });
+});


### PR DESCRIPTION
### **User description**
## Summary
- advance the commitAndTelemetry pipeline stage so each tick increments the world clock via the canonical HOURS_PER_TICK constant
- cover the new behaviour with an integration test that exercises repeated runTick calls against the demo world
- document the simulation-time progression behaviour in the changelog

## Testing
- pnpm --filter @wb/engine test

------
https://chatgpt.com/codex/tasks/task_e_68de4d6c7150832596204a8681b348a9


___

### **PR Type**
Enhancement


___

### **Description**
- Implement simulation time progression in commit stage

- Add integration test for time advancement behavior

- Document new functionality in changelog


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["runTick"] --> B["commitAndTelemetry"]
  B --> C["simTimeHours += HOURS_PER_TICK"]
  C --> D["Time Progression"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document simulation time progression feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/CHANGELOG.md

<ul><li>Add changelog entry for WB-022 tick commit functionality<br> <li> Document simulation time progression implementation<br> <li> Reference new integration test coverage</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/66/files#diff-2bfab3db5cc1baf4c6d3ff6b19901926e3bdf4411ec685dac973e5fcff1c723b">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>commitAndTelemetry.ts</strong><dd><code>Implement time progression in commit stage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/engine/src/backend/src/engine/pipeline/commitAndTelemetry.ts

<ul><li>Import <code>HOURS_PER_TICK</code> constant for time progression<br> <li> Add <code>MutableSimulationWorld</code> type for world mutation<br> <li> Implement time advancement logic in <code>commitAndTelemetry</code> function</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/66/files#diff-7ba70c2e312e51a173debad6c5b68e7c8c4149b6ea24153021b18e86791894a4">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>timeProgression.test.ts</strong><dd><code>Add integration test for time progression</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/engine/tests/integration/pipeline/timeProgression.test.ts

<ul><li>Create integration test for simulation time progression<br> <li> Test repeated <code>runTick</code> calls advance time correctly<br> <li> Verify cumulative hour count increases by <code>HOURS_PER_TICK</code></ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/66/files#diff-3bcd0e613a0e55a56e94bce136531451a3d2b63f1e8cb7143eb30ae9ffaa343f">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

