### PR TITLE
Fix total heap delta measurement in tick trace collector

### DIFF
--- a/packages/engine/src/backend/src/engine/trace.ts
+++ b/packages/engine/src/backend/src/engine/trace.ts
@@ -39,7 +39,6 @@ export function createTickTraceCollector(): TraceCollector {
   const steps: TraceStep[] = [];
   let tickEndTime = tickStartTime;
   let maxHeapUsedBytes = tickStartHeap;
-  let totalHeapDelta = 0;
 
   return {
     measureStage(name, fn) {
@@ -53,7 +52,6 @@ export function createTickTraceCollector(): TraceCollector {
         maxHeapUsedBytes = sample.heapUsedAfterBytes;
       }
 
-      totalHeapDelta += heapDelta;
       tickEndTime = sample.startedAtNs + sample.durationNs;
 
       steps.push({
@@ -67,6 +65,7 @@ export function createTickTraceCollector(): TraceCollector {
       });
     },
     finalize() {
+      const tickEndHeap = process.memoryUsage().heapUsed;
       const durationNs = Number(tickEndTime - tickStartTime);
 
       return {
@@ -74,8 +73,8 @@ export function createTickTraceCollector(): TraceCollector {
         endedAtNs: durationNs,
         durationNs,
         steps: steps.slice(),
-        totalHeapUsedDeltaBytes: totalHeapDelta,
-        maxHeapUsedBytes
+        totalHeapUsedDeltaBytes: tickEndHeap - tickStartHeap,
+        maxHeapUsedBytes: Math.max(maxHeapUsedBytes, tickEndHeap)
       } satisfies TickTrace;
     }
   } satisfies TraceCollector;


### PR DESCRIPTION
### **User description**
## Summary
- compute total heap delta using heap usage at the end of the tick during finalization
- ensure max heap metric accounts for the heap measurement taken at tick finalization

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de4fb1274c8325ac92f29e4c66506f


___

### **PR Type**
Bug fix


___

### **Description**
- Fix total heap delta calculation using actual tick end heap measurement

- Update max heap metric to include final heap usage

- Remove incremental heap delta tracking during tick execution


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Tick Start"] --> B["Measure Stages"]
  B --> C["Finalize Tick"]
  C --> D["Calculate Total Heap Delta"]
  D --> E["Update Max Heap Usage"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>trace.ts</strong><dd><code>Fix heap delta calculation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/engine/src/backend/src/engine/trace.ts

<ul><li>Remove <code>totalHeapDelta</code> variable and incremental tracking<br> <li> Calculate total heap delta using <code>tickEndHeap - tickStartHeap</code> in <br>finalize<br> <li> Update max heap calculation to include final heap measurement</ul>


</details>


  </td>
  <td><a href="https://github.com/rewired/weedbreed-2re-boot/pull/68/files#diff-da31785bf5d6f3e66db06924f8377017d88ccdf3d5e46b59b2fd1fd4e0ac7abe">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

