### PR TITLE
Add device condition lifecycle helpers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### #37 WB-030 device condition lifecycle scaffolding
+- Added a backend device condition helper module with placeholder degradation,
+  maintenance, and repair flows that honour SEC monotonic wear requirements and
+  clamp condition/threshold values to the canonical unit interval.
+- Exposed the condition helpers via the world barrel so downstream engine
+  surfaces can query maintenance/repair eligibility without bespoke imports.
+- Covered the new helpers with unit tests for monotonic wear, threshold checks,
+  RNG-ready repair hooks, and clamping semantics.
+
 ### #36 WB-029 deterministic device quality factory
 - Added `createDeviceInstance` to the backend device module so world/bootstrap
   loaders draw device `quality01` via the deterministic `device:<uuid>` RNG

--- a/packages/engine/src/backend/src/device/condition.ts
+++ b/packages/engine/src/backend/src/device/condition.ts
@@ -1,0 +1,122 @@
+/**
+ * Device condition lifecycle helpers.
+ *
+ * These are deliberately lightweight placeholders until the full SEC quality /
+ * condition models are implemented. They provide deterministic, monotonic wear
+ * relative to `quality01`, enforce threshold checks for maintenance/repairs, and
+ * expose RNG-ready hooks so future probabilistic repair flows can integrate
+ * without rewriting call sites.
+ */
+
+const BASE_WEAR_RATE01 = 0.01;
+const QUALITY_WEAR_SLOPE = 0.5;
+
+export interface RepairOptions {
+  readonly condition01: number;
+  readonly repairMinThreshold01: number;
+  readonly repairAmount01: number;
+  readonly successChance01?: number;
+  readonly sampleSuccess?: (chance01: number) => boolean;
+}
+
+export interface RepairResult {
+  readonly condition01: number;
+  readonly success: boolean;
+}
+
+export function degradeCondition(
+  condition01: number,
+  quality01: number,
+  wearMultiplier = 1
+): number {
+  assertFinite('condition01', condition01);
+  assertFinite('quality01', quality01);
+  assertFinite('wearMultiplier', wearMultiplier);
+
+  const condition = clamp01(condition01);
+  const quality = clamp01(quality01);
+  const multiplier = Math.max(0, wearMultiplier);
+
+  const wearRate = BASE_WEAR_RATE01 * multiplier * (1 + QUALITY_WEAR_SLOPE * (1 - quality));
+  const degraded = condition - wearRate;
+
+  return clamp01(degraded);
+}
+
+export function needsMaintenance(condition01: number, maintThreshold01: number): boolean {
+  assertFinite('condition01', condition01);
+  assertFinite('maintThreshold01', maintThreshold01);
+
+  const condition = clamp01(condition01);
+  const threshold = clamp01(maintThreshold01);
+
+  return condition <= threshold;
+}
+
+export function canRepair(condition01: number, repairMinThreshold01: number): boolean {
+  assertFinite('condition01', condition01);
+  assertFinite('repairMinThreshold01', repairMinThreshold01);
+
+  const condition = clamp01(condition01);
+  const threshold = clamp01(repairMinThreshold01);
+
+  return condition >= threshold;
+}
+
+export function applyRepair(options: RepairOptions): RepairResult {
+  const condition = clamp01(options.condition01);
+  const threshold = clamp01(options.repairMinThreshold01);
+  const amount = Math.max(0, options.repairAmount01);
+  const successChance = clamp01(options.successChance01 ?? 1);
+
+  if (!canRepair(condition, threshold)) {
+    return { condition01: condition, success: false };
+  }
+
+  const success = determineRepairSuccess(successChance, options.sampleSuccess);
+
+  if (!success) {
+    return { condition01: condition, success: false };
+  }
+
+  const repaired = clamp01(condition + amount);
+
+  return { condition01: repaired, success: true };
+}
+
+function determineRepairSuccess(
+  successChance01: number,
+  sampleSuccess: RepairOptions['sampleSuccess']
+): boolean {
+  if (successChance01 <= 0) {
+    return false;
+  }
+
+  if (successChance01 >= 1) {
+    return true;
+  }
+
+  if (sampleSuccess) {
+    return sampleSuccess(successChance01);
+  }
+
+  return successChance01 >= 0.5;
+}
+
+function clamp01(value: number): number {
+  if (value <= 0) {
+    return 0;
+  }
+
+  if (value >= 1) {
+    return 1;
+  }
+
+  return value;
+}
+
+function assertFinite(label: string, value: number): void {
+  if (!Number.isFinite(value)) {
+    throw new Error(`${label} must be a finite number`);
+  }
+}

