### PR TITLE
feat(engine): enforce device blueprint capacities and diagnostics

### DIFF
--- a/data/blueprints/devices/climate_unit_01.json
+++ b/data/blueprints/devices/climate_unit_01.json
@@ -2,6 +2,11 @@
   "id": "7d3d3f1a-8c6f-4e9c-926d-5a2a4a3b6f1b",
   "kind": "ClimateUnit",
   "name": "CoolAir Split 3000",
+  "placementScope": "zone",
+  "power_W": 1200,
+  "efficiency01": 0.65,
+  "coverage_m2": 25,
+  "airflow_m3_per_h": 350,
   "quality": 0.9,
   "complexity": 0.4,
   "lifetime_h": 35040,
@@ -50,8 +55,5 @@
   },
   "allowedRoomPurposes": [
     "growroom"
-  ],
-  "placementScope": [
-    "zone"
   ]
 }

--- a/data/blueprints/devices/co2injector-01.json
+++ b/data/blueprints/devices/co2injector-01.json
@@ -2,6 +2,10 @@
   "id": "c701efa6-1e90-4f28-8934-ea9c584596e4",
   "kind": "CO2Injector",
   "name": "CO2 Pulse",
+  "placementScope": "zone",
+  "power_W": 50,
+  "efficiency01": 0.9,
+  "coverage_m2": 10,
   "quality": 0.85,
   "complexity": 0.15,
   "lifetime_h": 8760,
@@ -44,8 +48,5 @@
   },
   "allowedRoomPurposes": [
     "growroom"
-  ],
-  "placementScope": [
-    "zone"
   ]
 }

--- a/data/blueprints/devices/dehumidifier-01.json
+++ b/data/blueprints/devices/dehumidifier-01.json
@@ -2,6 +2,10 @@
   "id": "7a639d3d-4750-440a-a200-f90d11dc3c62",
   "kind": "Dehumidifier",
   "name": "DryBox 200",
+  "placementScope": "zone",
+  "power_W": 300,
+  "efficiency01": 0.6,
+  "coverage_m2": 6.67,
   "quality": 0.8,
   "complexity": 0.25,
   "lifetime_h": 26280,
@@ -38,8 +42,5 @@
   },
   "allowedRoomPurposes": [
     "growroom"
-  ],
-  "placementScope": [
-    "zone"
   ]
 }

--- a/data/blueprints/devices/exhaust_fan_01.json
+++ b/data/blueprints/devices/exhaust_fan_01.json
@@ -2,6 +2,11 @@
   "id": "f5d5c5a0-1b2c-4d3e-8f9a-0b1c2d3e4f5a",
   "kind": "Ventilation",
   "name": "Exhaust Fan 4-inch",
+  "placementScope": "zone",
+  "power_W": 50,
+  "efficiency01": 0.7,
+  "coverage_m2": 5,
+  "airflow_m3_per_h": 170,
   "quality": 0.7,
   "complexity": 0.1,
   "lifetime_h": 17520,
@@ -40,8 +45,5 @@
   },
   "allowedRoomPurposes": [
     "growroom"
-  ],
-  "placementScope": [
-    "zone"
   ]
 }

--- a/data/blueprints/devices/humidity_control_unit_01.json
+++ b/data/blueprints/devices/humidity_control_unit_01.json
@@ -2,6 +2,10 @@
   "id": "3d762260-88a5-4104-b03c-9860bbac34b6",
   "kind": "HumidityControlUnit",
   "name": "Humidity Control Unit L1",
+  "placementScope": "zone",
+  "power_W": 350,
+  "efficiency01": 0.6,
+  "coverage_m2": 8.33,
   "quality": 0.8,
   "complexity": 0.3,
   "lifetime_h": 8760,
@@ -41,8 +45,5 @@
   },
   "allowedRoomPurposes": [
     "growroom"
-  ],
-  "placementScope": [
-    "zone"
   ]
 }

--- a/data/blueprints/devices/veg_light_01.json
+++ b/data/blueprints/devices/veg_light_01.json
@@ -2,6 +2,10 @@
   "id": "3b5f6ad7-672e-47cd-9a24-f0cc45c4101e",
   "kind": "Lamp",
   "name": "LED VegLight 600",
+  "placementScope": "zone",
+  "power_W": 600,
+  "efficiency01": 0.7,
+  "coverage_m2": 1.2,
   "quality": 0.95,
   "complexity": 0.2,
   "lifetime_h": 52560,
