### PR TITLE
feat: expose facade device read-model percent mapper

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### #38 WB-031 device read-model percent enrichment
+- Introduced a façade read-model mapper that forwards canonical device metrics
+  while appending `qualityPercent`/`conditionPercent` derived via the SEC-mandated
+  `Math.round(100 * value)` normalisation.
+- Re-exported the mapper from the façade entrypoint so downstream UI/transport
+  layers consume the enriched payload without bespoke imports.
+- Added Vitest unit coverage proving raw `[0,1]` fields coexist with the rounded
+  percentage metrics, including edge rounding behaviour.
+
 ### #37 WB-030 device condition lifecycle scaffolding
 - Added a backend device condition helper module with placeholder degradation,
   maintenance, and repair flows that honour SEC monotonic wear requirements and

--- a/packages/facade/src/index.ts
+++ b/packages/facade/src/index.ts
@@ -7,6 +7,7 @@ import {
 
 export type { ParsedCompanyWorld } from '@wb/engine';
 export { parseCompanyWorld } from '@wb/engine';
+export { mapDeviceToView, type DeviceView } from './readModels/deviceView.js';
 
 /**
  * Parameters required to initialise the façade layer that brokers between the engine and clients.

--- a/packages/facade/src/readModels/deviceView.ts
+++ b/packages/facade/src/readModels/deviceView.ts
@@ -1,0 +1,37 @@
+import type { DeviceInstance } from '@wb/engine';
+
+/**
+ * Public read-model contract representing a device enriched with UI-friendly metrics.
+ */
+export interface DeviceView extends DeviceInstance {
+  /**
+   * Device quality expressed as a percentage on the 0–100 scale for UI consumers.
+   */
+  readonly qualityPercent: number;
+
+  /**
+   * Device condition expressed as a percentage on the 0–100 scale for UI consumers.
+   */
+  readonly conditionPercent: number;
+}
+
+function normalisePercent(value01: number): number {
+  return Math.round(value01 * 100);
+}
+
+/**
+ * Projects a deterministic device instance onto the public read-model contract expected by UI layers.
+ *
+ * @param device - Canonical device instance emitted by the engine/domain layer.
+ * @returns Device view including raw [0,1] fields and their rounded percentage counterparts.
+ */
+export function mapDeviceToView(device: DeviceInstance): DeviceView {
+  const qualityPercent = normalisePercent(device.quality01);
+  const conditionPercent = normalisePercent(device.condition01);
+
+  return {
+    ...device,
+    qualityPercent,
+    conditionPercent
+  } satisfies DeviceView;
+}

--- a/packages/facade/tests/unit/readModels/deviceView.test.ts
+++ b/packages/facade/tests/unit/readModels/deviceView.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import type { DeviceInstance } from '@wb/engine';
+import { mapDeviceToView } from '../../../src/readModels/deviceView.js';
+
+function createDevice(overrides: Partial<DeviceInstance> = {}): DeviceInstance {
+  const base: DeviceInstance = {
+    id: '00000000-0000-0000-0000-000000000001' as DeviceInstance['id'],
+    slug: 'test-device',
+    name: 'Test Device',
+    blueprintId: '00000000-0000-0000-0000-000000000010' as DeviceInstance['blueprintId'],
+    placementScope: 'zone',
+    quality01: 0.5,
+    condition01: 0.5,
+    powerDraw_W: 1200,
+    dutyCycle01: 0.75,
+    efficiency01: 0.65,
+    coverage_m2: 12,
+    airflow_m3_per_h: 0,
+    sensibleHeatRemovalCapacity_W: 0
+  };
+
+  return { ...base, ...overrides };
+}
+
+describe('mapDeviceToView', () => {
+  it('forwards the canonical device fields while appending percentage metrics', () => {
+    const device = createDevice({ quality01: 0.81, condition01: 0.64 });
+
+    const view = mapDeviceToView(device);
+
+    expect(view).not.toBe(device);
+    expect(view.quality01).toBe(device.quality01);
+    expect(view.condition01).toBe(device.condition01);
+    expect(view.qualityPercent).toBe(81);
+    expect(view.conditionPercent).toBe(64);
+  });
+
+  it('rounds percentage metrics to the nearest integer', () => {
+    const device = createDevice({ quality01: 0.834, condition01: 0.995 });
+
+    const view = mapDeviceToView(device);
+
+    expect(view.qualityPercent).toBe(83);
+    expect(view.conditionPercent).toBe(100);
+  });
+});


### PR DESCRIPTION
## Summary
- add a device read-model mapper that enriches quality/condition metrics with percentage values
- export the mapper from the façade entry point for downstream consumers
- cover the new mapper with unit tests and document the change in the changelog

## Testing
- pnpm --filter @wb/facade test

------
https://chatgpt.com/codex/tasks/task_e_68de67e6f5308325a69a5afdc407ad26