--- a/packages/engine/src/backend/src/domain/world.ts
+++ b/packages/engine/src/backend/src/domain/world.ts
@@ -3,3 +3,4 @@ export * from './schemas.js';
 export * from './validation.js';
 export * from './blueprints/deviceBlueprint.js';
 export * from '../device/createDeviceInstance.js';
+export * from '../device/condition.js';

--- a/packages/engine/tests/unit/device/condition.test.ts
+++ b/packages/engine/tests/unit/device/condition.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  applyRepair,
+  canRepair,
+  degradeCondition,
+  needsMaintenance,
+  type RepairOptions
+} from '@/backend/src/domain/world.js';
+
+describe('degradeCondition', () => {
+  it('reduces wear as quality improves', () => {
+    const startingCondition = 0.9;
+
+    const lowQuality = degradeCondition(startingCondition, 0);
+    const highQuality = degradeCondition(startingCondition, 1);
+
+    expect(highQuality).toBeGreaterThan(lowQuality);
+    expect(highQuality).toBeLessThanOrEqual(startingCondition);
+  });
+
+  it('clamps condition within the unit interval', () => {
+    expect(degradeCondition(1.4, 0.5)).toBeLessThanOrEqual(1);
+    expect(degradeCondition(-0.1, 0.5)).toBe(0);
+  });
+});
+
+describe('needsMaintenance', () => {
+  it('flags condition at or below the maintenance threshold', () => {
+    expect(needsMaintenance(0.25, 0.3)).toBe(true);
+    expect(needsMaintenance(0.3, 0.3)).toBe(true);
+  });
+
+  it('returns false when condition is comfortably above the threshold', () => {
+    expect(needsMaintenance(0.6, 0.3)).toBe(false);
+  });
+});
+
+describe('canRepair', () => {
+  it('requires condition to meet the minimum repair threshold', () => {
+    expect(canRepair(0.45, 0.4)).toBe(true);
+    expect(canRepair(0.39, 0.4)).toBe(false);
+  });
+});
+
+describe('applyRepair', () => {
+  it('does not repair when the device is below the minimum threshold', () => {
+    const outcome = applyRepair({
+      condition01: 0.2,
+      repairMinThreshold01: 0.3,
+      repairAmount01: 0.5
+    });
+
+    expect(outcome.success).toBe(false);
+    expect(outcome.condition01).toBe(0.2);
+  });
+
+  it('repairs and clamps condition when successful', () => {
+    const outcome = applyRepair({
+      condition01: 0.7,
+      repairMinThreshold01: 0.5,
+      repairAmount01: 0.5
+    });
+
+    expect(outcome.success).toBe(true);
+    expect(outcome.condition01).toBe(1);
+  });
+
+  it('consults the provided RNG hook when probability is partial', () => {
+    const sampler = vi.fn<NonNullable<RepairOptions['sampleSuccess']>, [number]>((chance) => {
+      expect(chance).toBe(0.25);
+      return false;
+    });
+
+    const failure = applyRepair({
+      condition01: 0.8,
+      repairMinThreshold01: 0.5,
+      repairAmount01: 0.1,
+      successChance01: 0.25,
+      sampleSuccess: sampler
+    });
+
+    expect(sampler).toHaveBeenCalledTimes(1);
+    expect(failure.success).toBe(false);
+    expect(failure.condition01).toBe(0.8);
+
+    sampler.mockReturnValueOnce(true);
+
+    const success = applyRepair({
+      condition01: 0.8,
+      repairMinThreshold01: 0.5,
+      repairAmount01: 0.1,
+      successChance01: 0.25,
+      sampleSuccess: sampler
+    });
+
+    expect(success.success).toBe(true);
+    expect(success.condition01).toBeCloseTo(0.9, 5);
+  });
+});


### PR DESCRIPTION
## Summary
- add a backend device condition helper module with placeholder degradation, maintenance, and repair logic
- export the new helpers through the engine world barrel for downstream consumers and document the change
- cover the helpers with unit tests for wear monotonicity, threshold behaviour, and RNG hook semantics

## Testing
- pnpm --filter @wb/engine test *(fails: vitest not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de66ffd7bc832597b1af62e27a14a2