@@ -46,8 +50,5 @@
   },
   "allowedRoomPurposes": [
     "growroom"
-  ],
-  "placementScope": [
-    "zone"
   ]
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### #34 WB-027 device capacity diagnostics & blueprint schema hardening
+- Introduced a Zod-backed device blueprint schema enforcing `power_W`, `efficiency01`, and at least one of `coverage_m2`/`airflow_m3_per_h`, exporting the validator for downstream loaders and adding unit coverage (including live JSON fixtures).
+- Normalised device instances with `coverage_m2`/`airflow_m3_per_h` fields, updated validation, demo fixtures, and pipeline logic to aggregate coverage & airflow totals, clamp effectiveness by coverage ratio, and emit `zone.capacity.coverage.warn` / `zone.capacity.airflow.warn` diagnostics when undersized.
+- Added integration tests verifying the new runtime totals and warnings, refreshed SEC/DD/TDD guidance, and migrated device blueprints to the canonical placement scope + capacity fields.
+
 ### #33 WB-026 zone air mass bootstrap derivation
 - Extended the zone domain contract and Zod schema with a documented `airMass_kg`
   field that downstream thermodynamics consume directly.

--- a/docs/DD.md
+++ b/docs/DD.md
@@ -195,6 +195,9 @@ Fixed order per tick:
 }
 ```
 
+- **Coverage vs. demand:** Phase 1 sums `coverage_m2` across zone devices and scales useful work by `min(1, coverage/zoneArea)`. Emit `zone.capacity.coverage.warn` when the ratio < 1.
+- **Airflow audit:** Airflow totals yield **ACH**; raise `zone.capacity.airflow.warn` for ACH < 1 and expose totals for downstream models.
+
 ---
 
 ## 9) Engine vs Façade vs Transport (SEC §11)

--- a/docs/SEC.md
+++ b/docs/SEC.md
@@ -339,8 +339,10 @@ Validation occurs at load time; on failure, the engine must not start. Validatio
 - **Air/Climate:** HVAC devices contribute sensible/latent heat removal/addition and airflow. Well-mixed bucket as baseline (**upgrade path:** alternative psychrometric models like Magnus/Penman–Monteith may be slotted under the same interface later).
     
 - **CO₂:** injection rate limited by device spec and safety; leaks/venting modeled at zone level.
-    
+
 - **Dehumidification:** water removal from air, respecting device capacity and psychrometric constraints.
+
+- **Coverage & Airflow diagnostics:** Phase 1 aggregates device `coverage_m2` per zone; if effective coverage < zone floor area the stage clamps device effectiveness to the coverage ratio and emits `zone.capacity.coverage.warn`. Airflow totals produce **ACH** (air changes/hour); if ACH < 1, emit `zone.capacity.airflow.warn` and surface totals for downstream modelling.
     
 
 ### 6.1 Device Heat & Power Coupling (SHALL)

--- a/docs/TDD.md
+++ b/docs/TDD.md
@@ -234,7 +234,7 @@ it('zone without cultivationMethod fails validation', async () => {
 ## 10) Power→Heat Coupling (SEC §6.1)
 
 - Non‑useful electrical power becomes **sensible heat** in hosting zone unless exported. Assert temperature delta is positive given power draw and insufficient removal capacity.
-    
+
 
 ```ts
 // packages/engine/tests/unit/thermo/heat.spec.ts
@@ -250,6 +250,28 @@ it('adds sensible heat proportional to power draw and duty', () => {
   });
 
   expect(delta).toBeGreaterThan(0);
