### PR TITLE
Centralize canonical constants for simulation validation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### #35 WB-028 canonical constant consolidation
+- Added `SECONDS_PER_HOUR`, `FLOAT_TOLERANCE`, and geospatial boundary constants
+  to `simConstants`, eliminating duplicate physics values across the engine
+  pipeline and validation layers.
+- Updated world validation, schema guards, and thermal pipeline stages to import
+  the shared constants, unifying tolerance/error messaging and dropping
+  hard-coded ranges.
+- Normalised related test fixtures to declare descriptive constants for their
+  magic numbers and refreshed the canonical constant reference documentation.
+
 ### #34 WB-027 device capacity diagnostics & blueprint schema hardening
 - Introduced a Zod-backed device blueprint schema enforcing `power_W`, `efficiency01`, and at least one of `coverage_m2`/`airflow_m3_per_h`, exporting the validator for downstream loaders and adding unit coverage (including live JSON fixtures).
 - Normalised device instances with `coverage_m2`/`airflow_m3_per_h` fields, updated validation, demo fixtures, and pipeline logic to aggregate coverage & airflow totals, clamp effectiveness by coverage ratio, and emit `zone.capacity.coverage.warn` / `zone.capacity.airflow.warn` diagnostics when undersized.

--- a/docs/constants/simConstants.md
+++ b/docs/constants/simConstants.md
@@ -12,6 +12,7 @@ normalisation mandated by the SEC.
 | --- | --- | --- | --- |
 | `AREA_QUANTUM_M2` | `0.25` | m² | Minimal calculable floor area for placement, zoning, and area rounding. |
 | `LIGHT_SCHEDULE_GRID_HOURS` | `0.25` | h | Photoperiod grid resolution enforcing 15 minute scheduling steps. |
+| `SECONDS_PER_HOUR` | `3 600` | s | Seconds per in-game hour for power ↔ energy conversions. |
 | `ROOM_DEFAULT_HEIGHT_M` | `3` | m | Default room interior height when blueprints omit overrides. |
 | `CP_AIR_J_PER_KG_K` | `1 005` | J/(kg·K) | Specific heat capacity of dry air at constant pressure. |
 | `AIR_DENSITY_KG_PER_M3` | `1.2041` | kg/m³ | Density of dry air at standard conditions (20 °C, 1 atm). |
@@ -21,8 +22,13 @@ normalisation mandated by the SEC.
 | `MONTHS_PER_YEAR` | `12` | months | Months per in-game year. |
 | `HOURS_PER_MONTH` | `720` | h | Derived: `HOURS_PER_DAY × DAYS_PER_MONTH`. |
 | `HOURS_PER_YEAR` | `8 640` | h | Derived: `HOURS_PER_MONTH × MONTHS_PER_YEAR`. |
+| `FLOAT_TOLERANCE` | `1e-6` | — | Canonical tolerance for floating-point comparisons. |
 | `DEFAULT_COMPANY_LOCATION_LON` | `9.9937` | ° | Default headquarters longitude (Hamburg) until UI capture lands. |
 | `DEFAULT_COMPANY_LOCATION_LAT` | `53.5511` | ° | Default headquarters latitude (Hamburg) until UI capture lands. |
+| `LONGITUDE_MIN_DEG` | `-180` | ° | Minimal permissible longitude for world metadata. |
+| `LONGITUDE_MAX_DEG` | `180` | ° | Maximal permissible longitude for world metadata. |
+| `LATITUDE_MIN_DEG` | `-90` | ° | Minimal permissible latitude for world metadata. |
+| `LATITUDE_MAX_DEG` | `90` | ° | Maximal permissible latitude for world metadata. |
 | `DEFAULT_COMPANY_LOCATION_CITY` | `"Hamburg"` | — | Default headquarters city placeholder. |
 | `DEFAULT_COMPANY_LOCATION_COUNTRY` | `"Deutschland"` | — | Default headquarters country placeholder. |
 

