### PR TITLE
Implement device heat coupling across the pipeline

### DIFF
--- a/docs/ADR/ADR-0001-constants-alignment.md
+++ b/docs/ADR/ADR-0001-constants-alignment.md
@@ -11,6 +11,7 @@ The Simulation Engine Contract (SEC v0.2.1 §1.2) and downstream design document
   - `AREA_QUANTUM_M2 = 0.25`
   - `ROOM_DEFAULT_HEIGHT_M = 3`
   - Calendar invariants `HOURS_PER_DAY = 24`, `DAYS_PER_MONTH = 30`, `MONTHS_PER_YEAR = 12`
+  - Thermodynamic baselines `CP_AIR_J_PER_KG_K = 1 005` and `AIR_DENSITY_KG_PER_M3 = 1.2041`
 - Record the precedence order for simulation constants in this ADR to mirror the documentation contract hierarchy (SEC → DD → TDD → AGENTS → VISION_SCOPE) and ensure any change flows through all affected documents and the shared `simConstants` module.
 - Flag the legacy exporter specification advertising `AREA_QUANTUM_M2 = 0.5` for correction so downstream integrations are updated alongside the SEC-aligned constants.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### #32 WB-025 device thermal coupling
+- Added dry-air thermodynamic constants (`CP_AIR_J_PER_KG_K`,
+  `AIR_DENSITY_KG_PER_M3`) to the canonical sim constants module and mirrored the
+  reference documentation/ADR so pipeline code can compute heat deltas without
+  redeclaring physics baselines.
+- Implemented `applyDeviceHeat` plus the device/environment pipeline stages so
+  Phase 1 accumulates per-zone heat additions and Phase 2 removes sensible heat
+  within HVAC/dehumidifier capacity before committing air temperature updates.
+- Expanded the domain model with zone environment state and device duty/efficiency
+  fields, updating validation, fixtures, and tests (unit + integration) to cover
+  waste-heat heating, zero-duty stability, and cross-stage cooling flows.
+
 ### #31 WB-024 pipeline stages clone world snapshots
 - Normalised all pipeline stage modules to return shallow world clones so the
   immutable tick contract holds even before stage-specific logic lands.

--- a/docs/DD.md
+++ b/docs/DD.md
@@ -356,11 +356,13 @@ export function validateLightSchedule(onHours: number, offHours: number, startHo
 }
 
 // powerToHeat.ts (simplified)
