### PR TITLE
feat(engine): add deterministic device instance factory

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### #36 WB-029 deterministic device quality factory
+- Added `createDeviceInstance` to the backend device module so world/bootstrap
+  loaders draw device `quality01` via the deterministic `device:<uuid>` RNG
+  stream and clamp values into the canonical unit interval.
+- Updated domain exports and world/test fixtures to route device construction
+  through the shared helper, eliminating ad-hoc quality assignments in unit and
+  integration tests.
+- Introduced dedicated unit coverage that verifies frozen results and
+  deterministic equality for identical `{seed, id}` pairs.
+
 ### #35 WB-028 canonical constant consolidation
 - Added `SECONDS_PER_HOUR`, `FLOAT_TOLERANCE`, and geospatial boundary constants
   to `simConstants`, eliminating duplicate physics values across the engine

--- a/packages/engine/src/backend/src/device/createDeviceInstance.ts
+++ b/packages/engine/src/backend/src/device/createDeviceInstance.ts
@@ -1,0 +1,42 @@
+import type { Uuid } from '../domain/entities.js';
+import { createRng, type RandomNumberGenerator } from '../util/rng.js';
+
+export interface DeviceQualityPolicy {
+  sampleQuality01(rng: RandomNumberGenerator): number;
+}
+
+export interface DeviceInstanceSeededAttributes {
+  readonly quality01: number;
+}
+
+export function createDeviceInstance(
+  qualityPolicy: DeviceQualityPolicy,
+  seed: string,
+  id: Uuid
+): DeviceInstanceSeededAttributes {
+  if (!qualityPolicy) {
+    throw new Error('qualityPolicy must be provided');
+  }
+
+  const rng = createRng(seed, `device:${id}`);
+  const sampledQuality = qualityPolicy.sampleQuality01(rng);
+  const quality01 = clamp01(sampledQuality);
+
+  return Object.freeze({ quality01 }) as DeviceInstanceSeededAttributes;
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) {
+    throw new Error('quality01 sample must be a finite number');
+  }
+
+  if (value <= 0) {
+    return 0;
+  }
+
+  if (value >= 1) {
+    return 1;
+  }
+
+  return value;
+}

--- a/packages/engine/src/backend/src/domain/world.ts
+++ b/packages/engine/src/backend/src/domain/world.ts
@@ -2,3 +2,4 @@ export * from './entities.js';
 export * from './schemas.js';
 export * from './validation.js';
 export * from './blueprints/deviceBlueprint.js';
+export * from '../device/createDeviceInstance.js';