--- a/packages/engine/src/backend/src/constants/simConstants.ts
+++ b/packages/engine/src/backend/src/constants/simConstants.ts
@@ -17,6 +17,10 @@ export interface SimulationConstants {
    */
   readonly LIGHT_SCHEDULE_GRID_HOURS: number;
   /**
+   * Number of seconds contained within a single in-game hour.
+   */
+  readonly SECONDS_PER_HOUR: number;
+  /**
    * Default room interior height in metres whenever a blueprint does not
    * provide an explicit override.
    */
@@ -58,6 +62,11 @@ export interface SimulationConstants {
    */
   readonly HOURS_PER_YEAR: number;
   /**
+   * Acceptable floating point tolerance when comparing values that should be
+   * exact within the simulation.
+   */
+  readonly FLOAT_TOLERANCE: number;
+  /**
    * Default longitude (decimal degrees) for company headquarters metadata
    * until the UI allows customisation.
    */
@@ -67,6 +76,22 @@ export interface SimulationConstants {
    * until the UI allows customisation.
    */
   readonly DEFAULT_COMPANY_LOCATION_LAT: number;
+  /**
+   * Minimal canonical longitude expressed in decimal degrees.
+   */
+  readonly LONGITUDE_MIN_DEG: number;
+  /**
+   * Maximal canonical longitude expressed in decimal degrees.
+   */
+  readonly LONGITUDE_MAX_DEG: number;
+  /**
+   * Minimal canonical latitude expressed in decimal degrees.
+   */
+  readonly LATITUDE_MIN_DEG: number;
+  /**
+   * Maximal canonical latitude expressed in decimal degrees.
+   */
+  readonly LATITUDE_MAX_DEG: number;
   /**
    * Default city name used for company headquarters metadata.
    */
@@ -88,6 +113,12 @@ export const AREA_QUANTUM_M2 = 0.25 as const;
  * in in-game hours (15 minutes per step).
  */
 export const LIGHT_SCHEDULE_GRID_HOURS = 0.25 as const;
+
+/**
+ * Canonical constant describing the number of seconds contained in an
+ * in-game hour.
+ */
+export const SECONDS_PER_HOUR = 3_600 as const;
 
 /**
  * Canonical constant describing the default height of a room interior,
@@ -144,6 +175,11 @@ export const HOURS_PER_MONTH = HOURS_PER_DAY * DAYS_PER_MONTH;
 export const HOURS_PER_YEAR = HOURS_PER_MONTH * MONTHS_PER_YEAR;
 
 /**
+ * Canonical floating point comparison tolerance used across the simulation.
+ */
+export const FLOAT_TOLERANCE = 1e-6 as const;
+
+/**
  * Temporary default longitude for company headquarters metadata. Anchored to
  * Hamburg (Germany) until SEC-compliant UI capture is available.
  */
@@ -154,6 +190,26 @@ export const DEFAULT_COMPANY_LOCATION_LON = 9.9937 as const;
  * Hamburg (Germany) until SEC-compliant UI capture is available.
  */
 export const DEFAULT_COMPANY_LOCATION_LAT = 53.5511 as const;
+
+/**
+ * Canonical minimal longitude boundary expressed in decimal degrees.
+ */
+export const LONGITUDE_MIN_DEG = -180 as const;
+
+/**
+ * Canonical maximal longitude boundary expressed in decimal degrees.
+ */
+export const LONGITUDE_MAX_DEG = 180 as const;
+
+/**
+ * Canonical minimal latitude boundary expressed in decimal degrees.
+ */
+export const LATITUDE_MIN_DEG = -90 as const;
+
+/**
+ * Canonical maximal latitude boundary expressed in decimal degrees.
+ */
+export const LATITUDE_MAX_DEG = 90 as const;
 
 /**
  * Temporary default city name for company headquarters metadata.
@@ -172,6 +228,7 @@ export const DEFAULT_COMPANY_LOCATION_COUNTRY = 'Deutschland' as const;
 export const SIM_CONSTANTS: Readonly<SimulationConstants> = Object.freeze({
   AREA_QUANTUM_M2,
   LIGHT_SCHEDULE_GRID_HOURS,
+  SECONDS_PER_HOUR,
   ROOM_DEFAULT_HEIGHT_M,
   CP_AIR_J_PER_KG_K,
   AIR_DENSITY_KG_PER_M3,
@@ -181,8 +238,13 @@ export const SIM_CONSTANTS: Readonly<SimulationConstants> = Object.freeze({
   MONTHS_PER_YEAR,
   HOURS_PER_MONTH,
   HOURS_PER_YEAR,
+  FLOAT_TOLERANCE,
   DEFAULT_COMPANY_LOCATION_LON,
   DEFAULT_COMPANY_LOCATION_LAT,
+  LONGITUDE_MIN_DEG,
+  LONGITUDE_MAX_DEG,
+  LATITUDE_MIN_DEG,
+  LATITUDE_MAX_DEG,
   DEFAULT_COMPANY_LOCATION_CITY,
   DEFAULT_COMPANY_LOCATION_COUNTRY
 });

--- a/packages/engine/src/backend/src/domain/validation.ts
+++ b/packages/engine/src/backend/src/domain/validation.ts
@@ -1,7 +1,12 @@
 import {
   AREA_QUANTUM_M2,
+  FLOAT_TOLERANCE,
   HOURS_PER_DAY,
-  LIGHT_SCHEDULE_GRID_HOURS
+  LATITUDE_MAX_DEG,
+  LATITUDE_MIN_DEG,
+  LIGHT_SCHEDULE_GRID_HOURS,
+  LONGITUDE_MAX_DEG,
+  LONGITUDE_MIN_DEG
 } from '@/backend/src/constants/simConstants.js';
 
 import {
@@ -14,12 +19,6 @@ import {
   PLANT_LIFECYCLE_STAGES,
   ROOM_PURPOSES
 } from './entities.js';
-
-/**
- * Acceptable floating point tolerance when comparing values that should be
- * exact within the simulation.
- */
-const FLOAT_TOLERANCE = 1e-6;
 
 const VALID_ROOM_PURPOSES = new Set(ROOM_PURPOSES);
 const VALID_PHOTOPERIOD_PHASES = new Set<PhotoperiodPhase>([
@@ -106,14 +105,14 @@ function validateLightSchedule(
   if (schedule.onHours < 0 || schedule.onHours > HOURS_PER_DAY) {
     return {
       path,
-      message: 'onHours must lie within [0,24]'
+      message: `onHours must lie within [0,${String(HOURS_PER_DAY)}]`
     } satisfies WorldValidationIssue;
   }
 
   if (schedule.offHours < 0 || schedule.offHours > HOURS_PER_DAY) {
     return {
       path,
-      message: 'offHours must lie within [0,24]'
+      message: `offHours must lie within [0,${String(HOURS_PER_DAY)}]`
     } satisfies WorldValidationIssue;
   }
 
@@ -121,14 +120,14 @@ function validateLightSchedule(
   if (Math.abs(sum - HOURS_PER_DAY) > FLOAT_TOLERANCE) {
     return {
       path,
-      message: 'onHours + offHours must equal 24 hours'
+      message: `onHours + offHours must equal ${String(HOURS_PER_DAY)} hours`
     } satisfies WorldValidationIssue;
   }
 
   if (schedule.startHour < 0 || schedule.startHour >= HOURS_PER_DAY) {
     return {
       path,
-      message: 'startHour must lie within [0,24)'
+      message: `startHour must lie within [0,${String(HOURS_PER_DAY)})`
     } satisfies WorldValidationIssue;
   }
 
@@ -439,10 +438,10 @@ export function validateCompanyWorld(
         path: 'company.location.lon',
         message: 'longitude must be a finite number'
       });
-    } else if (lon < -180 || lon > 180) {
+    } else if (lon < LONGITUDE_MIN_DEG || lon > LONGITUDE_MAX_DEG) {
       issues.push({
         path: 'company.location.lon',
-        message: 'longitude must lie within [-180, 180]'
+        message: `longitude must lie within [${String(LONGITUDE_MIN_DEG)}, ${String(LONGITUDE_MAX_DEG)}]`
       });
     }
 
@@ -451,10 +450,10 @@ export function validateCompanyWorld(
         path: 'company.location.lat',
         message: 'latitude must be a finite number'
       });
-    } else if (lat < -90 || lat > 90) {
+    } else if (lat < LATITUDE_MIN_DEG || lat > LATITUDE_MAX_DEG) {
       issues.push({
         path: 'company.location.lat',
-        message: 'latitude must lie within [-90, 90]'
+        message: `latitude must lie within [${String(LATITUDE_MIN_DEG)}, ${String(LATITUDE_MAX_DEG)}]`
       });
     }
 

--- a/packages/engine/src/backend/src/engine/pipeline/applyDeviceEffects.ts
+++ b/packages/engine/src/backend/src/engine/pipeline/applyDeviceEffects.ts
@@ -1,4 +1,8 @@
-import { HOURS_PER_TICK, ROOM_DEFAULT_HEIGHT_M } from '../../constants/simConstants.js';
+import {
+  FLOAT_TOLERANCE,
+  HOURS_PER_TICK,
+  ROOM_DEFAULT_HEIGHT_M
+} from '../../constants/simConstants.js';
 import type { SimulationWorld, Zone } from '../../domain/world.js';
 import type { EngineDiagnostic, EngineRunContext } from '../Engine.js';
 import { applyDeviceHeat } from '../thermo/heat.js';
@@ -76,7 +80,6 @@ function accumulateTemperatureDelta(
   runtime.zoneTemperatureDeltaC.set(zoneId, current + deltaC);
 }
 
-const FLOAT_TOLERANCE = 1e-6;
 const MIN_AIR_CHANGES_PER_HOUR = 1;
 
 function resolveZoneHeight(zone: Zone): number {

--- a/packages/engine/src/backend/src/engine/pipeline/updateEnvironment.ts
+++ b/packages/engine/src/backend/src/engine/pipeline/updateEnvironment.ts
@@ -1,7 +1,9 @@
 import {
   AIR_DENSITY_KG_PER_M3,
   CP_AIR_J_PER_KG_K,
-  ROOM_DEFAULT_HEIGHT_M
+  FLOAT_TOLERANCE,
+  ROOM_DEFAULT_HEIGHT_M,
+  SECONDS_PER_HOUR
 } from '../../constants/simConstants.js';
 import type { SimulationWorld, Zone } from '../../domain/world.js';
 import type { EngineRunContext } from '../Engine.js';
@@ -10,8 +12,6 @@ import {
   getDeviceEffectsRuntime,
   resolveTickHours
 } from './applyDeviceEffects.js';
-
-const SECONDS_PER_HOUR = 3_600;
 
 function clamp01(value: number): number {
   if (!Number.isFinite(value)) {
@@ -73,7 +73,7 @@ function computeRemovalDeltaC(zone: Zone, tickHours: number): number {
 }
 
 function updateZoneTemperature(zone: Zone, netDeltaC: number): Zone {
-  if (Math.abs(netDeltaC) < Number.EPSILON) {
+  if (Math.abs(netDeltaC) < FLOAT_TOLERANCE) {
     return zone;
   }
 

--- a/packages/engine/src/backend/src/engine/thermo/heat.ts
+++ b/packages/engine/src/backend/src/engine/thermo/heat.ts
@@ -1,7 +1,9 @@
-import { CP_AIR_J_PER_KG_K, HOURS_PER_TICK } from '../../constants/simConstants.js';
+import {
+  CP_AIR_J_PER_KG_K,
+  HOURS_PER_TICK,
+  SECONDS_PER_HOUR
+} from '../../constants/simConstants.js';
 import type { Zone, ZoneDeviceInstance } from '../../domain/world.js';
-
-const SECONDS_PER_HOUR = 3_600;
 
 function clamp01(value: number): number {
   if (!Number.isFinite(value)) {

--- a/packages/engine/tests/integration/perf/baseline.spec.ts
+++ b/packages/engine/tests/integration/perf/baseline.spec.ts
@@ -2,13 +2,17 @@ import { describe, expect, it } from 'vitest';
 
 import { withPerfHarness } from '@/backend/src/engine/testHarness.js';
 
+const PERF_TICK_COUNT = 25;
+const PERF_MAX_AVERAGE_DURATION_NS = 5_000_000;
+const PERF_MAX_HEAP_BYTES = 64 * 1024 * 1024;
+
 describe('Tick performance baseline — deterministic harness', () => {
   it('maintains the baseline throughput and GC budget for the demo world', () => {
-    const result = withPerfHarness({ ticks: 25 });
+    const result = withPerfHarness({ ticks: PERF_TICK_COUNT });
 
-    expect(result.traces).toHaveLength(25);
+    expect(result.traces).toHaveLength(PERF_TICK_COUNT);
     expect(result.totalDurationNs).toBeGreaterThan(0);
-    expect(result.averageDurationNs).toBeLessThan(5_000_000);
-    expect(result.maxHeapUsedBytes).toBeLessThan(64 * 1024 * 1024);
+    expect(result.averageDurationNs).toBeLessThan(PERF_MAX_AVERAGE_DURATION_NS);
+    expect(result.maxHeapUsedBytes).toBeLessThan(PERF_MAX_HEAP_BYTES);
   });
 });

--- a/packages/engine/tests/integration/pipeline/deviceThermals.integration.test.ts
+++ b/packages/engine/tests/integration/pipeline/deviceThermals.integration.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
-import { CP_AIR_J_PER_KG_K, HOURS_PER_TICK } from '@/backend/src/constants/simConstants.js';
+import {
+  CP_AIR_J_PER_KG_K,
+  HOURS_PER_TICK,
+  SECONDS_PER_HOUR
+} from '@/backend/src/constants/simConstants.js';
 import type { EngineRunContext } from '@/backend/src/engine/Engine.js';
 import { runTick } from '@/backend/src/engine/Engine.js';
 import { createDemoWorld } from '@/backend/src/engine/testHarness.js';
 import type { Uuid, ZoneDeviceInstance } from '@/backend/src/domain/world.js';
-
-const SECONDS_PER_HOUR = 3_600;
 
 function uuid(value: string): Uuid {
   return value as Uuid;

--- a/packages/engine/tests/unit/thermo/heat.spec.ts
+++ b/packages/engine/tests/unit/thermo/heat.spec.ts
@@ -3,20 +3,27 @@ import { describe, expect, it } from 'vitest';
 import {
   AIR_DENSITY_KG_PER_M3,
   CP_AIR_J_PER_KG_K,
-  HOURS_PER_TICK
+  HOURS_PER_TICK,
+  SECONDS_PER_HOUR
 } from '@/backend/src/constants/simConstants.js';
 import { applyDeviceHeat } from '@/backend/src/engine/thermo/heat.js';
 
+const ZONE_FLOOR_AREA_M2 = 50;
+const ZONE_HEIGHT_M = 3;
+const DEVICE_POWER_DRAW_W = 600;
+const DEVICE_DUTY_CYCLE = 0.5;
+const DEVICE_EFFICIENCY = 0.9;
+
 const BASE_ZONE = {
-  floorArea_m2: 50,
-  height_m: 3,
-  airMass_kg: 50 * 3 * AIR_DENSITY_KG_PER_M3
+  floorArea_m2: ZONE_FLOOR_AREA_M2,
+  height_m: ZONE_HEIGHT_M,
+  airMass_kg: ZONE_FLOOR_AREA_M2 * ZONE_HEIGHT_M * AIR_DENSITY_KG_PER_M3
 } as const;
 
 const BASE_DEVICE = {
-  powerDraw_W: 600,
-  dutyCycle01: 0.5,
-  efficiency01: 0.9
+  powerDraw_W: DEVICE_POWER_DRAW_W,
+  dutyCycle01: DEVICE_DUTY_CYCLE,
+  efficiency01: DEVICE_EFFICIENCY
 } as const;
 
 describe('applyDeviceHeat', () => {
@@ -27,7 +34,8 @@ describe('applyDeviceHeat', () => {
     const wastePower_W =
       BASE_DEVICE.powerDraw_W * (1 - BASE_DEVICE.efficiency01) * BASE_DEVICE.dutyCycle01;
     const expectedDelta =
-      (wastePower_W * HOURS_PER_TICK * 3_600) / (airMassKg * CP_AIR_J_PER_KG_K);
+      (wastePower_W * HOURS_PER_TICK * SECONDS_PER_HOUR) /
+      (airMassKg * CP_AIR_J_PER_KG_K);
 
     expect(deltaC).toBeGreaterThan(0);
     expect(deltaC).toBeCloseTo(expectedDelta, 12);

--- a/packages/engine/tests/unit/util/createRng.test.ts
+++ b/packages/engine/tests/unit/util/createRng.test.ts
@@ -2,13 +2,16 @@ import { describe, expect, it } from 'vitest';
 
 import { createRng } from '@/backend/src/util/rng.js';
 
+const SEQUENCE_LENGTH = 16;
+const SAMPLE_LENGTH = 8;
+
 describe('createRng', () => {
   it('produces identical sequences for the same seed and stream', () => {
     const first = createRng('deterministic-seed', 'stream:quality');
     const second = createRng('deterministic-seed', 'stream:quality');
 
-    const firstSequence = Array.from({ length: 16 }, () => first());
-    const secondSequence = Array.from({ length: 16 }, () => second());
+    const firstSequence = Array.from({ length: SEQUENCE_LENGTH }, () => first());
+    const secondSequence = Array.from({ length: SEQUENCE_LENGTH }, () => second());
 
     expect(secondSequence).toStrictEqual(firstSequence);
   });
@@ -18,8 +21,8 @@ describe('createRng', () => {
     const qualityStream = createRng(baseSeed, 'stream:quality');
     const deviceStream = createRng(baseSeed, 'stream:device');
 
-    const qualitySamples = Array.from({ length: 8 }, () => qualityStream());
-    const deviceSamples = Array.from({ length: 8 }, () => deviceStream());
+    const qualitySamples = Array.from({ length: SAMPLE_LENGTH }, () => qualityStream());
+    const deviceSamples = Array.from({ length: SAMPLE_LENGTH }, () => deviceStream());
 
     expect(deviceSamples).not.toStrictEqual(qualitySamples);
   });


### PR DESCRIPTION
## Summary
- add SECONDS_PER_HOUR, FLOAT_TOLERANCE, and geographic bounds to the canonical simulation constants module
- refactor thermal pipeline, world validation, and schema checks to import the shared constants and reuse consistent tolerances/messages
- rename test magic numbers to descriptive constants and refresh constant documentation plus the changelog entry

## Testing
- pnpm --filter @wb/engine test *(fails: vitest binary is unavailable in the container image)*

------
https://chatgpt.com/codex/tasks/task_e_68de61a5fea88325b15408f96849e452