-export function applyDeviceHeat(zone: Zone, d: { powerW: number; duty01: number; efficiency01: number }) {
-  const wasteW = d.powerW * (1 - d.efficiency01) * d.duty01;
+export function applyDeviceHeat(zone: Zone, d: { powerDraw_W: number; dutyCycle01: number; efficiency01: number }) {
+  const wasteW = d.powerDraw_W * (1 - d.efficiency01) * d.dutyCycle01;
   const joules = wasteW * 3600; // 1h
-  const dT = joules / (zone.airMass_kg * 1005); // Cp_air ≈ 1005 J/(kg·K)
-  zone.tempC += dT;
+  const volume = zone.floorArea_m2 * zone.height_m;
+  const airMassKg = volume * 1.2041; // 20°C baseline density
+  const dT = joules / (airMassKg * 1005); // Cp_air ≈ 1005 J/(kg·K)
+  return dT;
 }
 ```
 

--- a/docs/TDD.md
+++ b/docs/TDD.md
@@ -237,14 +237,19 @@ it('zone without cultivationMethod fails validation', async () => {
     
 
 ```ts
-// tests/module/thermo/powerToHeat.spec.ts
+// packages/engine/tests/unit/thermo/heat.spec.ts
 import { expect, it } from 'vitest';
 import { applyDeviceHeat } from '@/backend/src/engine/thermo/heat';
 
 it('adds sensible heat proportional to power draw and duty', () => {
-  const z = { airMass_kg: 75, tempC: 22 } as any;
-  applyDeviceHeat(z, { powerW: 600, duty01: 0.5, efficiency01: 0.9 });
-  expect(z.tempC).toBeGreaterThan(22);
+  const zone = { floorArea_m2: 60, height_m: 3 } as const;
+  const delta = applyDeviceHeat(zone, {
+    powerDraw_W: 600,
+    dutyCycle01: 0.5,
+    efficiency01: 0.9
+  });
+
+  expect(delta).toBeGreaterThan(0);
 });
 ```
 

--- a/docs/constants/simConstants.md
+++ b/docs/constants/simConstants.md
@@ -13,6 +13,8 @@ normalisation mandated by the SEC.
 | `AREA_QUANTUM_M2` | `0.25` | m² | Minimal calculable floor area for placement, zoning, and area rounding. |
 | `LIGHT_SCHEDULE_GRID_HOURS` | `0.25` | h | Photoperiod grid resolution enforcing 15 minute scheduling steps. |
 | `ROOM_DEFAULT_HEIGHT_M` | `3` | m | Default room interior height when blueprints omit overrides. |
+| `CP_AIR_J_PER_KG_K` | `1 005` | J/(kg·K) | Specific heat capacity of dry air at constant pressure. |
+| `AIR_DENSITY_KG_PER_M3` | `1.2041` | kg/m³ | Density of dry air at standard conditions (20 °C, 1 atm). |
 | `HOURS_PER_TICK` | `1` | h | Duration represented by one simulation tick (one in-game hour). |
 | `HOURS_PER_DAY` | `24` | h | Hours per in-game day (calendar invariant). |
 | `DAYS_PER_MONTH` | `30` | d | Days per in-game month. |

--- a/packages/engine/src/backend/src/constants/simConstants.ts
+++ b/packages/engine/src/backend/src/constants/simConstants.ts
@@ -22,6 +22,16 @@ export interface SimulationConstants {
    */
   readonly ROOM_DEFAULT_HEIGHT_M: number;
   /**
+   * Specific heat capacity of dry air at constant pressure, expressed in
+   * joules per kilogram and kelvin.
+   */
+  readonly CP_AIR_J_PER_KG_K: number;
+  /**
+   * Density of dry air at standard conditions, expressed in kilograms per
+   * cubic metre.
+   */
+  readonly AIR_DENSITY_KG_PER_M3: number;
+  /**
    * Number of in-game hours contained in a single simulation tick.
    */
   readonly HOURS_PER_TICK: number;
@@ -84,6 +94,18 @@ export const LIGHT_SCHEDULE_GRID_HOURS = 0.25 as const;
  * expressed in metres.
  */
 export const ROOM_DEFAULT_HEIGHT_M = 3 as const;
+
+/**
+ * Canonical constant describing the specific heat capacity of dry air at
+ * constant pressure, expressed in joules per kilogram and kelvin.
+ */
+export const CP_AIR_J_PER_KG_K = 1_005 as const;
+
+/**
+ * Canonical constant describing the density of dry air at standard conditions,
+ * expressed in kilograms per cubic metre.
+ */
+export const AIR_DENSITY_KG_PER_M3 = 1.2041 as const;
 
 /**
  * Canonical constant describing the number of in-game hours represented by a
@@ -151,6 +173,8 @@ export const SIM_CONSTANTS: Readonly<SimulationConstants> = Object.freeze({
   AREA_QUANTUM_M2,
   LIGHT_SCHEDULE_GRID_HOURS,
   ROOM_DEFAULT_HEIGHT_M,
+  CP_AIR_J_PER_KG_K,
+  AIR_DENSITY_KG_PER_M3,
   HOURS_PER_TICK,
   HOURS_PER_DAY,
   DAYS_PER_MONTH,

--- a/packages/engine/src/backend/src/domain/entities.ts
+++ b/packages/engine/src/backend/src/domain/entities.ts
@@ -119,6 +119,12 @@ export interface DeviceInstance extends DomainEntity, SluggedEntity {
   readonly condition01: number;
   /** Electrical power draw expressed in watts. */
   readonly powerDraw_W: number;
+  /** Duty cycle applied during the current tick on the canonical [0,1] scale. */
+  readonly dutyCycle01: number;
+  /** Useful-work efficiency on the canonical [0,1] scale per SEC §6.1. */
+  readonly efficiency01: number;
+  /** Maximum sensible heat removal capacity expressed in watts. */
+  readonly sensibleHeatRemovalCapacity_W: number;
 }
 
 /**
@@ -182,6 +188,16 @@ export interface Zone extends DomainEntity, SluggedEntity, SpatialEntity {
   readonly plants: readonly Plant[];
   /** Device instances mounted at the zone scope. */
   readonly devices: readonly ZoneDeviceInstance[];
+  /** Environmental state describing the zone's well-mixed air mass. */
+  readonly environment: ZoneEnvironment;
+}
+
+/**
+ * Canonical representation of the environmental state maintained for a zone.
+ */
+export interface ZoneEnvironment {
+  /** Dry-bulb air temperature expressed in degrees Celsius. */
+  readonly airTemperatureC: number;
 }
 
 /**

--- a/packages/engine/src/backend/src/domain/schemas.ts
+++ b/packages/engine/src/backend/src/domain/schemas.ts
@@ -12,7 +12,8 @@ import {
   type Structure,
   type StructureDeviceInstance,
   type Zone,
-  type ZoneDeviceInstance
+  type ZoneDeviceInstance,
+  type ZoneEnvironment
 } from './entities.js';
 
 const [STRUCTURE_SCOPE, ROOM_SCOPE, ZONE_SCOPE] = DEVICE_PLACEMENT_SCOPES;
@@ -71,7 +72,13 @@ const baseDeviceSchema = domainEntitySchema
     blueprintId: uuidSchema,
     quality01: finiteNumber.min(0, 'quality01 must be >= 0.').max(1, 'quality01 must be <= 1.'),
     condition01: finiteNumber.min(0, 'condition01 must be >= 0.').max(1, 'condition01 must be <= 1.'),
-    powerDraw_W: finiteNumber.min(0, 'powerDraw_W cannot be negative.')
+    powerDraw_W: finiteNumber.min(0, 'powerDraw_W cannot be negative.'),
+    dutyCycle01: finiteNumber.min(0, 'dutyCycle01 must be >= 0.').max(1, 'dutyCycle01 must be <= 1.'),
+    efficiency01: finiteNumber.min(0, 'efficiency01 must be >= 0.').max(1, 'efficiency01 must be <= 1.'),
+    sensibleHeatRemovalCapacity_W: finiteNumber.min(
+      0,
+      'sensibleHeatRemovalCapacity_W cannot be negative.'
+    )
   });
 
 const structureDeviceSchema: z.ZodType<StructureDeviceInstance> = baseDeviceSchema.extend({
@@ -98,6 +105,10 @@ const plantSchema: z.ZodType<Plant> = domainEntitySchema
     substrateId: uuidSchema
   });
 
+const zoneEnvironmentSchema: z.ZodType<ZoneEnvironment> = z.object({
+  airTemperatureC: finiteNumber
+});
+
 export const zoneSchema: z.ZodType<Zone> = domainEntitySchema
   .merge(sluggedEntitySchema)
   .merge(spatialEntitySchema)
@@ -109,7 +120,8 @@ export const zoneSchema: z.ZodType<Zone> = domainEntitySchema
     lightSchedule: lightScheduleSchema,
     photoperiodPhase: z.enum(['vegetative', 'flowering']),
     plants: z.array(plantSchema).readonly(),
-    devices: z.array(zoneDeviceSchema).readonly()
+    devices: z.array(zoneDeviceSchema).readonly(),
+    environment: zoneEnvironmentSchema
   });
 
 export const roomSchema: z.ZodType<Room> = domainEntitySchema

--- a/packages/engine/src/backend/src/domain/validation.ts
+++ b/packages/engine/src/backend/src/domain/validation.ts
@@ -192,6 +192,27 @@ function validateDevice(
       message: 'device power draw must be non-negative'
     });
   }
+
+  if (!isWithinUnitInterval(device.dutyCycle01)) {
+    issues.push({
+      path: `${path}.dutyCycle01`,
+      message: 'device dutyCycle01 must lie within [0,1]'
+    });
+  }
+
+  if (!isWithinUnitInterval(device.efficiency01)) {
+    issues.push({
+      path: `${path}.efficiency01`,
+      message: 'device efficiency01 must lie within [0,1]'
+    });
+  }
+
+  if (device.sensibleHeatRemovalCapacity_W < 0) {
+    issues.push({
+      path: `${path}.sensibleHeatRemovalCapacity_W`,
+      message: 'device sensible heat removal capacity must be non-negative'
+    });
+  }
 }
 
 /**
@@ -313,6 +334,13 @@ function validateRoom(
       issues.push({
         path: `${zonePath}.photoperiodPhase`,
         message: 'photoperiod phase must be either "vegetative" or "flowering"'
+      });
+    }
+
+    if (!Number.isFinite(zone.environment.airTemperatureC)) {
+      issues.push({
+        path: `${zonePath}.environment.airTemperatureC`,
+        message: 'zone air temperature must be a finite number'
       });
     }
 

--- a/packages/engine/src/backend/src/engine/pipeline/applyDeviceEffects.ts
+++ b/packages/engine/src/backend/src/engine/pipeline/applyDeviceEffects.ts
@@ -1,10 +1,87 @@
-import type { SimulationWorld } from '../../domain/world.js';
+import { HOURS_PER_TICK } from '../../constants/simConstants.js';
+import type { SimulationWorld, Zone } from '../../domain/world.js';
 import type { EngineRunContext } from '../Engine.js';
+import { applyDeviceHeat } from '../thermo/heat.js';
+
+export interface DeviceEffectsRuntime {
+  readonly zoneTemperatureDeltaC: Map<Zone['id'], number>;
+}
+
+const DEVICE_EFFECTS_CONTEXT_KEY = '__wb_deviceEffects' as const;
+
+type Mutable<T> = { -readonly [K in keyof T]: T[K] };
+
+type DeviceEffectsCarrier = Mutable<EngineRunContext> & {
+  [DEVICE_EFFECTS_CONTEXT_KEY]?: DeviceEffectsRuntime;
+};
+
+function setDeviceEffectsRuntime(
+  ctx: EngineRunContext,
+  runtime: DeviceEffectsRuntime
+): DeviceEffectsRuntime {
+  (ctx as DeviceEffectsCarrier)[DEVICE_EFFECTS_CONTEXT_KEY] = runtime;
+  return runtime;
+}
+
+export function ensureDeviceEffectsRuntime(ctx: EngineRunContext): DeviceEffectsRuntime {
+  return setDeviceEffectsRuntime(ctx, {
+    zoneTemperatureDeltaC: new Map()
+  });
+}
+
+export function getDeviceEffectsRuntime(
+  ctx: EngineRunContext
+): DeviceEffectsRuntime | undefined {
+  return (ctx as DeviceEffectsCarrier)[DEVICE_EFFECTS_CONTEXT_KEY];
+}
+
+export function clearDeviceEffectsRuntime(ctx: EngineRunContext): void {
+  delete (ctx as DeviceEffectsCarrier)[DEVICE_EFFECTS_CONTEXT_KEY];
+}
+
+function isPositiveFinite(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+export function resolveTickHours(ctx: EngineRunContext): number {
+  const candidate =
+    (ctx as { tickDurationHours?: unknown }).tickDurationHours ??
+    (ctx as { tickHours?: unknown }).tickHours;
+
+  if (isPositiveFinite(candidate)) {
+    return candidate;
+  }
+
+  return HOURS_PER_TICK;
+}
+
+function accumulateTemperatureDelta(
+  runtime: DeviceEffectsRuntime,
+  zoneId: Zone['id'],
+  deltaC: number
+): void {
+  if (!Number.isFinite(deltaC) || deltaC === 0) {
+    return;
+  }
+
+  const current = runtime.zoneTemperatureDeltaC.get(zoneId) ?? 0;
+  runtime.zoneTemperatureDeltaC.set(zoneId, current + deltaC);
+}
 
 export function applyDeviceEffects(world: SimulationWorld, ctx: EngineRunContext): SimulationWorld {
-  void ctx;
+  const tickHours = resolveTickHours(ctx);
+  const runtime = ensureDeviceEffectsRuntime(ctx);
 
-  const nextWorld = { ...world } satisfies SimulationWorld;
+  for (const structure of world.company.structures) {
+    for (const room of structure.rooms) {
+      for (const zone of room.zones) {
+        for (const device of zone.devices) {
+          const deltaC = applyDeviceHeat(zone, device, tickHours);
+          accumulateTemperatureDelta(runtime, zone.id, deltaC);
+        }
+      }
+    }
+  }
 
-  return nextWorld;
+  return world;
 }

--- a/packages/engine/src/backend/src/engine/pipeline/updateEnvironment.ts
+++ b/packages/engine/src/backend/src/engine/pipeline/updateEnvironment.ts
@@ -1,10 +1,149 @@
-import type { SimulationWorld } from '../../domain/world.js';
+import { AIR_DENSITY_KG_PER_M3, CP_AIR_J_PER_KG_K } from '../../constants/simConstants.js';
+import type { SimulationWorld, Zone } from '../../domain/world.js';
 import type { EngineRunContext } from '../Engine.js';
+import {
+  clearDeviceEffectsRuntime,
+  getDeviceEffectsRuntime,
+  resolveTickHours
+} from './applyDeviceEffects.js';
+
+const SECONDS_PER_HOUR = 3_600;
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  if (value <= 0) {
+    return 0;
+  }
+
+  if (value >= 1) {
+    return 1;
+  }
+
+  return value;
+}
+
+function resolveAirMassKg(zone: Zone): number {
+  const volume_m3 = zone.floorArea_m2 * zone.height_m;
+
+  if (!Number.isFinite(volume_m3) || volume_m3 <= 0) {
+    return 0;
+  }
+
+  return volume_m3 * AIR_DENSITY_KG_PER_M3;
+}
+
+function computeRemovalDeltaC(zone: Zone, tickHours: number): number {
+  const airMassKg = resolveAirMassKg(zone);
+
+  if (airMassKg === 0) {
+    return 0;
+  }
+
+  const tickSeconds = tickHours * SECONDS_PER_HOUR;
+  const removalPower_W = zone.devices.reduce((total, device) => {
+    const duty = clamp01(device.dutyCycle01);
+    const capacity = Math.max(0, device.sensibleHeatRemovalCapacity_W);
+
+    if (capacity === 0 || duty === 0) {
+      return total;
+    }
+
+    return total + capacity * duty;
+  }, 0);
+
+  if (removalPower_W === 0) {
+    return 0;
+  }
+
+  const joules = removalPower_W * tickSeconds;
+
+  return joules / (airMassKg * CP_AIR_J_PER_KG_K);
+}
+
+function updateZoneTemperature(zone: Zone, netDeltaC: number): Zone {
+  if (Math.abs(netDeltaC) < Number.EPSILON) {
+    return zone;
+  }
+
+  return {
+    ...zone,
+    environment: {
+      ...zone.environment,
+      airTemperatureC: zone.environment.airTemperatureC + netDeltaC
+    }
+  } satisfies Zone;
+}
 
 export function updateEnvironment(world: SimulationWorld, ctx: EngineRunContext): SimulationWorld {
-  void ctx;
+  const runtime = getDeviceEffectsRuntime(ctx);
 
-  const nextWorld = { ...world } satisfies SimulationWorld;
+  if (!runtime) {
+    return world;
+  }
 
-  return nextWorld;
+  const tickHours = resolveTickHours(ctx);
+  const zoneHeatMap = runtime.zoneTemperatureDeltaC;
+
+  let structuresChanged = false;
+
+  const nextStructures = world.company.structures.map((structure) => {
+    let roomsChanged = false;
+
+    const nextRooms = structure.rooms.map((room) => {
+      let zonesChanged = false;
+
+      const nextZones = room.zones.map((zone) => {
+        const additionDeltaC = zoneHeatMap.get(zone.id) ?? 0;
+        const removalDeltaC = computeRemovalDeltaC(zone, tickHours);
+        const netDeltaC = additionDeltaC - removalDeltaC;
+
+        const nextZone = updateZoneTemperature(zone, netDeltaC);
+
+        if (nextZone !== zone) {
+          zonesChanged = true;
+        }
+
+        zoneHeatMap.delete(zone.id);
+
+        return nextZone;
+      });
+
+      if (zonesChanged) {
+        roomsChanged = true;
+        return {
+          ...room,
+          zones: nextZones
+        };
+      }
+
+      return room;
+    });
+
+    if (roomsChanged) {
+      structuresChanged = true;
+      return {
+        ...structure,
+        rooms: nextRooms
+      };
+    }
+
+    return structure;
+  });
+
+  clearDeviceEffectsRuntime(ctx);
+
+  if (!structuresChanged) {
+    return world;
+  }
+
+  return {
+    ...world,
+    company: {
+      ...world.company,
+      structures: nextStructures
+    }
+  } satisfies SimulationWorld;
 }

--- a/packages/engine/src/backend/src/engine/testHarness.ts
+++ b/packages/engine/src/backend/src/engine/testHarness.ts
@@ -61,6 +61,9 @@ const DEMO_WORLD: SimulationWorld = {
                   startHour: 0
                 },
                 photoperiodPhase: 'vegetative',
+                environment: {
+                  airTemperatureC: 22
+                },
                 plants: [],
                 devices: []
               }

--- a/packages/engine/src/backend/src/engine/thermo/heat.ts
+++ b/packages/engine/src/backend/src/engine/thermo/heat.ts
@@ -1,0 +1,88 @@
+import { AIR_DENSITY_KG_PER_M3, CP_AIR_J_PER_KG_K, HOURS_PER_TICK } from '../../constants/simConstants.js';
+import type { Zone, ZoneDeviceInstance } from '../../domain/world.js';
+
+const SECONDS_PER_HOUR = 3_600;
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  if (value <= 0) {
+    return 0;
+  }
+
+  if (value >= 1) {
+    return 1;
+  }
+
+  return value;
+}
+
+function resolveTickHours(tickHours: number | undefined): number {
+  if (typeof tickHours !== 'number') {
+    return HOURS_PER_TICK;
+  }
+
+  if (!Number.isFinite(tickHours) || tickHours <= 0) {
+    return HOURS_PER_TICK;
+  }
+
+  return tickHours;
+}
+
+function resolveAirMassKg(zone: Pick<Zone, 'floorArea_m2' | 'height_m'>): number {
+  const volume_m3 = zone.floorArea_m2 * zone.height_m;
+
+  if (!Number.isFinite(volume_m3) || volume_m3 <= 0) {
+    return 0;
+  }
+
+  return volume_m3 * AIR_DENSITY_KG_PER_M3;
+}
+
+/**
+ * Converts waste electrical power produced by a device into a sensible heat
+ * delta for the hosting zone.
+ *
+ * @param zone - Zone receiving the sensible heat load.
+ * @param device - Device producing the waste heat.
+ * @param tickHours - Duration of the simulation tick in hours.
+ * @returns Temperature delta in degrees Celsius for the tick duration.
+ */
+export function applyDeviceHeat(
+  zone: Pick<Zone, 'floorArea_m2' | 'height_m'>,
+  device: Pick<ZoneDeviceInstance, 'powerDraw_W' | 'dutyCycle01' | 'efficiency01'>,
+  tickHours: number = HOURS_PER_TICK
+): number {
+  const efficiency = device.efficiency01;
+
+  if (!Number.isFinite(efficiency) || efficiency < 0 || efficiency > 1) {
+    throw new RangeError('Device efficiency must lie within [0,1].');
+  }
+
+  const duty = clamp01(device.dutyCycle01);
+  const powerDraw_W = Math.max(0, device.powerDraw_W);
+  const resolvedTickHours = resolveTickHours(tickHours);
+
+  if (duty === 0 || powerDraw_W === 0 || resolvedTickHours === 0) {
+    return 0;
+  }
+
+  const airMassKg = resolveAirMassKg(zone);
+
+  if (airMassKg === 0) {
+    return 0;
+  }
+
+  const wastePower_W = powerDraw_W * (1 - efficiency) * duty;
+
+  if (wastePower_W <= 0) {
+    return 0;
+  }
+
+  const joules = wastePower_W * resolvedTickHours * SECONDS_PER_HOUR;
+  const deltaK = joules / (airMassKg * CP_AIR_J_PER_KG_K);
+
+  return deltaK;
+}

--- a/packages/engine/tests/integration/domain/worldValidation.integration.test.ts
+++ b/packages/engine/tests/integration/domain/worldValidation.integration.test.ts
@@ -92,7 +92,10 @@ function buildInvalidCompany(): Company {
             placementScope: invalidStructureDeviceScope,
             quality01: 1.2,
             condition01: -0.2,
-            powerDraw_W: -150
+            powerDraw_W: -150,
+            dutyCycle01: 1.1,
+            efficiency01: -0.1,
+            sensibleHeatRemovalCapacity_W: -10
           }
         ],
         rooms: [
@@ -117,6 +120,9 @@ function buildInvalidCompany(): Company {
                 substrateId: uuid(''),
                 lightSchedule: { onHours: 20, offHours: 5, startHour: 24 },
                 photoperiodPhase: invalidPhotoperiodPhase,
+                environment: {
+                  airTemperatureC: Number.NaN
+                },
                 devices: [
                   {
                     id: uuid('10000000-0000-0000-0000-000000000023'),
@@ -126,7 +132,10 @@ function buildInvalidCompany(): Company {
                     placementScope: invalidZoneDeviceScope,
                     quality01: 2,
                     condition01: -1,
-                    powerDraw_W: -50
+                    powerDraw_W: -50,
+                    dutyCycle01: -0.5,
+                    efficiency01: 1.5,
+                    sensibleHeatRemovalCapacity_W: -5
                   }
                 ],
                 plants: [
@@ -180,7 +189,10 @@ function buildInvalidCompany(): Company {
                 lightSchedule: { onHours: 12, offHours: 12, startHour: 0 },
                 photoperiodPhase: 'vegetative',
                 devices: [],
-                plants: []
+                plants: [],
+                environment: {
+                  airTemperatureC: 21
+                }
               }
             ]
           },

--- a/packages/engine/tests/integration/pipeline/deviceThermals.integration.test.ts
+++ b/packages/engine/tests/integration/pipeline/deviceThermals.integration.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AIR_DENSITY_KG_PER_M3,
+  CP_AIR_J_PER_KG_K,
+  HOURS_PER_TICK
+} from '@/backend/src/constants/simConstants.js';
+import type { EngineRunContext } from '@/backend/src/engine/Engine.js';
+import { runTick } from '@/backend/src/engine/Engine.js';
+import { createDemoWorld } from '@/backend/src/engine/testHarness.js';
+import type { Uuid, ZoneDeviceInstance } from '@/backend/src/domain/world.js';
+
+const SECONDS_PER_HOUR = 3_600;
+
+function uuid(value: string): Uuid {
+  return value as Uuid;
+}
+
+describe('Tick pipeline — device thermal effects', () => {
+  it('integrates heat additions and HVAC removals across the first two stages', () => {
+    const world = createDemoWorld();
+    const structure = world.company.structures[0];
+    const room = structure.rooms[0];
+    const zone = room.zones[0];
+    const initialTemperatureC = zone.environment.airTemperatureC;
+
+    const lightingDevice: ZoneDeviceInstance = {
+      id: uuid('20000000-0000-0000-0000-000000000001'),
+      slug: 'veg-light',
+      name: 'Veg Light',
+      blueprintId: uuid('20000000-0000-0000-0000-000000000002'),
+      placementScope: 'zone',
+      quality01: 0.95,
+      condition01: 0.94,
+      powerDraw_W: 600,
+      dutyCycle01: 1,
+      efficiency01: 0.2,
+      sensibleHeatRemovalCapacity_W: 0
+    } satisfies ZoneDeviceInstance;
+
+    const hvacDevice: ZoneDeviceInstance = {
+      id: uuid('20000000-0000-0000-0000-000000000003'),
+      slug: 'zone-hvac',
+      name: 'Zone HVAC',
+      blueprintId: uuid('20000000-0000-0000-0000-000000000004'),
+      placementScope: 'zone',
+      quality01: 0.9,
+      condition01: 0.9,
+      powerDraw_W: 800,
+      dutyCycle01: 1,
+      efficiency01: 0.6,
+      sensibleHeatRemovalCapacity_W: 500
+    } satisfies ZoneDeviceInstance;
+
+    zone.devices = [lightingDevice, hvacDevice];
+
+    const ctx: EngineRunContext = {
+      tickDurationHours: 0.5
+    } satisfies EngineRunContext;
+
+    const { world: nextWorld } = runTick(world, ctx);
+
+    const nextZone = nextWorld.company.structures[0].rooms[0].zones[0];
+    const tickHours = (ctx as { tickDurationHours: number }).tickDurationHours ?? HOURS_PER_TICK;
+    const tickSeconds = tickHours * SECONDS_PER_HOUR;
+    const airMassKg = zone.floorArea_m2 * zone.height_m * AIR_DENSITY_KG_PER_M3;
+
+    const wasteLight_W = lightingDevice.powerDraw_W * (1 - lightingDevice.efficiency01);
+    const wasteHvac_W = hvacDevice.powerDraw_W * (1 - hvacDevice.efficiency01);
+    const additionDeltaC =
+      ((wasteLight_W + wasteHvac_W) * tickSeconds) / (airMassKg * CP_AIR_J_PER_KG_K);
+
+    const removalDeltaC =
+      (hvacDevice.sensibleHeatRemovalCapacity_W * tickSeconds) /
+      (airMassKg * CP_AIR_J_PER_KG_K);
+
+    const expectedTemperatureC = initialTemperatureC + additionDeltaC - removalDeltaC;
+
+    expect(nextZone.environment.airTemperatureC).toBeCloseTo(expectedTemperatureC, 10);
+    expect((ctx as Record<string, unknown>).__wb_deviceEffects).toBeUndefined();
+  });
+});

--- a/packages/engine/tests/unit/domain/schemas.test.ts
+++ b/packages/engine/tests/unit/domain/schemas.test.ts
@@ -64,6 +64,9 @@ const BASE_WORLD = {
                 startHour: 0
               },
               photoperiodPhase: 'vegetative',
+              environment: {
+                airTemperatureC: 22
+              },
               plants: [
                 {
                   id: '00000000-0000-0000-0000-000000000050',
@@ -87,7 +90,10 @@ const BASE_WORLD = {
                   placementScope: 'zone',
                   quality01: 0.98,
                   condition01: 0.97,
-                  powerDraw_W: 450
+                  powerDraw_W: 450,
+                  dutyCycle01: 1,
+                  efficiency01: 0.9,
+                  sensibleHeatRemovalCapacity_W: 0
                 }
               ]
             }
@@ -101,7 +107,10 @@ const BASE_WORLD = {
               placementScope: 'room',
               quality01: 0.92,
               condition01: 0.91,
-              powerDraw_W: 320
+              powerDraw_W: 320,
+              dutyCycle01: 1,
+              efficiency01: 0.85,
+              sensibleHeatRemovalCapacity_W: 0
             }
           ]
         }
@@ -115,7 +124,10 @@ const BASE_WORLD = {
           placementScope: 'structure',
           quality01: 0.93,
           condition01: 0.9,
-          powerDraw_W: 500
+          powerDraw_W: 500,
+          dutyCycle01: 1,
+          efficiency01: 0.88,
+          sensibleHeatRemovalCapacity_W: 0
         }
       ]
     }

--- a/packages/engine/tests/unit/domain/validateCompanyWorld.test.ts
+++ b/packages/engine/tests/unit/domain/validateCompanyWorld.test.ts
@@ -306,7 +306,10 @@ function createCompany(): Company {
     placementScope: 'zone',
     quality01: 0.8,
     condition01: 0.75,
-    powerDraw_W: 480
+    powerDraw_W: 480,
+    dutyCycle01: 1,
+    efficiency01: 0.85,
+    sensibleHeatRemovalCapacity_W: 0
   } satisfies ZoneDeviceInstance;
 
   const zone: Zone = {
@@ -322,7 +325,10 @@ function createCompany(): Company {
     lightSchedule: { onHours: 18, offHours: 6, startHour: 0 },
     photoperiodPhase: 'vegetative',
     plants: [plant],
-    devices: [zoneDevice]
+    devices: [zoneDevice],
+    environment: {
+      airTemperatureC: 22
+    }
   } satisfies Zone;
 
   const roomDevice: RoomDeviceInstance = {
@@ -333,7 +339,10 @@ function createCompany(): Company {
     placementScope: 'room',
     quality01: 0.85,
     condition01: 0.9,
-    powerDraw_W: 250
+    powerDraw_W: 250,
+    dutyCycle01: 1,
+    efficiency01: 0.8,
+    sensibleHeatRemovalCapacity_W: 0
   } satisfies RoomDeviceInstance;
 
   const room: Room = {
@@ -355,7 +364,10 @@ function createCompany(): Company {
     placementScope: 'structure',
     quality01: 0.95,
     condition01: 0.88,
-    powerDraw_W: 3500
+    powerDraw_W: 3_500,
+    dutyCycle01: 1,
+    efficiency01: 0.9,
+    sensibleHeatRemovalCapacity_W: 0
   } satisfies StructureDeviceInstance;
 
   const structure: Structure = {

--- a/packages/engine/tests/unit/simConstants.test.ts
+++ b/packages/engine/tests/unit/simConstants.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  AIR_DENSITY_KG_PER_M3,
   AREA_QUANTUM_M2,
+  CP_AIR_J_PER_KG_K,
   DAYS_PER_MONTH,
   HOURS_PER_DAY,
   HOURS_PER_MONTH,
@@ -18,6 +20,8 @@ describe('simConstants', () => {
     expect(AREA_QUANTUM_M2).toBe(LIGHT_SCHEDULE_GRID_HOURS);
     expect(LIGHT_SCHEDULE_GRID_HOURS).toBeCloseTo(1 / 4);
     expect(ROOM_DEFAULT_HEIGHT_M).toBe(3);
+    expect(CP_AIR_J_PER_KG_K).toBe(1_005);
+    expect(AIR_DENSITY_KG_PER_M3).toBeCloseTo(1.2041);
     expect(HOURS_PER_TICK).toBe(1);
     expect(HOURS_PER_DAY).toBe(24);
     expect(DAYS_PER_MONTH).toBe(30);
@@ -33,6 +37,8 @@ describe('simConstants', () => {
     expect(SIM_CONSTANTS.LIGHT_SCHEDULE_GRID_HOURS).toBe(
       LIGHT_SCHEDULE_GRID_HOURS
     );
+    expect(SIM_CONSTANTS.CP_AIR_J_PER_KG_K).toBe(CP_AIR_J_PER_KG_K);
+    expect(SIM_CONSTANTS.AIR_DENSITY_KG_PER_M3).toBe(AIR_DENSITY_KG_PER_M3);
   });
 
 });

--- a/packages/engine/tests/unit/thermo/heat.spec.ts
+++ b/packages/engine/tests/unit/thermo/heat.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AIR_DENSITY_KG_PER_M3,
+  CP_AIR_J_PER_KG_K,
+  HOURS_PER_TICK
+} from '@/backend/src/constants/simConstants.js';
+import { applyDeviceHeat } from '@/backend/src/engine/thermo/heat.js';
+
+const BASE_ZONE = {
+  floorArea_m2: 50,
+  height_m: 3
+} as const;
+
+const BASE_DEVICE = {
+  powerDraw_W: 600,
+  dutyCycle01: 0.5,
+  efficiency01: 0.9
+} as const;
+
+describe('applyDeviceHeat', () => {
+  it('returns a positive temperature delta for waste heat', () => {
+    const deltaC = applyDeviceHeat(BASE_ZONE, BASE_DEVICE);
+
+    const airMassKg = BASE_ZONE.floorArea_m2 * BASE_ZONE.height_m * AIR_DENSITY_KG_PER_M3;
+    const wastePower_W =
+      BASE_DEVICE.powerDraw_W * (1 - BASE_DEVICE.efficiency01) * BASE_DEVICE.dutyCycle01;
+    const expectedDelta =
+      (wastePower_W * HOURS_PER_TICK * 3_600) / (airMassKg * CP_AIR_J_PER_KG_K);
+
+    expect(deltaC).toBeGreaterThan(0);
+    expect(deltaC).toBeCloseTo(expectedDelta, 12);
+  });
+
+  it('returns zero when the duty cycle is zero', () => {
+    const deltaC = applyDeviceHeat(BASE_ZONE, {
+      ...BASE_DEVICE,
+      dutyCycle01: 0
+    });
+
+    expect(deltaC).toBe(0);
+  });
+
+  it('returns zero when efficiency equals one', () => {
+    const deltaC = applyDeviceHeat(BASE_ZONE, {
+      ...BASE_DEVICE,
+      efficiency01: 1
+    });
+
+    expect(deltaC).toBe(0);
+  });
+
+  it('throws an error when the efficiency lies outside the [0,1] range', () => {
+    expect(() =>
+      applyDeviceHeat(BASE_ZONE, {
+        ...BASE_DEVICE,
+        efficiency01: 1.2
+      })
+    ).toThrowError(RangeError);
+  });
+});


### PR DESCRIPTION
## Summary
- extend the canonical simulation constants and documentation with dry-air thermodynamic baselines
- add a thermo module plus duty/efficiency metadata so device heat is accumulated and HVAC removal is applied in the pipeline
- update zone validation/test fixtures and add unit/integration coverage for the new heat behaviour

## Testing
- pnpm --filter @wb/engine test

------
https://chatgpt.com/codex/tasks/task_e_68de54a64b5883258ce47ed0beb38993