--- a/packages/engine/tests/integration/pipeline/deviceThermals.integration.test.ts
+++ b/packages/engine/tests/integration/pipeline/deviceThermals.integration.test.ts
@@ -8,10 +8,25 @@ import {
 import type { EngineRunContext } from '@/backend/src/engine/Engine.js';
 import { runTick } from '@/backend/src/engine/Engine.js';
 import { createDemoWorld } from '@/backend/src/engine/testHarness.js';
-import type { Uuid, ZoneDeviceInstance } from '@/backend/src/domain/world.js';
+import {
+  createDeviceInstance,
+  type DeviceQualityPolicy,
+  type Uuid,
+  type ZoneDeviceInstance
+} from '@/backend/src/domain/world.js';
 
 function uuid(value: string): Uuid {
   return value as Uuid;
+}
+
+const QUALITY_POLICY: DeviceQualityPolicy = {
+  sampleQuality01: (rng) => rng()
+};
+
+const WORLD_SEED = 'device-thermals-seed';
+
+function deviceQuality(id: Uuid): number {
+  return createDeviceInstance(QUALITY_POLICY, WORLD_SEED, id).quality01;
 }
 
 describe('Tick pipeline — device thermal effects', () => {
@@ -22,13 +37,14 @@ describe('Tick pipeline — device thermal effects', () => {
     const zone = room.zones[0];
     const initialTemperatureC = zone.environment.airTemperatureC;
 
+    const lightingDeviceId = uuid('20000000-0000-0000-0000-000000000001');
     const lightingDevice: ZoneDeviceInstance = {
-      id: uuid('20000000-0000-0000-0000-000000000001'),
+      id: lightingDeviceId,
       slug: 'veg-light',
       name: 'Veg Light',
       blueprintId: uuid('20000000-0000-0000-0000-000000000002'),
       placementScope: 'zone',
-      quality01: 0.95,
+      quality01: deviceQuality(lightingDeviceId),
       condition01: 0.94,
       powerDraw_W: 600,
       dutyCycle01: 1,
@@ -38,13 +54,14 @@ describe('Tick pipeline — device thermal effects', () => {
       sensibleHeatRemovalCapacity_W: 0
     } satisfies ZoneDeviceInstance;
 
+    const hvacDeviceId = uuid('20000000-0000-0000-0000-000000000003');
     const hvacDevice: ZoneDeviceInstance = {
-      id: uuid('20000000-0000-0000-0000-000000000003'),
+      id: hvacDeviceId,
       slug: 'zone-hvac',
       name: 'Zone HVAC',
       blueprintId: uuid('20000000-0000-0000-0000-000000000004'),
       placementScope: 'zone',
-      quality01: 0.9,
+      quality01: deviceQuality(hvacDeviceId),
       condition01: 0.9,
       powerDraw_W: 800,
       dutyCycle01: 1,

--- a/packages/engine/tests/integration/pipeline/zoneCapacity.integration.test.ts
+++ b/packages/engine/tests/integration/pipeline/zoneCapacity.integration.test.ts
@@ -13,7 +13,22 @@ import {
 import { updateEnvironment } from '@/backend/src/engine/pipeline/updateEnvironment.js';
 import { createDemoWorld } from '@/backend/src/engine/testHarness.js';
 import { applyDeviceHeat } from '@/backend/src/engine/thermo/heat.js';
-import type { ZoneDeviceInstance } from '@/backend/src/domain/world.js';
+import {
+  createDeviceInstance,
+  type DeviceQualityPolicy,
+  type ZoneDeviceInstance,
+  type Uuid
+} from '@/backend/src/domain/world.js';
+
+const QUALITY_POLICY: DeviceQualityPolicy = {
+  sampleQuality01: (rng) => rng()
+};
+
+const WORLD_SEED = 'zone-capacity-seed';
+
+function deviceQuality(id: Uuid): number {
+  return createDeviceInstance(QUALITY_POLICY, WORLD_SEED, id).quality01;
+}
 
 describe('Phase 1 zone capacity diagnostics', () => {
   it('clamps device effectiveness and emits coverage warnings when undersized', () => {
@@ -23,13 +38,14 @@ describe('Phase 1 zone capacity diagnostics', () => {
     zone.height_m = ROOM_DEFAULT_HEIGHT_M;
     zone.airMass_kg = zone.floorArea_m2 * zone.height_m * AIR_DENSITY_KG_PER_M3;
 
+    const heaterId = '40000000-0000-0000-0000-000000000001' as Uuid;
     const heater: ZoneDeviceInstance = {
-      id: '40000000-0000-0000-0000-000000000001',
+      id: heaterId,
       slug: 'coverage-test-heater',
       name: 'Coverage Test Heater',
       blueprintId: '40000000-0000-0000-0000-000000000002',
       placementScope: 'zone',
-      quality01: 1,
+      quality01: deviceQuality(heaterId),
       condition01: 1,
       powerDraw_W: 1_000,
       dutyCycle01: 1,
@@ -84,13 +100,14 @@ describe('Phase 1 zone capacity diagnostics', () => {
     zone.height_m = ROOM_DEFAULT_HEIGHT_M;
     zone.airMass_kg = zone.floorArea_m2 * zone.height_m * AIR_DENSITY_KG_PER_M3;
 
+    const fanId = '40000000-0000-0000-0000-000000000010' as Uuid;
     const fan: ZoneDeviceInstance = {
-      id: '40000000-0000-0000-0000-000000000010',
+      id: fanId,
       slug: 'airflow-test-fan',
       name: 'Airflow Test Fan',
       blueprintId: '40000000-0000-0000-0000-000000000011',
       placementScope: 'zone',
-      quality01: 1,
+      quality01: deviceQuality(fanId),
       condition01: 1,
       powerDraw_W: 200,
       dutyCycle01: 1,

--- a/packages/engine/tests/unit/device/createDeviceInstance.test.ts
+++ b/packages/engine/tests/unit/device/createDeviceInstance.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createDeviceInstance,
+  type DeviceQualityPolicy,
+  type Uuid
+} from '@/backend/src/domain/world.js';
+
+const QUALITY_POLICY: DeviceQualityPolicy = {
+  sampleQuality01: (rng) => rng()
+};
+
+const WORLD_SEED = 'device-factory-seed';
+
+function uuid(value: string): Uuid {
+  return value as Uuid;
+}
+
+describe('createDeviceInstance', () => {
+  it('returns identical quality for repeated {seed, id} pairs', () => {
+    const deviceId = uuid('50000000-0000-0000-0000-000000000001');
+
+    const first = createDeviceInstance(QUALITY_POLICY, WORLD_SEED, deviceId);
+    const second = createDeviceInstance(QUALITY_POLICY, WORLD_SEED, deviceId);
+
+    expect(first.quality01).toBe(second.quality01);
+    expect(Object.isFrozen(first)).toBe(true);
+  });
+
+  it('clamps sampled quality to the unit interval', () => {
+    const highPolicy: DeviceQualityPolicy = {
+      sampleQuality01: () => 1.42
+    };
+
+    const lowPolicy: DeviceQualityPolicy = {
+      sampleQuality01: () => -0.2
+    };
+
+    expect(
+      createDeviceInstance(highPolicy, WORLD_SEED, uuid('50000000-0000-0000-0000-000000000002')).quality01
+    ).toBe(1);
+
+    expect(
+      createDeviceInstance(lowPolicy, WORLD_SEED, uuid('50000000-0000-0000-0000-000000000003')).quality01
+    ).toBe(0);
+  });
+});

--- a/packages/engine/tests/unit/domain/schemas.test.ts
+++ b/packages/engine/tests/unit/domain/schemas.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from 'vitest';
 import { AIR_DENSITY_KG_PER_M3, ROOM_DEFAULT_HEIGHT_M } from '@/backend/src/constants/simConstants.js';
 import {
   companySchema,
+  createDeviceInstance,
   parseCompanyWorld,
   type DevicePlacementScope,
-  type ParsedCompanyWorld
+  type DeviceQualityPolicy,
+  type ParsedCompanyWorld,
+  type Uuid
 } from '@wb/engine';
 
 type DeepMutable<T> = T extends (...args: unknown[]) => unknown
@@ -22,6 +25,16 @@ type MutableCompanyWorld = DeepMutable<ParsedCompanyWorld>;
 type MutableZoneDeviceInstance = MutableCompanyWorld['structures'][number]['rooms'][number]['zones'][number]['devices'][number] & {
   placementScope: DevicePlacementScope;
 };
+
+const QUALITY_POLICY: DeviceQualityPolicy = {
+  sampleQuality01: (rng) => rng()
+};
+
+const WORLD_SEED = 'schema-world-seed';
+
+function deviceQuality(id: Uuid): number {
+  return createDeviceInstance(QUALITY_POLICY, WORLD_SEED, id).quality01;
+}
 
 const BASE_WORLD = {
   id: '00000000-0000-0000-0000-000000000001',
@@ -90,7 +103,7 @@ const BASE_WORLD = {
                   name: 'Zone Device',
                   blueprintId: '00000000-0000-0000-0000-000000000061',
                   placementScope: 'zone',
-                  quality01: 0.98,
+                  quality01: deviceQuality('00000000-0000-0000-0000-000000000060' as Uuid),
                   condition01: 0.97,
                   powerDraw_W: 450,
                   dutyCycle01: 1,
@@ -109,7 +122,7 @@ const BASE_WORLD = {
               name: 'Room Device',
               blueprintId: '00000000-0000-0000-0000-000000000071',
               placementScope: 'room',
-              quality01: 0.92,
+              quality01: deviceQuality('00000000-0000-0000-0000-000000000070' as Uuid),
               condition01: 0.91,
               powerDraw_W: 320,
               dutyCycle01: 1,
@@ -128,7 +141,7 @@ const BASE_WORLD = {
           name: 'Structure Device',
           blueprintId: '00000000-0000-0000-0000-000000000081',
           placementScope: 'structure',
-          quality01: 0.93,
+          quality01: deviceQuality('00000000-0000-0000-0000-000000000080' as Uuid),
           condition01: 0.9,
           powerDraw_W: 500,
           dutyCycle01: 1,

--- a/packages/engine/tests/unit/domain/validateCompanyWorld.test.ts
+++ b/packages/engine/tests/unit/domain/validateCompanyWorld.test.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_COMPANY_LOCATION_COUNTRY
 } from '@/backend/src/constants/simConstants.js';
 import {
+  createDeviceInstance,
   type Company,
   type Structure,
   type Room,
@@ -19,8 +20,19 @@ import {
   type RoomDeviceInstance,
   type ZoneDeviceInstance,
   type Uuid,
+  type DeviceQualityPolicy,
   validateCompanyWorld
 } from '@/backend/src/domain/world.js';
+
+const QUALITY_POLICY: DeviceQualityPolicy = {
+  sampleQuality01: (rng) => rng()
+};
+
+const WORLD_SEED = 'validate-company-world-seed';
+
+function deviceQuality(id: Uuid): number {
+  return createDeviceInstance(QUALITY_POLICY, WORLD_SEED, id).quality01;
+}
 
 function uuid(value: string): Uuid {
   return value as Uuid;
@@ -299,13 +311,14 @@ function createCompany(): Company {
     substrateId: uuid('00000000-0000-0000-0000-000000000040')
   } satisfies Plant;
 
+  const zoneDeviceId = uuid('00000000-0000-0000-0000-000000000050');
   const zoneDevice: ZoneDeviceInstance = {
-    id: uuid('00000000-0000-0000-0000-000000000050'),
+    id: zoneDeviceId,
     slug: 'zone-device',
     name: 'Zone Device',
     blueprintId: uuid('00000000-0000-0000-0000-000000000051'),
     placementScope: 'zone',
-    quality01: 0.8,
+    quality01: deviceQuality(zoneDeviceId),
     condition01: 0.75,
     powerDraw_W: 480,
     dutyCycle01: 1,
@@ -335,13 +348,14 @@ function createCompany(): Company {
     }
   } satisfies Zone;
 
+  const roomDeviceId = uuid('00000000-0000-0000-0000-000000000070');
   const roomDevice: RoomDeviceInstance = {
-    id: uuid('00000000-0000-0000-0000-000000000070'),
+    id: roomDeviceId,
     slug: 'room-dehumidifier',
     name: 'Room Dehumidifier',
     blueprintId: uuid('00000000-0000-0000-0000-000000000071'),
     placementScope: 'room',
-    quality01: 0.85,
+    quality01: deviceQuality(roomDeviceId),
     condition01: 0.9,
     powerDraw_W: 250,
     dutyCycle01: 1,
@@ -362,13 +376,14 @@ function createCompany(): Company {
     devices: [roomDevice]
   } satisfies Room;
 
+  const structureDeviceId = uuid('00000000-0000-0000-0000-000000000090');
   const structureDevice: StructureDeviceInstance = {
-    id: uuid('00000000-0000-0000-0000-000000000090'),
+    id: structureDeviceId,
     slug: 'structure-hvac',
     name: 'Structure HVAC',
     blueprintId: uuid('00000000-0000-0000-0000-000000000091'),
     placementScope: 'structure',
-    quality01: 0.95,
+    quality01: deviceQuality(structureDeviceId),
     condition01: 0.88,
     powerDraw_W: 3_500,
     dutyCycle01: 1,


### PR DESCRIPTION
## Summary
- add a backend device factory that samples deterministic quality from the device RNG stream and expose it via the domain barrel
- update world/bootstrap fixtures to obtain device quality through the factory and document the change in the changelog
- cover the helper with new unit tests and adjust existing suites to keep deterministic expectations intact

## Testing
- `pnpm --filter @wb/engine test`


------
https://chatgpt.com/codex/tasks/task_e_68de64f3d6788325b3d2a0fb0753a2e7