+});
+```
+
+---
+
+## 10.1) Zone capacity diagnostics (SEC §6)
+
+- Phase 1 clamps device impact to `coverage_m2 / zoneArea` when < 1. Warn via `zone.capacity.coverage.warn` and surface totals.
+- Airflow totals compute ACH; emit `zone.capacity.airflow.warn` when ACH < 1.
+
+```
+// packages/engine/tests/integration/pipeline/zoneCapacity.integration.test.ts
+import { describe, expect, it } from 'vitest';
+
+describe('Phase 1 zone capacity diagnostics', () => {
+  it('clamps device effectiveness when coverage undershoots demand', () => {
+    // assert coverage ratio scales heat delta and warning triggers
+  });
+
+  it('warns when airflow-derived ACH drops below 1', () => {
+    // expect ACH warning + totals in runtime snapshot
+  });
 });
 ```
 

--- a/packages/engine/src/backend/src/domain/blueprints/deviceBlueprint.ts
+++ b/packages/engine/src/backend/src/domain/blueprints/deviceBlueprint.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod';
+
+import { DEVICE_PLACEMENT_SCOPES, ROOM_PURPOSES } from '../entities.js';
+
+const nonEmptyString = z.string().trim().min(1, 'String fields must not be empty.');
+const finiteNumber = z.number().finite('Value must be a finite number.');
+
+const placementScopeSchema = z.enum([...DEVICE_PLACEMENT_SCOPES]);
+const roomPurposeSchema = z.enum([...ROOM_PURPOSES]);
+
+/**
+ * Canonical device blueprint contract enforced for JSON payloads.
+ */
+const deviceBlueprintObjectSchema = z
+  .object({
+    id: z.string().uuid('Device blueprint id must be a UUID v4.'),
+    slug: nonEmptyString.optional(),
+    name: nonEmptyString,
+    kind: nonEmptyString.optional(),
+    placementScope: placementScopeSchema,
+    allowedRoomPurposes: z
+      .array(roomPurposeSchema, {
+        invalid_type_error: 'allowedRoomPurposes must be an array of room purposes.'
+      })
+      .nonempty('allowedRoomPurposes must contain at least one room purpose.'),
+    power_W: finiteNumber.min(0, 'power_W must be non-negative.'),
+    efficiency01: finiteNumber
+      .min(0, 'efficiency01 must be >= 0.')
+      .max(1, 'efficiency01 must be <= 1.'),
+    coverage_m2: finiteNumber.min(0, 'coverage_m2 must be non-negative.').optional(),
+    airflow_m3_per_h: finiteNumber
+      .min(0, 'airflow_m3_per_h must be non-negative.')
+      .optional()
+  })
+  .passthrough();
+
+export const deviceBlueprintSchema = deviceBlueprintObjectSchema.superRefine((blueprint, ctx) => {
+    if (!blueprint.coverage_m2 && !blueprint.airflow_m3_per_h) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['coverage_m2'],
+        message: 'Device blueprint must declare coverage_m2 or airflow_m3_per_h.'
+      });
+    }
+  });
+
+export type DeviceBlueprint = z.infer<typeof deviceBlueprintSchema>;
+
+export function parseDeviceBlueprint(input: unknown): DeviceBlueprint {
+  return deviceBlueprintSchema.parse(input);
+}
+
+export interface DeviceInstanceCapacity {
+  readonly powerDraw_W: number;
+  readonly efficiency01: number;
+  readonly coverage_m2: number;
+  readonly airflow_m3_per_h: number;
+}
+
+export function toDeviceInstanceCapacity(blueprint: DeviceBlueprint): DeviceInstanceCapacity {
+  return {
+    powerDraw_W: blueprint.power_W,
+    efficiency01: blueprint.efficiency01,
+    coverage_m2: blueprint.coverage_m2 ?? 0,
+    airflow_m3_per_h: blueprint.airflow_m3_per_h ?? 0
+  } satisfies DeviceInstanceCapacity;
+}

--- a/packages/engine/src/backend/src/domain/entities.ts
+++ b/packages/engine/src/backend/src/domain/entities.ts
@@ -123,6 +123,10 @@ export interface DeviceInstance extends DomainEntity, SluggedEntity {
   readonly dutyCycle01: number;
   /** Useful-work efficiency on the canonical [0,1] scale per SEC §6.1. */
   readonly efficiency01: number;
+  /** Effective floor coverage provided by the device expressed in square metres. */
+  readonly coverage_m2: number;
+  /** Volumetric airflow throughput expressed in cubic metres per hour. */
+  readonly airflow_m3_per_h: number;
   /** Maximum sensible heat removal capacity expressed in watts. */
   readonly sensibleHeatRemovalCapacity_W: number;
 }

--- a/packages/engine/src/backend/src/domain/schemas.ts
+++ b/packages/engine/src/backend/src/domain/schemas.ts
@@ -77,6 +77,10 @@ const baseDeviceSchema = domainEntitySchema
     powerDraw_W: finiteNumber.min(0, 'powerDraw_W cannot be negative.'),
     dutyCycle01: finiteNumber.min(0, 'dutyCycle01 must be >= 0.').max(1, 'dutyCycle01 must be <= 1.'),
     efficiency01: finiteNumber.min(0, 'efficiency01 must be >= 0.').max(1, 'efficiency01 must be <= 1.'),
+    coverage_m2: finiteNumber.min(0, 'coverage_m2 cannot be negative.').default(0),
+    airflow_m3_per_h: finiteNumber
+      .min(0, 'airflow_m3_per_h cannot be negative.')
+      .default(0),
     sensibleHeatRemovalCapacity_W: finiteNumber.min(
       0,
       'sensibleHeatRemovalCapacity_W cannot be negative.'

--- a/packages/engine/src/backend/src/domain/validation.ts
+++ b/packages/engine/src/backend/src/domain/validation.ts
@@ -213,6 +213,20 @@ function validateDevice(
       message: 'device sensible heat removal capacity must be non-negative'
     });
   }
+
+  if (device.coverage_m2 < 0) {
+    issues.push({
+      path: `${path}.coverage_m2`,
+      message: 'device coverage_m2 must be non-negative'
+    });
+  }
+
+  if (device.airflow_m3_per_h < 0) {
+    issues.push({
+      path: `${path}.airflow_m3_per_h`,
+      message: 'device airflow_m3_per_h must be non-negative'
+    });
+  }
 }
 
 /**

--- a/packages/engine/src/backend/src/domain/world.ts
+++ b/packages/engine/src/backend/src/domain/world.ts
@@ -1,3 +1,4 @@
 export * from './entities.js';
 export * from './schemas.js';
 export * from './validation.js';
+export * from './blueprints/deviceBlueprint.js';

--- a/packages/engine/src/backend/src/engine/Engine.ts
+++ b/packages/engine/src/backend/src/engine/Engine.ts
@@ -1,4 +1,4 @@
-import type { SimulationWorld } from '../domain/world.js';
+import type { SimulationWorld, Uuid } from '../domain/world.js';
 import { applyDeviceEffects } from './pipeline/applyDeviceEffects.js';
 import { updateEnvironment } from './pipeline/updateEnvironment.js';
 import { applyIrrigationAndNutrients } from './pipeline/applyIrrigationAndNutrients.js';
@@ -12,8 +12,21 @@ export interface EngineInstrumentation {
   readonly onStageComplete?: (stage: StepName, world: SimulationWorld) => void;
 }
 
+export interface EngineDiagnostic {
+  readonly scope: 'zone';
+  readonly code: string;
+  readonly zoneId: Uuid;
+  readonly message: string;
+  readonly metadata?: Record<string, unknown>;
+}
+
+export interface EngineDiagnosticsSink {
+  emit(diagnostic: EngineDiagnostic): void;
+}
+
 export interface EngineRunContext {
   readonly instrumentation?: EngineInstrumentation;
+  readonly diagnostics?: EngineDiagnosticsSink;
   readonly [key: string]: unknown;
 }
 

--- a/packages/engine/src/backend/src/engine/pipeline/applyDeviceEffects.ts
+++ b/packages/engine/src/backend/src/engine/pipeline/applyDeviceEffects.ts
@@ -1,10 +1,14 @@
-import { HOURS_PER_TICK } from '../../constants/simConstants.js';
+import { HOURS_PER_TICK, ROOM_DEFAULT_HEIGHT_M } from '../../constants/simConstants.js';
 import type { SimulationWorld, Zone } from '../../domain/world.js';
-import type { EngineRunContext } from '../Engine.js';
+import type { EngineDiagnostic, EngineRunContext } from '../Engine.js';
 import { applyDeviceHeat } from '../thermo/heat.js';
 
 export interface DeviceEffectsRuntime {
   readonly zoneTemperatureDeltaC: Map<Zone['id'], number>;
+  readonly zoneCoverageTotals_m2: Map<Zone['id'], number>;
+  readonly zoneAirflowTotals_m3_per_h: Map<Zone['id'], number>;
+  readonly zoneCoverageEffectiveness01: Map<Zone['id'], number>;
+  readonly zoneAirChangesPerHour: Map<Zone['id'], number>;
 }
 
 const DEVICE_EFFECTS_CONTEXT_KEY = '__wb_deviceEffects' as const;
@@ -25,7 +29,11 @@ function setDeviceEffectsRuntime(
 
 export function ensureDeviceEffectsRuntime(ctx: EngineRunContext): DeviceEffectsRuntime {
   return setDeviceEffectsRuntime(ctx, {
-    zoneTemperatureDeltaC: new Map()
+    zoneTemperatureDeltaC: new Map(),
+    zoneCoverageTotals_m2: new Map(),
+    zoneAirflowTotals_m3_per_h: new Map(),
+    zoneCoverageEffectiveness01: new Map(),
+    zoneAirChangesPerHour: new Map()
   });
 }
 
@@ -68,6 +76,120 @@ function accumulateTemperatureDelta(
   runtime.zoneTemperatureDeltaC.set(zoneId, current + deltaC);
 }
 
+const FLOAT_TOLERANCE = 1e-6;
+const MIN_AIR_CHANGES_PER_HOUR = 1;
+
+function resolveZoneHeight(zone: Zone): number {
+  if (Number.isFinite(zone.height_m) && zone.height_m > 0) {
+    return zone.height_m;
+  }
+
+  return ROOM_DEFAULT_HEIGHT_M;
+}
+
+function computeCoverageTotals(zone: Zone): {
+  readonly totalCoverage_m2: number;
+  readonly effectiveness01: number;
+} {
+  const demand_m2 = Math.max(0, zone.floorArea_m2);
+  const totalCoverage_m2 = zone.devices.reduce((sum, device) => {
+    if (!Number.isFinite(device.coverage_m2) || device.coverage_m2 <= 0) {
+      return sum;
+    }
+
+    return sum + device.coverage_m2;
+  }, 0);
+
+  if (demand_m2 <= 0) {
+    return { totalCoverage_m2, effectiveness01: 1 };
+  }
+
+  const ratio = totalCoverage_m2 / demand_m2;
+  const effectiveness01 = Math.min(1, Math.max(0, ratio));
+
+  return { totalCoverage_m2, effectiveness01 };
+}
+
+function computeAirflowMetrics(zone: Zone): {
+  readonly totalAirflow_m3_per_h: number;
+  readonly ach: number;
+} {
+  const totalAirflow_m3_per_h = zone.devices.reduce((sum, device) => {
+    if (!Number.isFinite(device.airflow_m3_per_h) || device.airflow_m3_per_h <= 0) {
+      return sum;
+    }
+
+    return sum + device.airflow_m3_per_h;
+  }, 0);
+
+  const height_m = resolveZoneHeight(zone);
+  const volume_m3 = Math.max(0, zone.floorArea_m2) * height_m;
+
+  if (volume_m3 <= 0) {
+    return { totalAirflow_m3_per_h, ach: 0 };
+  }
+
+  return {
+    totalAirflow_m3_per_h,
+    ach: totalAirflow_m3_per_h / volume_m3
+  };
+}
+
+function emitDiagnostic(ctx: EngineRunContext, diagnostic: EngineDiagnostic): void {
+  ctx.diagnostics?.emit(diagnostic);
+}
+
+function emitCoverageWarning(
+  ctx: EngineRunContext,
+  zone: Zone,
+  totalCoverage_m2: number,
+  demand_m2: number,
+  effectiveness01: number
+): void {
+  if (effectiveness01 + FLOAT_TOLERANCE >= 1) {
+    return;
+  }
+
+  emitDiagnostic(ctx, {
+    scope: 'zone',
+    code: 'zone.capacity.coverage.warn',
+    zoneId: zone.id,
+    message: `Zone "${zone.name}" coverage shortfall: ${totalCoverage_m2.toFixed(2)} m² < ${demand_m2.toFixed(2)} m².`,
+    metadata: {
+      zoneSlug: zone.slug,
+      coverage_m2: totalCoverage_m2,
+      demand_m2,
+      effectiveness01
+    }
+  });
+}
+
+function emitAirflowWarning(
+  ctx: EngineRunContext,
+  zone: Zone,
+  totalAirflow_m3_per_h: number,
+  ach: number,
+  volume_m3: number
+): void {
+  if (ach + FLOAT_TOLERANCE >= MIN_AIR_CHANGES_PER_HOUR) {
+    return;
+  }
+
+  emitDiagnostic(ctx, {
+    scope: 'zone',
+    code: 'zone.capacity.airflow.warn',
+    zoneId: zone.id,
+    message: `Zone "${zone.name}" airflow shortfall: ${ach.toFixed(2)} ACH < ${MIN_AIR_CHANGES_PER_HOUR.toFixed(2)} ACH target.`,
+    metadata: {
+      zoneSlug: zone.slug,
+      airflow_m3_per_h: totalAirflow_m3_per_h,
+      ach,
+      volume_m3,
+      targetAch: MIN_AIR_CHANGES_PER_HOUR
+    }
+  });
+}
+
 export function applyDeviceEffects(world: SimulationWorld, ctx: EngineRunContext): SimulationWorld {
   const tickHours = resolveTickHours(ctx);
   const runtime = ensureDeviceEffectsRuntime(ctx);
@@ -75,8 +197,21 @@ export function applyDeviceEffects(world: SimulationWorld, ctx: EngineRunContext
   for (const structure of world.company.structures) {
     for (const room of structure.rooms) {
       for (const zone of room.zones) {
+        const { totalCoverage_m2, effectiveness01 } = computeCoverageTotals(zone);
+        const { totalAirflow_m3_per_h, ach } = computeAirflowMetrics(zone);
+        const height_m = resolveZoneHeight(zone);
+        const volume_m3 = Math.max(0, zone.floorArea_m2) * height_m;
+
+        runtime.zoneCoverageTotals_m2.set(zone.id, totalCoverage_m2);
+        runtime.zoneCoverageEffectiveness01.set(zone.id, effectiveness01);
+        runtime.zoneAirflowTotals_m3_per_h.set(zone.id, totalAirflow_m3_per_h);
+        runtime.zoneAirChangesPerHour.set(zone.id, ach);
+
+        emitCoverageWarning(ctx, zone, totalCoverage_m2, Math.max(0, zone.floorArea_m2), effectiveness01);
+        emitAirflowWarning(ctx, zone, totalAirflow_m3_per_h, ach, volume_m3);
+
         for (const device of zone.devices) {
-          const deltaC = applyDeviceHeat(zone, device, tickHours);
+          const deltaC = applyDeviceHeat(zone, device, tickHours) * effectiveness01;
           accumulateTemperatureDelta(runtime, zone.id, deltaC);
         }
       }

--- a/packages/engine/tests/integration/domain/worldValidation.integration.test.ts
+++ b/packages/engine/tests/integration/domain/worldValidation.integration.test.ts
@@ -96,6 +96,8 @@ function buildInvalidCompany(): Company {
             powerDraw_W: -150,
             dutyCycle01: 1.1,
             efficiency01: -0.1,
+            coverage_m2: -5,
+            airflow_m3_per_h: -10,
             sensibleHeatRemovalCapacity_W: -10
           }
         ],
@@ -137,6 +139,8 @@ function buildInvalidCompany(): Company {
                     powerDraw_W: -50,
                     dutyCycle01: -0.5,
                     efficiency01: 1.5,
+                    coverage_m2: -1,
+                    airflow_m3_per_h: -2,
                     sensibleHeatRemovalCapacity_W: -5
                   }
                 ],
@@ -174,7 +178,12 @@ function buildInvalidCompany(): Company {
                   'zone' as unknown as RoomDeviceInstance['placementScope'],
                 quality01: 0.5,
                 condition01: 0.5,
-                powerDraw_W: 100
+                powerDraw_W: 100,
+                dutyCycle01: 1,
+                efficiency01: 0.5,
+                coverage_m2: 0,
+                airflow_m3_per_h: 0,
+                sensibleHeatRemovalCapacity_W: 0
               }
             ],
             zones: [

--- a/packages/engine/tests/integration/pipeline/deviceThermals.integration.test.ts
+++ b/packages/engine/tests/integration/pipeline/deviceThermals.integration.test.ts
@@ -31,6 +31,8 @@ describe('Tick pipeline — device thermal effects', () => {
       powerDraw_W: 600,
       dutyCycle01: 1,
       efficiency01: 0.2,
+      coverage_m2: 60,
+      airflow_m3_per_h: 0,
       sensibleHeatRemovalCapacity_W: 0
     } satisfies ZoneDeviceInstance;
 
@@ -45,6 +47,8 @@ describe('Tick pipeline — device thermal effects', () => {
       powerDraw_W: 800,
       dutyCycle01: 1,
       efficiency01: 0.6,
+      coverage_m2: 60,
+      airflow_m3_per_h: 0,
       sensibleHeatRemovalCapacity_W: 500
     } satisfies ZoneDeviceInstance;
 

--- a/packages/engine/tests/integration/pipeline/zoneCapacity.integration.test.ts
+++ b/packages/engine/tests/integration/pipeline/zoneCapacity.integration.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AIR_DENSITY_KG_PER_M3,
+  HOURS_PER_TICK,
+  ROOM_DEFAULT_HEIGHT_M
+} from '@/backend/src/constants/simConstants.js';
+import type { EngineDiagnostic, EngineRunContext } from '@/backend/src/engine/Engine.js';
+import {
+  applyDeviceEffects,
+  getDeviceEffectsRuntime
+} from '@/backend/src/engine/pipeline/applyDeviceEffects.js';
+import { updateEnvironment } from '@/backend/src/engine/pipeline/updateEnvironment.js';
+import { createDemoWorld } from '@/backend/src/engine/testHarness.js';
+import { applyDeviceHeat } from '@/backend/src/engine/thermo/heat.js';
+import type { ZoneDeviceInstance } from '@/backend/src/domain/world.js';
+
+describe('Phase 1 zone capacity diagnostics', () => {
+  it('clamps device effectiveness and emits coverage warnings when undersized', () => {
+    const world = createDemoWorld();
+    const zone = world.company.structures[0].rooms[0].zones[0];
+    zone.floorArea_m2 = 20;
+    zone.height_m = ROOM_DEFAULT_HEIGHT_M;
+    zone.airMass_kg = zone.floorArea_m2 * zone.height_m * AIR_DENSITY_KG_PER_M3;
+
+    const heater: ZoneDeviceInstance = {
+      id: '40000000-0000-0000-0000-000000000001',
+      slug: 'coverage-test-heater',
+      name: 'Coverage Test Heater',
+      blueprintId: '40000000-0000-0000-0000-000000000002',
+      placementScope: 'zone',
+      quality01: 1,
+      condition01: 1,
+      powerDraw_W: 1_000,
+      dutyCycle01: 1,
+      efficiency01: 0.5,
+      coverage_m2: 10,
+      airflow_m3_per_h: 0,
+      sensibleHeatRemovalCapacity_W: 0
+    } satisfies ZoneDeviceInstance;
+
+    zone.devices = [heater];
+
+    const diagnostics: EngineDiagnostic[] = [];
+    const ctx: EngineRunContext = {
+      diagnostics: {
+        emit: (diagnostic) => {
+          diagnostics.push(diagnostic);
+        }
+      }
+    } satisfies EngineRunContext;
+
+    applyDeviceEffects(world, ctx);
+
+    const runtime = getDeviceEffectsRuntime(ctx);
+    expect(runtime).toBeDefined();
+
+    const rawDeltaC = applyDeviceHeat(zone, heater, HOURS_PER_TICK);
+    const recordedDeltaC = runtime!.zoneTemperatureDeltaC.get(zone.id) ?? 0;
+
+    expect(recordedDeltaC).toBeCloseTo(rawDeltaC * 0.5, 6);
+    expect(runtime!.zoneCoverageTotals_m2.get(zone.id)).toBeCloseTo(10);
+    expect(runtime!.zoneCoverageEffectiveness01.get(zone.id)).toBeCloseTo(0.5);
+
+    expect(diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'zone.capacity.coverage.warn', zoneId: zone.id })
+      ])
+    );
+
+    const nextWorld = updateEnvironment(world, ctx);
+    const nextZone = nextWorld.company.structures[0].rooms[0].zones[0];
+
+    expect(nextZone.environment.airTemperatureC).toBeCloseTo(
+      zone.environment.airTemperatureC + recordedDeltaC,
+      6
+    );
+  });
+
+  it('aggregates airflow and emits ACH warnings when insufficient', () => {
+    const world = createDemoWorld();
+    const zone = world.company.structures[0].rooms[0].zones[0];
+    zone.floorArea_m2 = 10;
+    zone.height_m = ROOM_DEFAULT_HEIGHT_M;
+    zone.airMass_kg = zone.floorArea_m2 * zone.height_m * AIR_DENSITY_KG_PER_M3;
+
+    const fan: ZoneDeviceInstance = {
+      id: '40000000-0000-0000-0000-000000000010',
+      slug: 'airflow-test-fan',
+      name: 'Airflow Test Fan',
+      blueprintId: '40000000-0000-0000-0000-000000000011',
+      placementScope: 'zone',
+      quality01: 1,
+      condition01: 1,
+      powerDraw_W: 200,
+      dutyCycle01: 1,
+      efficiency01: 0.8,
+      coverage_m2: zone.floorArea_m2,
+      airflow_m3_per_h: 15,
+      sensibleHeatRemovalCapacity_W: 0
+    } satisfies ZoneDeviceInstance;
+
+    zone.devices = [fan];
+
+    const diagnostics: EngineDiagnostic[] = [];
+    const ctx: EngineRunContext = {
+      diagnostics: {
+        emit: (diagnostic) => {
+          diagnostics.push(diagnostic);
+        }
+      }
+    } satisfies EngineRunContext;
+
+    applyDeviceEffects(world, ctx);
+
+    const runtime = getDeviceEffectsRuntime(ctx);
+    expect(runtime).toBeDefined();
+
+    const expectedAch = 15 / (zone.floorArea_m2 * zone.height_m);
+
+    expect(runtime!.zoneAirflowTotals_m3_per_h.get(zone.id)).toBeCloseTo(15);
+    expect(runtime!.zoneAirChangesPerHour.get(zone.id)).toBeCloseTo(expectedAch, 6);
+
+    expect(diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'zone.capacity.airflow.warn', zoneId: zone.id })
+      ])
+    );
+
+    updateEnvironment(world, ctx);
+  });
+});

--- a/packages/engine/tests/unit/domain/deviceBlueprintSchema.test.ts
+++ b/packages/engine/tests/unit/domain/deviceBlueprintSchema.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  deviceBlueprintSchema,
+  parseDeviceBlueprint,
+  toDeviceInstanceCapacity
+} from '@/backend/src/domain/world.js';
+
+import climateUnit from '../../../../../data/blueprints/devices/climate_unit_01.json' assert { type: 'json' };
+import co2Injector from '../../../../../data/blueprints/devices/co2injector-01.json' assert { type: 'json' };
+import dehumidifier from '../../../../../data/blueprints/devices/dehumidifier-01.json' assert { type: 'json' };
+import exhaustFan from '../../../../../data/blueprints/devices/exhaust_fan_01.json' assert { type: 'json' };
+import humidityControl from '../../../../../data/blueprints/devices/humidity_control_unit_01.json' assert { type: 'json' };
+import vegLight from '../../../../../data/blueprints/devices/veg_light_01.json' assert { type: 'json' };
+
+describe('deviceBlueprintSchema', () => {
+  it('accepts canonical blueprint payloads', () => {
+    const base = {
+      id: '00000000-0000-4000-8000-000000000000',
+      name: 'Test Device',
+      slug: 'test-device',
+      placementScope: 'zone',
+      allowedRoomPurposes: ['growroom'],
+      power_W: 500,
+      efficiency01: 0.75,
+      coverage_m2: 12
+    };
+
+    expect(() => deviceBlueprintSchema.parse(base)).not.toThrow();
+  });
+
+  it('rejects blueprints missing both coverage and airflow', () => {
+    const invalid = {
+      id: '00000000-0000-4000-8000-000000000001',
+      name: 'Invalid Device',
+      placementScope: 'zone',
+      allowedRoomPurposes: ['growroom'],
+      power_W: 200,
+      efficiency01: 0.5
+    };
+
+    const result = deviceBlueprintSchema.safeParse(invalid);
+
+    expect(result.success).toBe(false);
+    expect(result.success ? [] : result.error.issues.map((issue) => issue.path)).toContainEqual([
+      'coverage_m2'
+    ]);
+  });
+
+  it('rejects efficiency values outside the unit interval', () => {
+    const invalid = {
+      id: '00000000-0000-4000-8000-000000000002',
+      name: 'Invalid Efficiency',
+      placementScope: 'zone',
+      allowedRoomPurposes: ['growroom'],
+      power_W: 200,
+      efficiency01: 1.5,
+      coverage_m2: 5
+    };
+
+    const result = deviceBlueprintSchema.safeParse(invalid);
+
+    expect(result.success).toBe(false);
+    expect(result.success ? [] : result.error.issues.map((issue) => issue.message)).toContain(
+      'efficiency01 must be <= 1.'
+    );
+  });
+
+  it('parses repository device blueprints without modification', () => {
+    const fixtures = [climateUnit, co2Injector, dehumidifier, exhaustFan, humidityControl, vegLight];
+
+    for (const fixture of fixtures) {
+      expect(() => parseDeviceBlueprint(fixture)).not.toThrow();
+    }
+  });
+
+  it('maps blueprint capacity fields onto device instance props', () => {
+    const parsed = parseDeviceBlueprint({
+      id: '00000000-0000-4000-8000-000000000003',
+      name: 'Mapper Device',
+      placementScope: 'zone',
+      allowedRoomPurposes: ['growroom'],
+      power_W: 420,
+      efficiency01: 0.6,
+      coverage_m2: 8,
+      airflow_m3_per_h: 120
+    });
+
+    expect(toDeviceInstanceCapacity(parsed)).toEqual({
+      powerDraw_W: 420,
+      efficiency01: 0.6,
+      coverage_m2: 8,
+      airflow_m3_per_h: 120
+    });
+  });
+});

--- a/packages/engine/tests/unit/domain/schemas.test.ts
+++ b/packages/engine/tests/unit/domain/schemas.test.ts
@@ -95,6 +95,8 @@ const BASE_WORLD = {
                   powerDraw_W: 450,
                   dutyCycle01: 1,
                   efficiency01: 0.9,
+                  coverage_m2: 30,
+                  airflow_m3_per_h: 0,
                   sensibleHeatRemovalCapacity_W: 0
                 }
               ]
@@ -112,6 +114,8 @@ const BASE_WORLD = {
               powerDraw_W: 320,
               dutyCycle01: 1,
               efficiency01: 0.85,
+              coverage_m2: 0,
+              airflow_m3_per_h: 0,
               sensibleHeatRemovalCapacity_W: 0
             }
           ]
@@ -129,6 +133,8 @@ const BASE_WORLD = {
           powerDraw_W: 500,
           dutyCycle01: 1,
           efficiency01: 0.88,
+          coverage_m2: 0,
+          airflow_m3_per_h: 0,
           sensibleHeatRemovalCapacity_W: 0
         }
       ]

--- a/packages/engine/tests/unit/domain/validateCompanyWorld.test.ts
+++ b/packages/engine/tests/unit/domain/validateCompanyWorld.test.ts
@@ -310,6 +310,8 @@ function createCompany(): Company {
     powerDraw_W: 480,
     dutyCycle01: 1,
     efficiency01: 0.85,
+    coverage_m2: AREA_QUANTUM_M2 * 8,
+    airflow_m3_per_h: 0,
     sensibleHeatRemovalCapacity_W: 0
   } satisfies ZoneDeviceInstance;
 
@@ -344,6 +346,8 @@ function createCompany(): Company {
     powerDraw_W: 250,
     dutyCycle01: 1,
     efficiency01: 0.8,
+    coverage_m2: 0,
+    airflow_m3_per_h: 0,
     sensibleHeatRemovalCapacity_W: 0
   } satisfies RoomDeviceInstance;
 
@@ -369,6 +373,8 @@ function createCompany(): Company {
     powerDraw_W: 3_500,
     dutyCycle01: 1,
     efficiency01: 0.9,
+    coverage_m2: 0,
+    airflow_m3_per_h: 0,
     sensibleHeatRemovalCapacity_W: 0
   } satisfies StructureDeviceInstance;
 


### PR DESCRIPTION
## Summary
- add a canonical device blueprint schema enforcing power, efficiency, and coverage/airflow capacity fields and expose a helper for mapping these to device instances
- migrate device blueprints and validation to carry coverage and airflow data, extend runtime diagnostics to clamp under-covered devices, and surface zone capacity warnings
- refresh documentation and add unit/integration tests covering the new schema rules and capacity diagnostics

## Testing
- pnpm --filter engine test

------
https://chatgpt.com/codex/tasks/task_e_68de5d37e3e483259d80070491077766