### PR TITLE
Add ESLint guard against percent identifiers in engine package

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,7 +1,16 @@
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import { noDuplicateSimConstantsRule } from "./tools/eslint/rules/no-duplicate-sim-constants.js";
+import { noEnginePercentIdentifiersRule } from "./tools/eslint/rules/no-engine-percent-identifiers.js";
 import { noMathRandomRule } from "./tools/eslint/rules/no-math-random.js";
+
+const wbSimPlugin = {
+  rules: {
+    "no-duplicate-sim-constants": noDuplicateSimConstantsRule,
+    "no-engine-percent-identifiers": noEnginePercentIdentifiersRule,
+    "no-math-random": noMathRandomRule
+  }
+};
 
 export default tseslint.config(
   {
@@ -19,17 +28,21 @@ export default tseslint.config(
       }
     },
     plugins: {
-      "wb-sim": {
-        rules: {
-          "no-duplicate-sim-constants": noDuplicateSimConstantsRule,
-          "no-math-random": noMathRandomRule
-        }
-      }
+      "wb-sim": wbSimPlugin
     },
     rules: {
       "@typescript-eslint/explicit-module-boundary-types": "error",
       "wb-sim/no-duplicate-sim-constants": "error",
       "wb-sim/no-math-random": "error"
+    }
+  },
+  {
+    files: ["packages/engine/**/*.{ts,tsx,js,jsx}", "packages/engine/**/*.cts", "packages/engine/**/*.mts"],
+    plugins: {
+      "wb-sim": wbSimPlugin
+    },
+    rules: {
+      "wb-sim/no-engine-percent-identifiers": "error"
     }
   }
 );

--- a/tools/eslint/rules/no-engine-percent-identifiers.js
+++ b/tools/eslint/rules/no-engine-percent-identifiers.js
@@ -1,0 +1,61 @@
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
+export const noEnginePercentIdentifiersRule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "disallow Percent-based identifiers in the engine package so read-model layers stay responsible for percent formatting",
+      recommended: false
+    },
+    schema: [],
+    messages: {
+      forbidden:
+        "Engine modules must not use Percent-based identifiers; keep internal values in 0-1 form and defer percent formatting to façades/read-models."
+    }
+  },
+  create(context) {
+    const getFilename = () => {
+      if (typeof context.getPhysicalFilename === "function") {
+        return context.getPhysicalFilename();
+      }
+
+      if (typeof context.physicalFilename === "string") {
+        return context.physicalFilename;
+      }
+
+      return context.getFilename();
+    };
+
+    const shouldCheckFile = () => {
+      const filename = getFilename();
+
+      if (!filename || filename === "<input>") {
+        return false;
+      }
+
+      const normalized = filename.replace(/\\/g, "/");
+      return normalized.includes("/packages/engine/") || normalized.endsWith("/packages/engine");
+    };
+
+    if (!shouldCheckFile()) {
+      return {};
+    }
+
+    const containsPercentToken = (name) => name.includes("Percent") || name.includes("_percent");
+
+    return {
+      Identifier(node) {
+        if (!containsPercentToken(node.name)) {
+          return;
+        }
+
+        context.report({
+          node,
+          messageId: "forbidden"
+        });
+      }
+    };
+  }
+};

--- a/tools/eslint/tests/no-engine-percent-identifiers.test.js
+++ b/tools/eslint/tests/no-engine-percent-identifiers.test.js
@@ -1,0 +1,51 @@
+import test from "node:test";
+import path from "node:path";
+import { RuleTester } from "eslint";
+import { noEnginePercentIdentifiersRule } from "../rules/no-engine-percent-identifiers.js";
+
+RuleTester.describe = (text, method) => {
+  method();
+};
+RuleTester.it = (text, method) => {
+  method();
+};
+RuleTester.itOnly = (text, method) => {
+  method();
+};
+RuleTester.itSkip = () => {
+  // noop for compatibility
+};
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: "module"
+  }
+});
+
+test("no-engine-percent-identifiers rule", () => {
+  ruleTester.run("no-engine-percent-identifiers", noEnginePercentIdentifiersRule, {
+    valid: [
+      {
+        code: "const qualityPercent = 42;",
+        filename: path.resolve("packages/facade/src/example.ts")
+      },
+      {
+        code: "const normalizedQuality = quality01;",
+        filename: path.resolve("packages/engine/src/example.ts")
+      }
+    ],
+    invalid: [
+      {
+        code: "const qualityPercent = 42;",
+        filename: path.resolve("packages/engine/src/example.ts"),
+        errors: [{ messageId: "forbidden" }]
+      },
+      {
+        code: "const quality_percent = 42;",
+        filename: path.resolve("packages/engine/src/example.ts"),
+        errors: [{ messageId: "forbidden" }]
+      }
+    ]
+  });
+});


### PR DESCRIPTION
## Summary
- add a custom eslint rule that blocks Percent/_percent identifiers when linting the engine package
- register the rule via a dedicated override so façade/read-model code can continue using percent labels
- cover the rule with node:test-based RuleTester cases for engine and façade file paths

## Testing
- node --test tools/eslint/tests/no-engine-percent-identifiers.test.js
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68de693a01f48325bd78363df9a446b0