### PR TITLE
feat: align blueprints with class taxonomy

### DIFF
--- a/data/blueprints/containers/pot_10l.json
+++ b/data/blueprints/containers/pot_10l.json
@@ -1,9 +1,8 @@
 {
   "id": "0c48f3e3-2c19-4be4-86ea-4de97f5aa51e",
   "slug": "pot-10l",
-  "kind": "Container",
+  "class": "container.pot",
   "name": "10 L Pot",
-  "type": "pot",
   "volumeInLiters": 10,
   "footprintArea": 0.25,
   "reusableCycles": 3,

--- a/data/blueprints/containers/pot_11l.json
+++ b/data/blueprints/containers/pot_11l.json
@@ -1,9 +1,8 @@
 {
   "id": "d9267b6f-41f3-4e91-95b8-5bd7be381d3f",
   "slug": "pot-11l",
-  "kind": "Container",
+  "class": "container.pot",
   "name": "11 L Pot",
-  "type": "pot",
   "volumeInLiters": 11,
   "footprintArea": 0.2,
   "reusableCycles": 6,

--- a/data/blueprints/containers/pot_25l.json
+++ b/data/blueprints/containers/pot_25l.json
@@ -1,9 +1,8 @@
 {
   "id": "9fb62d74-df4e-4e74-a0fb-77fa1f21d3ef",
   "slug": "pot-25l",
-  "kind": "Container",
+  "class": "container.pot",
   "name": "25 L Pot",
-  "type": "pot",
   "volumeInLiters": 25,
   "footprintArea": 0.3,
   "reusableCycles": 6,

--- a/data/blueprints/cultivationMethods/basic_soil_pot.json
+++ b/data/blueprints/cultivationMethods/basic_soil_pot.json
@@ -1,6 +1,7 @@
 {
   "id": "85cc0916-0e8a-495e-af8f-50291abe6855",
-  "kind": "CultivationMethod",
+  "slug": "basic-soil-pot",
+  "class": "cultivation-method.soil.basic-pot",
   "name": "Basic Soil Pot",
   "laborIntensity": 0.1,
   "laborProfile": {
@@ -9,8 +10,13 @@
   "areaPerPlant_m2": 0.5,
   "minimumSpacing": 0.5,
   "maxCycles": 1,
-  "substrates": ["soil-single-cycle", "coco-coir"],
-  "containers": ["pot-10l"],
+  "substrates": [
+    "soil-single-cycle",
+    "coco-coir"
+  ],
+  "containers": [
+    "pot-10l"
+  ],
   "strainTraitCompatibility": {},
   "envBias": {},
   "capacityHints": {
@@ -18,13 +24,26 @@
     "canopyHeight_m": 1.2
   },
   "idealConditions": {
-    "idealTemperature": [20, 28],
-    "idealHumidity": [0.5, 0.7]
+    "idealTemperature": [
+      20,
+      28
+    ],
+    "idealHumidity": [
+      0.5,
+      0.7
+    ]
   },
   "meta": {
     "description": "Simple cultivation method: one plant per pot in soil. Low setup cost, minimal labor, universally compatible.",
-    "advantages": ["Very low initial cost", "Compatible with most strains", "Easy to manage"],
-    "disadvantages": ["Moderate space usage", "Lower productivity than advanced methods"],
+    "advantages": [
+      "Very low initial cost",
+      "Compatible with most strains",
+      "Easy to manage"
+    ],
+    "disadvantages": [
+      "Moderate space usage",
+      "Lower productivity than advanced methods"
+    ],
     "defaults": {
       "containerSlug": "pot-10l",
       "substrateSlug": "soil-single-cycle"

--- a/data/blueprints/cultivationMethods/scrog.json
+++ b/data/blueprints/cultivationMethods/scrog.json
@@ -1,6 +1,7 @@
 {
   "id": "41229377-ef2d-4723-931f-72eea87d7a62",
-  "kind": "CultivationMethod",
+  "slug": "screen-of-green",
+  "class": "cultivation-method.training.scrog",
   "name": "Screen of Green",
   "laborIntensity": 0.7,
   "laborProfile": {
@@ -9,8 +10,13 @@
   "areaPerPlant_m2": 1.0,
   "minimumSpacing": 0.8,
   "maxCycles": 4,
-  "substrates": ["soil-multi-cycle", "coco-coir"],
-  "containers": ["pot-25l"],
+  "substrates": [
+    "soil-multi-cycle",
+    "coco-coir"
+  ],
+  "containers": [
+    "pot-25l"
+  ],
   "strainTraitCompatibility": {
     "preferred": {
       "genotype.sativa": {
@@ -32,8 +38,14 @@
     "canopyHeight_m": 0.8
   },
   "idealConditions": {
-    "idealTemperature": [21, 27],
-    "idealHumidity": [0.55, 0.7]
+    "idealTemperature": [
+      21,
+      27
+    ],
+    "idealHumidity": [
+      0.55,
+      0.7
+    ]
   },
   "meta": {
     "description": "Screen of Green (SCROG) is a low-density cultivation method that uses a screen to train plants to grow horizontally, creating a flat, even canopy. It maximizes light exposure for a smaller number of larger plants.",

--- a/data/blueprints/cultivationMethods/sog.json
+++ b/data/blueprints/cultivationMethods/sog.json
@@ -1,6 +1,7 @@
 {
   "id": "659ba4d7-a5fc-482e-98d4-b614341883ac",
-  "kind": "CultivationMethod",
+  "slug": "sea-of-green",
+  "class": "cultivation-method.training.sog",
   "name": "Sea of Green",
   "laborIntensity": 0.4,
   "laborProfile": {
@@ -9,8 +10,13 @@
   "areaPerPlant_m2": 0.25,
   "minimumSpacing": 0.25,
   "maxCycles": 2,
-  "substrates": ["soil-single-cycle", "coco-coir"],
-  "containers": ["pot-11l"],
+  "substrates": [
+    "soil-single-cycle",
+    "coco-coir"
+  ],
+  "containers": [
+    "pot-11l"
+  ],
   "strainTraitCompatibility": {
     "preferred": {
       "genotype.indica": {
@@ -38,12 +44,22 @@
     "canopyHeight_m": 0.6
   },
   "idealConditions": {
-    "idealTemperature": [22, 28],
-    "idealHumidity": [0.5, 0.65]
+    "idealTemperature": [
+      22,
+      28
+    ],
+    "idealHumidity": [
+      0.5,
+      0.65
+    ]
   },
   "meta": {
     "description": "Sea of Green (SOG) is a high-density cultivation method where many small plants are grown close together to quickly fill a canopy. It emphasizes short vegetative phases and rapid cycling, ideal for fast-flowering indica-dominant strains.",
-    "advantages": ["Shorter grow cycles", "Efficient use of space", "Lower training effort"],
+    "advantages": [
+      "Shorter grow cycles",
+      "Efficient use of space",
+      "Lower training effort"
+    ],
     "disadvantages": [
       "More plants to manage",
       "Legal limitations in plant count (IRL)",

--- a/data/blueprints/devices/climate_unit_01.json
+++ b/data/blueprints/devices/climate_unit_01.json
@@ -1,8 +1,12 @@
 {
   "id": "7d3d3f1a-8c6f-4e9c-926d-5a2a4a3b6f1b",
-  "kind": "ClimateUnit",
+  "slug": "cool-air-split-3000",
+  "class": "device.climate.cooling",
   "name": "CoolAir Split 3000",
   "placementScope": "zone",
+  "allowedRoomPurposes": [
+    "growroom"
+  ],
   "power_W": 1200,
   "efficiency01": 0.65,
   "coverage_m2": 25,
@@ -52,8 +56,5 @@
       "Limited precision for multi-zone systems"
     ],
     "notes": "Recommended for vegetative and early flowering stages in temperate climates."
-  },
-  "allowedRoomPurposes": [
-    "growroom"
-  ]
+  }
 }

--- a/data/blueprints/devices/co2injector-01.json
+++ b/data/blueprints/devices/co2injector-01.json
@@ -1,8 +1,12 @@
 {
   "id": "c701efa6-1e90-4f28-8934-ea9c584596e4",
-  "kind": "CO2Injector",
+  "slug": "co2-pulse",
+  "class": "device.climate.co2",
   "name": "CO2 Pulse",
   "placementScope": "zone",
+  "allowedRoomPurposes": [
+    "growroom"
+  ],
   "power_W": 50,
   "efficiency01": 0.9,
   "coverage_m2": 10,
@@ -45,8 +49,5 @@
       "Requires CO2 supply",
       "Overuse can harm plants"
     ]
-  },
-  "allowedRoomPurposes": [
-    "growroom"
-  ]
+  }
 }

--- a/data/blueprints/devices/dehumidifier-01.json
+++ b/data/blueprints/devices/dehumidifier-01.json
@@ -1,8 +1,12 @@
 {
   "id": "7a639d3d-4750-440a-a200-f90d11dc3c62",
-  "kind": "Dehumidifier",
+  "slug": "drybox-200",
+  "class": "device.climate.dehumidifier",
   "name": "DryBox 200",
   "placementScope": "zone",
+  "allowedRoomPurposes": [
+    "growroom"
+  ],
   "power_W": 300,
   "efficiency01": 0.6,
   "coverage_m2": 6.67,
@@ -39,8 +43,5 @@
       "Limited capacity for large rooms",
       "Generates heat"
     ]
-  },
-  "allowedRoomPurposes": [
-    "growroom"
-  ]
+  }
 }

--- a/data/blueprints/devices/exhaust_fan_01.json
+++ b/data/blueprints/devices/exhaust_fan_01.json
@@ -1,8 +1,12 @@
 {
   "id": "f5d5c5a0-1b2c-4d3e-8f9a-0b1c2d3e4f5a",
-  "kind": "Ventilation",
+  "slug": "exhaust-fan-4-inch",
+  "class": "device.airflow.exhaust",
   "name": "Exhaust Fan 4-inch",
   "placementScope": "zone",
+  "allowedRoomPurposes": [
+    "growroom"
+  ],
   "power_W": 50,
   "efficiency01": 0.7,
   "coverage_m2": 5,
@@ -42,8 +46,5 @@
       "Relies on ambient temperature for cooling"
     ],
     "notes": "Essential for any small grow setup to prevent heat and humidity buildup without the cost of a full climate unit."
-  },
-  "allowedRoomPurposes": [
-    "growroom"
-  ]
+  }
 }

--- a/data/blueprints/devices/humidity_control_unit_01.json
+++ b/data/blueprints/devices/humidity_control_unit_01.json
@@ -1,8 +1,12 @@
 {
   "id": "3d762260-88a5-4104-b03c-9860bbac34b6",
-  "kind": "HumidityControlUnit",
+  "slug": "humidity-control-unit-l1",
+  "class": "device.climate.humidity-controller",
   "name": "Humidity Control Unit L1",
   "placementScope": "zone",
+  "allowedRoomPurposes": [
+    "growroom"
+  ],
   "power_W": 350,
   "efficiency01": 0.6,
   "coverage_m2": 8.33,
@@ -42,8 +46,5 @@
       "Limited capacity for large rooms",
       "Requires regular maintenance"
     ]
-  },
-  "allowedRoomPurposes": [
-    "growroom"
-  ]
+  }
 }

--- a/data/blueprints/devices/veg_light_01.json
+++ b/data/blueprints/devices/veg_light_01.json
@@ -1,8 +1,12 @@
 {
   "id": "3b5f6ad7-672e-47cd-9a24-f0cc45c4101e",
-  "kind": "Lamp",
+  "slug": "led-veg-light-600",
+  "class": "device.lighting.vegetative",
   "name": "LED VegLight 600",
   "placementScope": "zone",
+  "allowedRoomPurposes": [
+    "growroom"
+  ],
   "power_W": 600,
   "efficiency01": 0.7,
   "coverage_m2": 1.2,
@@ -47,8 +51,5 @@
       "Higher upfront cost compared to HPS"
     ],
     "notes": "Best used in enclosed environments with adequate canopy management."
-  },
-  "allowedRoomPurposes": [
-    "growroom"
-  ]
+  }
 }

--- a/data/blueprints/diseases/anthracnose.json
+++ b/data/blueprints/diseases/anthracnose.json
@@ -1,15 +1,28 @@
 {
   "id": "83c4447f-8439-44cb-84ab-bbed8725e190",
-  "kind": "Disease",
+  "slug": "anthracnose",
+  "class": "disease.fungal.anthracnose",
   "name": "Anthracnose",
   "pathogenType": "fungus",
-  "targets": ["leaves", "stems"],
+  "targets": [
+    "leaves",
+    "stems"
+  ],
   "environmentalRisk": {
-    "idealHumidityRange": [0.6, 0.9],
-    "temperatureRange": [18, 28],
+    "idealHumidityRange": [
+      0.6,
+      0.9
+    ],
+    "temperatureRange": [
+      18,
+      28
+    ],
     "leafWetnessRequired": true
   },
-  "transmission": ["splashingWater", "tools"],
+  "transmission": [
+    "splashingWater",
+    "tools"
+  ],
   "contagious": true,
   "model": {
     "dailyInfectionIncrement": 0.05,
@@ -20,10 +33,18 @@
     "fatalityThreshold": 0.93
   },
   "detection": {
-    "symptoms": ["Dark, sunken lesions on leaves and stems", "Possible spore rings"]
+    "symptoms": [
+      "Dark, sunken lesions on leaves and stems",
+      "Possible spore rings"
+    ]
   },
   "treatments": {
-    "cultural": ["Avoid overhead irrigation", "Disinfect tools"],
-    "mechanical": ["Remove infected shoots"]
+    "cultural": [
+      "Avoid overhead irrigation",
+      "Disinfect tools"
+    ],
+    "mechanical": [
+      "Remove infected shoots"
+    ]
   }
 }

--- a/data/blueprints/diseases/bacterial_leaf_spot.json
+++ b/data/blueprints/diseases/bacterial_leaf_spot.json
@@ -1,15 +1,28 @@
 {
   "id": "c1823c46-47df-4106-a039-88e60a6aa5ed",
-  "kind": "Disease",
+  "slug": "bacterial-leaf-spot",
+  "class": "disease.bacterial.leaf-spot",
   "name": "Bacterial Leaf Spot",
   "pathogenType": "bacteria",
-  "targets": ["leaves"],
+  "targets": [
+    "leaves"
+  ],
   "environmentalRisk": {
-    "idealHumidityRange": [0.6, 0.95],
-    "temperatureRange": [18, 28],
+    "idealHumidityRange": [
+      0.6,
+      0.95
+    ],
+    "temperatureRange": [
+      18,
+      28
+    ],
     "leafWetnessRequired": true
   },
-  "transmission": ["splashingWater", "tools", "workers"],
+  "transmission": [
+    "splashingWater",
+    "tools",
+    "workers"
+  ],
   "contagious": true,
   "model": {
     "dailyInfectionIncrement": 0.06,
@@ -26,7 +39,12 @@
     ]
   },
   "treatments": {
-    "cultural": ["Keep foliage dry", "Disinfect tools"],
-    "mechanical": ["Remove heavily infected leaves"]
+    "cultural": [
+      "Keep foliage dry",
+      "Disinfect tools"
+    ],
+    "mechanical": [
+      "Remove heavily infected leaves"
+    ]
   }
 }

--- a/data/blueprints/diseases/bacterial_wilt.json
+++ b/data/blueprints/diseases/bacterial_wilt.json
@@ -1,15 +1,29 @@
 {
   "id": "01b6d921-88d8-42f0-8009-7111eff56e70",
-  "kind": "Disease",
+  "slug": "bacterial-wilt-erwinia-like",
+  "class": "disease.bacterial.wilt",
   "name": "Bacterial Wilt (Erwinia-like)",
   "pathogenType": "bacteria",
-  "targets": ["stems", "vascular"],
+  "targets": [
+    "stems",
+    "vascular"
+  ],
   "environmentalRisk": {
-    "idealHumidityRange": [0.5, 0.9],
-    "temperatureRange": [20, 30],
+    "idealHumidityRange": [
+      0.5,
+      0.9
+    ],
+    "temperatureRange": [
+      20,
+      30
+    ],
     "woundEntryRisk": 0.8
   },
-  "transmission": ["tools", "substrate", "splashingWater"],
+  "transmission": [
+    "tools",
+    "substrate",
+    "splashingWater"
+  ],
   "contagious": true,
   "model": {
     "dailyInfectionIncrement": 0.07,
@@ -20,10 +34,19 @@
     "fatalityThreshold": 0.96
   },
   "detection": {
-    "symptoms": ["Sudden wilting despite sufficient soil moisture", "Darkened vascular tissue"]
+    "symptoms": [
+      "Sudden wilting despite sufficient soil moisture",
+      "Darkened vascular tissue"
+    ]
   },
   "treatments": {
-    "cultural": ["Avoid wounding", "Increase hygiene", "Maintain low rH"],
-    "mechanical": ["Remove heavily infected plants"]
+    "cultural": [
+      "Avoid wounding",
+      "Increase hygiene",
+      "Maintain low rH"
+    ],
+    "mechanical": [
+      "Remove heavily infected plants"
+    ]
   }
 }

--- a/data/blueprints/diseases/botrytis_gray_mold.json
+++ b/data/blueprints/diseases/botrytis_gray_mold.json
@@ -1,17 +1,31 @@
 {
   "id": "eaca3c76-875c-4ebe-9ea5-c91dc9651f73",
-  "kind": "Disease",
+  "slug": "botrytis-gray-mold-bud-rot",
+  "class": "disease.fungal.botrytis",
   "name": "Botrytis (Gray Mold / Bud Rot)",
   "pathogenType": "fungus",
-  "targets": ["buds", "flowers", "leaves"],
+  "targets": [
+    "buds",
+    "flowers",
+    "leaves"
+  ],
   "environmentalRisk": {
-    "idealHumidityRange": [0.6, 0.9],
-    "temperatureRange": [15, 22],
+    "idealHumidityRange": [
+      0.6,
+      0.9
+    ],
+    "temperatureRange": [
+      15,
+      22
+    ],
     "leafWetnessRequired": true,
     "lowAirflowRisk": 0.8,
     "denseCanopyRisk": 0.85
   },
-  "transmission": ["airborneSpores", "wounds"],
+  "transmission": [
+    "airborneSpores",
+    "wounds"
+  ],
   "contagious": true,
   "model": {
     "dailyInfectionIncrement": 0.08,
@@ -25,10 +39,18 @@
     "budLossFractionPerDay": 0.05
   },
   "detection": {
-    "symptoms": ["Brown-gray, mushy spots inside buds", "Cottony mold growth with musty smell"]
+    "symptoms": [
+      "Brown-gray, mushy spots inside buds",
+      "Cottony mold growth with musty smell"
+    ]
   },
   "treatments": {
-    "cultural": ["Maintain rH < 0.55 in late flowering", "Increase air circulation"],
-    "mechanical": ["Remove affected buds"]
+    "cultural": [
+      "Maintain rH < 0.55 in late flowering",
+      "Increase air circulation"
+    ],
+    "mechanical": [
+      "Remove affected buds"
+    ]
   }
 }

--- a/data/blueprints/diseases/downy_mildew.json
+++ b/data/blueprints/diseases/downy_mildew.json
@@ -1,16 +1,28 @@
 {
   "id": "645b6253-4692-4396-ab6a-f3b02c9783bf",
-  "kind": "Disease",
+  "slug": "downy-mildew",
+  "class": "disease.fungal.downy-mildew",
   "name": "Downy Mildew",
   "pathogenType": "fungus",
-  "targets": ["leaves"],
+  "targets": [
+    "leaves"
+  ],
   "environmentalRisk": {
-    "idealHumidityRange": [0.7, 0.95],
-    "temperatureRange": [15, 24],
+    "idealHumidityRange": [
+      0.7,
+      0.95
+    ],
+    "temperatureRange": [
+      15,
+      24
+    ],
     "leafWetnessRequired": true,
     "lowAirflowRisk": 0.7
   },
-  "transmission": ["airborneSpores", "splashingWater"],
+  "transmission": [
+    "airborneSpores",
+    "splashingWater"
+  ],
   "contagious": true,
   "model": {
     "dailyInfectionIncrement": 0.055,
@@ -21,10 +33,18 @@
     "fatalityThreshold": 0.92
   },
   "detection": {
-    "symptoms": ["Yellowish angular leaf spots", "Gray-white fungal growth on leaf undersides"]
+    "symptoms": [
+      "Yellowish angular leaf spots",
+      "Gray-white fungal growth on leaf undersides"
+    ]
   },
   "treatments": {
-    "cultural": ["Avoid night condensation", "Irrigate during day"],
-    "mechanical": ["Remove infected leaves"]
+    "cultural": [
+      "Avoid night condensation",
+      "Irrigate during day"
+    ],
+    "mechanical": [
+      "Remove infected leaves"
+    ]
   }
 }

--- a/data/blueprints/diseases/hop_latent_viroid.json
+++ b/data/blueprints/diseases/hop_latent_viroid.json
@@ -1,13 +1,23 @@
 {
   "id": "259acd2f-d4af-49dd-8f0e-450c3045aea1",
-  "kind": "Disease",
+  "slug": "hop-latent-viroid-hplvd",
+  "class": "disease.viroid.hlvd",
   "name": "Hop Latent Viroid (HpLVd)",
   "pathogenType": "viroid",
-  "targets": ["systemic"],
+  "targets": [
+    "systemic"
+  ],
   "environmentalRisk": {
-    "temperatureRange": [18, 28]
+    "temperatureRange": [
+      18,
+      28
+    ]
   },
-  "transmission": ["clones", "sap", "tools"],
+  "transmission": [
+    "clones",
+    "sap",
+    "tools"
+  ],
   "contagious": true,
   "model": {
     "dailyInfectionIncrement": 0.03,
@@ -24,7 +34,12 @@
     ]
   },
   "treatments": {
-    "cultural": ["Use tested clones only", "Strict tool hygiene"],
-    "mechanical": ["Screen and remove infected mother plants"]
+    "cultural": [
+      "Use tested clones only",
+      "Strict tool hygiene"
+    ],
+    "mechanical": [
+      "Screen and remove infected mother plants"
+    ]
   }
 }

--- a/data/blueprints/diseases/mosaic_virus.json
+++ b/data/blueprints/diseases/mosaic_virus.json
@@ -1,13 +1,24 @@
 {
   "id": "da9b207b-3aeb-4784-875e-bbee1e27ced9",
-  "kind": "Disease",
+  "slug": "mosaic-virus-tmv-cmv-like",
+  "class": "disease.viral.mosaic",
   "name": "Mosaic Virus (TMV/CMV-like)",
   "pathogenType": "virus",
-  "targets": ["leaves", "systemic"],
+  "targets": [
+    "leaves",
+    "systemic"
+  ],
   "environmentalRisk": {
-    "temperatureRange": [18, 28]
+    "temperatureRange": [
+      18,
+      28
+    ]
   },
-  "transmission": ["sap", "tools", "pests"],
+  "transmission": [
+    "sap",
+    "tools",
+    "pests"
+  ],
   "contagious": true,
   "model": {
     "dailyInfectionIncrement": 0.04,
@@ -24,7 +35,12 @@
     ]
   },
   "treatments": {
-    "cultural": ["Use pathogen-free plant material", "Disinfect tools"],
-    "mechanical": ["Remove infected plants"]
+    "cultural": [
+      "Use pathogen-free plant material",
+      "Disinfect tools"
+    ],
+    "mechanical": [
+      "Remove infected plants"
+    ]
   }
 }

--- a/data/blueprints/diseases/powdery_mildew.json
+++ b/data/blueprints/diseases/powdery_mildew.json
@@ -1,17 +1,31 @@
 {
   "id": "818bc83c-0a18-47c5-b861-c378181b0812",
-  "kind": "Disease",
+  "slug": "powdery-mildew",
+  "class": "disease.fungal.powdery-mildew",
   "name": "Powdery Mildew",
   "pathogenType": "fungus",
-  "targets": ["leaves", "stems"],
+  "targets": [
+    "leaves",
+    "stems"
+  ],
   "environmentalRisk": {
-    "idealHumidityRange": [0.5, 0.7],
-    "temperatureRange": [20, 28],
+    "idealHumidityRange": [
+      0.5,
+      0.7
+    ],
+    "temperatureRange": [
+      20,
+      28
+    ],
     "leafWetnessRequired": false,
     "lowAirflowRisk": 0.8,
     "overcrowdingRisk": 0.7
   },
-  "transmission": ["airborneSpores", "tools", "workers"],
+  "transmission": [
+    "airborneSpores",
+    "tools",
+    "workers"
+  ],
   "contagious": true,
   "model": {
     "dailyInfectionIncrement": 0.06,
@@ -22,15 +36,27 @@
     "fatalityThreshold": 0.9
   },
   "detection": {
-    "symptoms": ["White, powdery coating on leaf surfaces", "Yellowish spots leading to necrosis"],
+    "symptoms": [
+      "White, powdery coating on leaf surfaces",
+      "Yellowish spots leading to necrosis"
+    ],
     "scoutingHints": [
       "Inspect leaf surfaces in dense canopies",
       "Check during humidity fluctuations"
     ]
   },
   "treatments": {
-    "cultural": ["Increase air circulation", "Prune dense leaves", "Avoid humidity spikes"],
-    "biological": ["Bacillus subtilis", "Low-dose sulfur sprays"],
-    "mechanical": ["Remove heavily infected leaves"]
+    "cultural": [
+      "Increase air circulation",
+      "Prune dense leaves",
+      "Avoid humidity spikes"
+    ],
+    "biological": [
+      "Bacillus subtilis",
+      "Low-dose sulfur sprays"
+    ],
+    "mechanical": [
+      "Remove heavily infected leaves"
+    ]
   }
 }

--- a/data/blueprints/diseases/root_rot.json
+++ b/data/blueprints/diseases/root_rot.json
@@ -1,16 +1,30 @@
 {
   "id": "55741064-9052-407f-8fbe-9eb3690ff851",
-  "kind": "Disease",
+  "slug": "root-rot-pythium-fusarium-rhizoctonia",
+  "class": "disease.fungal.root-rot",
   "name": "Root Rot (Pythium/Fusarium/Rhizoctonia)",
   "pathogenType": "fungus-complex",
-  "targets": ["roots", "crown"],
+  "targets": [
+    "roots",
+    "crown"
+  ],
   "environmentalRisk": {
-    "idealHumidityRange": [0.4, 0.7],
-    "temperatureRange": [18, 26],
+    "idealHumidityRange": [
+      0.4,
+      0.7
+    ],
+    "temperatureRange": [
+      18,
+      26
+    ],
     "substrateWaterloggingRisk": 0.9,
     "poorDrainageRisk": 0.85
   },
-  "transmission": ["contaminatedWater", "substrate", "tools"],
+  "transmission": [
+    "contaminatedWater",
+    "substrate",
+    "tools"
+  ],
   "contagious": true,
   "model": {
     "dailyInfectionIncrement": 0.07,
@@ -21,11 +35,22 @@
     "fatalityThreshold": 0.98
   },
   "detection": {
-    "symptoms": ["Plants wilting despite wet soil", "Brown, slimy roots with foul smell"]
+    "symptoms": [
+      "Plants wilting despite wet soil",
+      "Brown, slimy roots with foul smell"
+    ]
   },
   "treatments": {
-    "cultural": ["Avoid overwatering", "Improve drainage", "Extend irrigation intervals"],
-    "biological": ["Trichoderma spp."],
-    "mechanical": ["Remove heavily affected plants"]
+    "cultural": [
+      "Avoid overwatering",
+      "Improve drainage",
+      "Extend irrigation intervals"
+    ],
+    "biological": [
+      "Trichoderma spp."
+    ],
+    "mechanical": [
+      "Remove heavily affected plants"
+    ]
   }
 }

--- a/data/blueprints/irrigationMethods/drip-inline-fertigation-basic.json
+++ b/data/blueprints/irrigationMethods/drip-inline-fertigation-basic.json
@@ -1,8 +1,8 @@
 {
   "id": "c8f3a2b1-7d4e-4c9a-b5e6-3f8a9c1d2e4f",
   "slug": "drip-inline-fertigation-basic",
+  "class": "irrigation.drip.inline-fertigation",
   "name": "Drip Inline Fertigation (Basic)",
-  "kind": "DripSystem",
   "description": "Automated drip irrigation with inline nutrient injection. Balanced labor and uniformity.",
   "mixing": "inline",
   "couplesFertilizer": true,
@@ -21,8 +21,16 @@
     "minPressure_bar": 1.5
   },
   "compatibility": {
-    "substrates": ["soil", "coco", "rockwool"],
-    "methods": ["sog", "scrog", "basic_soil_pot"]
+    "substrates": [
+      "soil",
+      "coco",
+      "rockwool"
+    ],
+    "methods": [
+      "sog",
+      "scrog",
+      "basic_soil_pot"
+    ]
   },
   "maintenance": {
     "inspectionEveryDays": 7,

--- a/data/blueprints/irrigationMethods/ebb-flow-table-small.json
+++ b/data/blueprints/irrigationMethods/ebb-flow-table-small.json
@@ -1,8 +1,8 @@
 {
   "id": "d9e4b3c2-8e5f-5d0b-c6f7-4g9b0d2e3f5g",
   "slug": "ebb-flow-table-small",
+  "class": "irrigation.ebb-flow.table",
   "name": "Ebb & Flow Table (Small)",
-  "kind": "EbbFlow",
   "description": "Flood-and-drain table system with batch nutrient mixing. High uniformity, moderate labor.",
   "mixing": "batch",
   "couplesFertilizer": true,
@@ -21,8 +21,15 @@
     "minPressure_bar": 0.5
   },
   "compatibility": {
-    "substrates": ["coco", "rockwool", "perlite"],
-    "methods": ["sog", "scrog"]
+    "substrates": [
+      "coco",
+      "rockwool",
+      "perlite"
+    ],
+    "methods": [
+      "sog",
+      "scrog"
+    ]
   },
   "maintenance": {
     "inspectionEveryDays": 10,

--- a/data/blueprints/irrigationMethods/manual-watering-can.json
+++ b/data/blueprints/irrigationMethods/manual-watering-can.json
@@ -1,8 +1,8 @@
 {
   "id": "b7a5d5fa-6561-4a1c-93c8-2d3f9a11c201",
   "slug": "manual-watering-can",
+  "class": "irrigation.manual.can",
   "name": "Watering Can",
-  "kind": "ManualCan",
   "description": "Hand watering with premixed nutrients; highest labor, lowest capex.",
   "mixing": "batch",
   "couplesFertilizer": true,
@@ -21,8 +21,15 @@
     "minPressure_bar": 0
   },
   "compatibility": {
-    "substrates": ["soil", "coco"],
-    "methods": ["sog", "scrog", "basic_soil_pot"]
+    "substrates": [
+      "soil",
+      "coco"
+    ],
+    "methods": [
+      "sog",
+      "scrog",
+      "basic_soil_pot"
+    ]
   },
   "maintenance": {
     "inspectionEveryDays": 14,

--- a/data/blueprints/irrigationMethods/top-feed-pump-timer.json
+++ b/data/blueprints/irrigationMethods/top-feed-pump-timer.json
@@ -1,8 +1,8 @@
 {
   "id": "e0f5c4d3-9f6g-6e1c-d7g8-5h0c1e3f4g6h",
   "slug": "top-feed-pump-timer",
+  "class": "irrigation.top-feed.timer",
   "name": "Top-Feed Pump (Timer)",
-  "kind": "TopFeed",
   "description": "Timer-controlled top-feed system with batch nutrient mixing. Automated delivery with moderate uniformity.",
   "mixing": "batch",
   "couplesFertilizer": true,
@@ -21,8 +21,16 @@
     "minPressure_bar": 0.8
   },
   "compatibility": {
-    "substrates": ["soil", "coco", "perlite"],
-    "methods": ["sog", "scrog", "basic_soil_pot"]
+    "substrates": [
+      "soil",
+      "coco",
+      "perlite"
+    ],
+    "methods": [
+      "sog",
+      "scrog",
+      "basic_soil_pot"
+    ]
   },
   "maintenance": {
     "inspectionEveryDays": 7,

--- a/data/blueprints/personnel/roles/Gardener.json
+++ b/data/blueprints/personnel/roles/Gardener.json
@@ -1,11 +1,25 @@
 {
   "id": "Gardener",
+  "slug": "gardener",
+  "class": "personnel.role.gardener",
   "name": "Gardener",
   "salary": {
     "basePerTick": 24,
-    "skillFactor": { "base": 0.85, "perPoint": 0.04, "min": 0.85, "max": 1.45 },
-    "randomRange": { "min": 0.9, "max": 1.1 },
-    "skillWeights": { "primary": 1.2, "secondary": 0.6, "tertiary": 0.35 }
+    "skillFactor": {
+      "base": 0.85,
+      "perPoint": 0.04,
+      "min": 0.85,
+      "max": 1.45
+    },
+    "randomRange": {
+      "min": 0.9,
+      "max": 1.1
+    },
+    "skillWeights": {
+      "primary": 1.2,
+      "secondary": 0.6,
+      "tertiary": 0.35
+    }
   },
   "maxMinutesPerTick": 90,
   "roleWeight": 0.35,
@@ -13,20 +27,38 @@
     "primary": {
       "skill": "Gardening",
       "startingLevel": 4,
-      "roll": { "min": 3, "max": 5 }
+      "roll": {
+        "min": 3,
+        "max": 5
+      }
     },
     "secondary": {
       "skill": "Cleanliness",
       "startingLevel": 2,
-      "roll": { "min": 1, "max": 4 }
+      "roll": {
+        "min": 1,
+        "max": 4
+      }
     },
     "tertiary": {
       "chance": 0.25,
-      "roll": { "min": 1, "max": 3 },
+      "roll": {
+        "min": 1,
+        "max": 3
+      },
       "candidates": [
-        { "skill": "Logistics", "startingLevel": 1 },
-        { "skill": "Administration", "startingLevel": 1 },
-        { "skill": "Maintenance", "startingLevel": 1 }
+        {
+          "skill": "Logistics",
+          "startingLevel": 1
+        },
+        {
+          "skill": "Administration",
+          "startingLevel": 1
+        },
+        {
+          "skill": "Maintenance",
+          "startingLevel": 1
+        }
       ]
     }
   }

--- a/data/blueprints/personnel/roles/Janitor.json
+++ b/data/blueprints/personnel/roles/Janitor.json
@@ -1,11 +1,25 @@
 {
   "id": "Janitor",
+  "slug": "janitor",
+  "class": "personnel.role.janitor",
   "name": "Janitor",
   "salary": {
     "basePerTick": 18,
-    "skillFactor": { "base": 0.85, "perPoint": 0.04, "min": 0.85, "max": 1.45 },
-    "randomRange": { "min": 0.88, "max": 1.08 },
-    "skillWeights": { "primary": 1.1, "secondary": 0.55, "tertiary": 0.3 }
+    "skillFactor": {
+      "base": 0.85,
+      "perPoint": 0.04,
+      "min": 0.85,
+      "max": 1.45
+    },
+    "randomRange": {
+      "min": 0.88,
+      "max": 1.08
+    },
+    "skillWeights": {
+      "primary": 1.1,
+      "secondary": 0.55,
+      "tertiary": 0.3
+    }
   },
   "maxMinutesPerTick": 75,
   "preferredShiftId": "shift.night",
@@ -14,20 +28,38 @@
     "primary": {
       "skill": "Cleanliness",
       "startingLevel": 4,
-      "roll": { "min": 3, "max": 5 }
+      "roll": {
+        "min": 3,
+        "max": 5
+      }
     },
     "secondary": {
       "skill": "Logistics",
       "startingLevel": 1,
-      "roll": { "min": 0, "max": 3 }
+      "roll": {
+        "min": 0,
+        "max": 3
+      }
     },
     "tertiary": {
       "chance": 0.3,
-      "roll": { "min": 1, "max": 3 },
+      "roll": {
+        "min": 1,
+        "max": 3
+      },
       "candidates": [
-        { "skill": "Administration", "startingLevel": 1 },
-        { "skill": "Gardening", "startingLevel": 1 },
-        { "skill": "Maintenance", "startingLevel": 1 }
+        {
+          "skill": "Administration",
+          "startingLevel": 1
+        },
+        {
+          "skill": "Gardening",
+          "startingLevel": 1
+        },
+        {
+          "skill": "Maintenance",
+          "startingLevel": 1
+        }
       ]
     }
   }

--- a/data/blueprints/personnel/roles/Manager.json
+++ b/data/blueprints/personnel/roles/Manager.json
@@ -1,11 +1,25 @@
 {
   "id": "Manager",
+  "slug": "manager",
+  "class": "personnel.role.manager",
   "name": "Manager",
   "salary": {
     "basePerTick": 35,
-    "skillFactor": { "base": 0.85, "perPoint": 0.04, "min": 0.85, "max": 1.5 },
-    "randomRange": { "min": 0.95, "max": 1.18 },
-    "skillWeights": { "primary": 1.3, "secondary": 0.7, "tertiary": 0.45 }
+    "skillFactor": {
+      "base": 0.85,
+      "perPoint": 0.04,
+      "min": 0.85,
+      "max": 1.5
+    },
+    "randomRange": {
+      "min": 0.95,
+      "max": 1.18
+    },
+    "skillWeights": {
+      "primary": 1.3,
+      "secondary": 0.7,
+      "tertiary": 0.45
+    }
   },
   "maxMinutesPerTick": 60,
   "preferredShiftId": "shift.day",
@@ -14,17 +28,32 @@
     "primary": {
       "skill": "Administration",
       "startingLevel": 4,
-      "roll": { "min": 3, "max": 5 }
+      "roll": {
+        "min": 3,
+        "max": 5
+      }
     },
     "secondary": {
       "skill": "Logistics",
       "startingLevel": 2,
-      "roll": { "min": 1, "max": 4 }
+      "roll": {
+        "min": 1,
+        "max": 4
+      }
     },
     "tertiary": {
       "chance": 0.4,
-      "roll": { "min": 1, "max": 3 },
-      "candidates": [{ "skill": "Cleanliness", "startingLevel": 2, "weight": 2 }]
+      "roll": {
+        "min": 1,
+        "max": 3
+      },
+      "candidates": [
+        {
+          "skill": "Cleanliness",
+          "startingLevel": 2,
+          "weight": 2
+        }
+      ]
     }
   }
 }

--- a/data/blueprints/personnel/roles/Operator.json
+++ b/data/blueprints/personnel/roles/Operator.json
@@ -1,11 +1,25 @@
 {
   "id": "Operator",
+  "slug": "operator",
+  "class": "personnel.role.operator",
   "name": "Operator",
   "salary": {
     "basePerTick": 22,
-    "skillFactor": { "base": 0.85, "perPoint": 0.04, "min": 0.85, "max": 1.45 },
-    "randomRange": { "min": 0.9, "max": 1.1 },
-    "skillWeights": { "primary": 1.15, "secondary": 0.6, "tertiary": 0.35 }
+    "skillFactor": {
+      "base": 0.85,
+      "perPoint": 0.04,
+      "min": 0.85,
+      "max": 1.45
+    },
+    "randomRange": {
+      "min": 0.9,
+      "max": 1.1
+    },
+    "skillWeights": {
+      "primary": 1.15,
+      "secondary": 0.6,
+      "tertiary": 0.35
+    }
   },
   "maxMinutesPerTick": 90,
   "preferredShiftId": "shift.day",
@@ -14,20 +28,38 @@
     "primary": {
       "skill": "Logistics",
       "startingLevel": 3,
-      "roll": { "min": 2, "max": 4 }
+      "roll": {
+        "min": 2,
+        "max": 4
+      }
     },
     "secondary": {
       "skill": "Administration",
       "startingLevel": 2,
-      "roll": { "min": 1, "max": 4 }
+      "roll": {
+        "min": 1,
+        "max": 4
+      }
     },
     "tertiary": {
       "chance": 0.25,
-      "roll": { "min": 1, "max": 3 },
+      "roll": {
+        "min": 1,
+        "max": 3
+      },
       "candidates": [
-        { "skill": "Cleanliness", "startingLevel": 1 },
-        { "skill": "Gardening", "startingLevel": 1 },
-        { "skill": "Maintenance", "startingLevel": 1 }
+        {
+          "skill": "Cleanliness",
+          "startingLevel": 1
+        },
+        {
+          "skill": "Gardening",
+          "startingLevel": 1
+        },
+        {
+          "skill": "Maintenance",
+          "startingLevel": 1
+        }
       ]
     }
   }

--- a/data/blueprints/personnel/roles/Technician.json
+++ b/data/blueprints/personnel/roles/Technician.json
@@ -1,11 +1,25 @@
 {
   "id": "Technician",
+  "slug": "technician",
+  "class": "personnel.role.technician",
   "name": "Technician",
   "salary": {
     "basePerTick": 28,
-    "skillFactor": { "base": 0.85, "perPoint": 0.04, "min": 0.85, "max": 1.45 },
-    "randomRange": { "min": 0.9, "max": 1.12 },
-    "skillWeights": { "primary": 1.25, "secondary": 0.65, "tertiary": 0.4 }
+    "skillFactor": {
+      "base": 0.85,
+      "perPoint": 0.04,
+      "min": 0.85,
+      "max": 1.45
+    },
+    "randomRange": {
+      "min": 0.9,
+      "max": 1.12
+    },
+    "skillWeights": {
+      "primary": 1.25,
+      "secondary": 0.65,
+      "tertiary": 0.4
+    }
   },
   "maxMinutesPerTick": 120,
   "roleWeight": 0.2,
@@ -13,20 +27,38 @@
     "primary": {
       "skill": "Maintenance",
       "startingLevel": 4,
-      "roll": { "min": 3, "max": 5 }
+      "roll": {
+        "min": 3,
+        "max": 5
+      }
     },
     "secondary": {
       "skill": "Logistics",
       "startingLevel": 2,
-      "roll": { "min": 1, "max": 4 }
+      "roll": {
+        "min": 1,
+        "max": 4
+      }
     },
     "tertiary": {
       "chance": 0.25,
-      "roll": { "min": 1, "max": 3 },
+      "roll": {
+        "min": 1,
+        "max": 3
+      },
       "candidates": [
-        { "skill": "Gardening", "startingLevel": 1 },
-        { "skill": "Administration", "startingLevel": 1 },
-        { "skill": "Cleanliness", "startingLevel": 1 }
+        {
+          "skill": "Gardening",
+          "startingLevel": 1
+        },
+        {
+          "skill": "Administration",
+          "startingLevel": 1
+        },
+        {
+          "skill": "Cleanliness",
+          "startingLevel": 1
+        }
       ]
     }
   }

--- a/data/blueprints/personnel/skills/Administration.json
+++ b/data/blueprints/personnel/skills/Administration.json
@@ -1,6 +1,11 @@
 {
   "id": "Administration",
+  "slug": "administration",
+  "class": "personnel.skill.administration",
   "name": "Administration",
   "description": "Planning, reporting, compliance oversight, and documentation workflows.",
-  "tags": ["management", "compliance"]
+  "tags": [
+    "management",
+    "compliance"
+  ]
 }

--- a/data/blueprints/personnel/skills/Cleanliness.json
+++ b/data/blueprints/personnel/skills/Cleanliness.json
@@ -1,6 +1,11 @@
 {
   "id": "Cleanliness",
+  "slug": "cleanliness",
+  "class": "personnel.skill.cleanliness",
   "name": "Cleanliness",
   "description": "Sanitation, hygiene, and compliance routines across rooms and devices.",
-  "tags": ["quality", "safety"]
+  "tags": [
+    "quality",
+    "safety"
+  ]
 }

--- a/data/blueprints/personnel/skills/Gardening.json
+++ b/data/blueprints/personnel/skills/Gardening.json
@@ -1,6 +1,10 @@
 {
   "id": "Gardening",
+  "slug": "gardening",
+  "class": "personnel.skill.gardening",
   "name": "Gardening",
   "description": "Plant care, canopy management, pruning, and phenology adjustments.",
-  "tags": ["cultivation"]
+  "tags": [
+    "cultivation"
+  ]
 }

--- a/data/blueprints/personnel/skills/Logistics.json
+++ b/data/blueprints/personnel/skills/Logistics.json
@@ -1,6 +1,10 @@
 {
   "id": "Logistics",
+  "slug": "logistics",
+  "class": "personnel.skill.logistics",
   "name": "Logistics",
   "description": "Inventory stewardship, material handling, and production scheduling.",
-  "tags": ["operations"]
+  "tags": [
+    "operations"
+  ]
 }

--- a/data/blueprints/personnel/skills/Maintenance.json
+++ b/data/blueprints/personnel/skills/Maintenance.json
@@ -1,6 +1,11 @@
 {
   "id": "Maintenance",
+  "slug": "maintenance",
+  "class": "personnel.skill.maintenance",
   "name": "Maintenance",
   "description": "Device diagnostics, preventive maintenance, and facility upkeep routines.",
-  "tags": ["operations", "technical"]
+  "tags": [
+    "operations",
+    "technical"
+  ]
 }

--- a/data/blueprints/pests/aphids.json
+++ b/data/blueprints/pests/aphids.json
@@ -1,12 +1,22 @@
 {
   "id": "90fd2899-4563-468d-9e32-500a75ce9275",
-  "kind": "Pest",
+  "slug": "aphids",
+  "class": "pest.insect.aphid",
   "name": "Aphids",
   "category": "sap-sucking",
-  "targets": ["leaves", "stems"],
+  "targets": [
+    "leaves",
+    "stems"
+  ],
   "environmentalRisk": {
-    "temperatureRange": [18, 28],
-    "humidityRange": [0.4, 0.8]
+    "temperatureRange": [
+      18,
+      28
+    ],
+    "humidityRange": [
+      0.4,
+      0.8
+    ]
   },
   "populationDynamics": {
     "dailyReproductionRate": 0.32,
@@ -26,12 +36,27 @@
       "Sticky honeydew leading to sooty mold",
       "Leaf curling"
     ],
-    "monitoring": ["Yellow sticky cards", "Visual scouting on new growth"]
+    "monitoring": [
+      "Yellow sticky cards",
+      "Visual scouting on new growth"
+    ]
   },
   "controlOptions": {
-    "biological": ["Lady beetles (Coccinellidae)", "Aphidius parasitoids"],
-    "cultural": ["Remove infested shoots", "Avoid over-fertilizing with N"],
-    "mechanical": ["Water jet dislodging", "Pruning"],
-    "chemical": ["Soaps and oils", "Azadirachtin (where compliant)"]
+    "biological": [
+      "Lady beetles (Coccinellidae)",
+      "Aphidius parasitoids"
+    ],
+    "cultural": [
+      "Remove infested shoots",
+      "Avoid over-fertilizing with N"
+    ],
+    "mechanical": [
+      "Water jet dislodging",
+      "Pruning"
+    ],
+    "chemical": [
+      "Soaps and oils",
+      "Azadirachtin (where compliant)"
+    ]
   }
 }

--- a/data/blueprints/pests/broad_mites.json
+++ b/data/blueprints/pests/broad_mites.json
@@ -1,12 +1,23 @@
 {
   "id": "2c574211-0e96-44f1-82ee-327056ac5fcb",
-  "kind": "Pest",
+  "slug": "broad-mites-russet-mites",
+  "class": "pest.mite.broad",
   "name": "Broad Mites / Russet Mites",
   "category": "sap-sucking",
-  "targets": ["meristems", "flowers", "leaves"],
+  "targets": [
+    "meristems",
+    "flowers",
+    "leaves"
+  ],
   "environmentalRisk": {
-    "temperatureRange": [20, 28],
-    "humidityRange": [0.4, 0.8]
+    "temperatureRange": [
+      20,
+      28
+    ],
+    "humidityRange": [
+      0.4,
+      0.8
+    ]
   },
   "populationDynamics": {
     "dailyReproductionRate": 0.33,
@@ -26,12 +37,24 @@
       "Bronzed, rough leaf surfaces",
       "Flower deformities"
     ],
-    "monitoring": ["High-magnification scope (≥60x) on meristems", "Sentinel plants in hotspots"]
+    "monitoring": [
+      "High-magnification scope (\u226560x) on meristems",
+      "Sentinel plants in hotspots"
+    ]
   },
   "controlOptions": {
-    "biological": ["Predatory mites (Amblyseius swirskii, A. andersoni)"],
-    "cultural": ["Quarantine and destroy heavily infested stock", "Strict sanitation"],
-    "mechanical": ["Remove infested tips"],
-    "chemical": ["Targeted miticides where compliant; rotate modes"]
+    "biological": [
+      "Predatory mites (Amblyseius swirskii, A. andersoni)"
+    ],
+    "cultural": [
+      "Quarantine and destroy heavily infested stock",
+      "Strict sanitation"
+    ],
+    "mechanical": [
+      "Remove infested tips"
+    ],
+    "chemical": [
+      "Targeted miticides where compliant; rotate modes"
+    ]
   }
 }

--- a/data/blueprints/pests/caterpillars.json
+++ b/data/blueprints/pests/caterpillars.json
@@ -1,12 +1,22 @@
 {
   "id": "2335b750-3c2a-4540-a44c-3d510036bafd",
-  "kind": "Pest",
+  "slug": "caterpillars",
+  "class": "pest.insect.caterpillar",
   "name": "Caterpillars",
   "category": "chewing",
-  "targets": ["leaves", "buds"],
+  "targets": [
+    "leaves",
+    "buds"
+  ],
   "environmentalRisk": {
-    "temperatureRange": [18, 30],
-    "humidityRange": [0.4, 0.8]
+    "temperatureRange": [
+      18,
+      30
+    ],
+    "humidityRange": [
+      0.4,
+      0.8
+    ]
   },
   "populationDynamics": {
     "dailyReproductionRate": 0.2,
@@ -26,12 +36,25 @@
       "Holes and tunnels in buds",
       "Secondary bud rot (Botrytis)"
     ],
-    "monitoring": ["Blacklight scouting outdoors", "Pheromone traps where available"]
+    "monitoring": [
+      "Blacklight scouting outdoors",
+      "Pheromone traps where available"
+    ]
   },
   "controlOptions": {
-    "biological": ["Bacillus thuringiensis kurstaki (Btk)", "Trichogramma wasps"],
-    "cultural": ["Remove plant debris", "Timing: treat early instars"],
-    "mechanical": ["Hand-pick, inspect buds"],
-    "chemical": ["Selective stomach poisons (where allowed)"]
+    "biological": [
+      "Bacillus thuringiensis kurstaki (Btk)",
+      "Trichogramma wasps"
+    ],
+    "cultural": [
+      "Remove plant debris",
+      "Timing: treat early instars"
+    ],
+    "mechanical": [
+      "Hand-pick, inspect buds"
+    ],
+    "chemical": [
+      "Selective stomach poisons (where allowed)"
+    ]
   }
 }

--- a/data/blueprints/pests/fungus_gnats.json
+++ b/data/blueprints/pests/fungus_gnats.json
@@ -1,12 +1,22 @@
 {
   "id": "33fc7bb4-9ca1-42e8-8d70-8267f8b6abe3",
-  "kind": "Pest",
+  "slug": "fungus-gnats",
+  "class": "pest.insect.fungus-gnat",
   "name": "Fungus Gnats",
   "category": "soil-dwelling",
-  "targets": ["roots", "substrate"],
+  "targets": [
+    "roots",
+    "substrate"
+  ],
   "environmentalRisk": {
-    "temperatureRange": [18, 26],
-    "humidityRange": [0.5, 0.9],
+    "temperatureRange": [
+      18,
+      26
+    ],
+    "humidityRange": [
+      0.5,
+      0.9
+    ],
     "overwateringRisk": 0.9
   },
   "populationDynamics": {
@@ -27,12 +37,26 @@
       "Larvae feed on roots causing stunting",
       "Algae growth on wet media"
     ],
-    "monitoring": ["Yellow sticky cards at substrate level", "Potato slice test for larvae"]
+    "monitoring": [
+      "Yellow sticky cards at substrate level",
+      "Potato slice test for larvae"
+    ]
   },
   "controlOptions": {
-    "biological": ["Steinernema feltiae (nematodes)", "Bacillus thuringiensis israelensis (Bti)"],
-    "cultural": ["Dry-down cycles", "Improve drainage", "Avoid algae"],
-    "mechanical": ["Top-dress with sand/perlite layer"],
-    "chemical": ["H2O2 drenches (careful), compliant larvicides where allowed"]
+    "biological": [
+      "Steinernema feltiae (nematodes)",
+      "Bacillus thuringiensis israelensis (Bti)"
+    ],
+    "cultural": [
+      "Dry-down cycles",
+      "Improve drainage",
+      "Avoid algae"
+    ],
+    "mechanical": [
+      "Top-dress with sand/perlite layer"
+    ],
+    "chemical": [
+      "H2O2 drenches (careful), compliant larvicides where allowed"
+    ]
   }
 }

--- a/data/blueprints/pests/root_aphids.json
+++ b/data/blueprints/pests/root_aphids.json
@@ -1,12 +1,21 @@
 {
   "id": "1946a4a4-e2c7-494b-8777-7beffafcffba",
-  "kind": "Pest",
+  "slug": "root-aphids",
+  "class": "pest.insect.root-aphid",
   "name": "Root Aphids",
   "category": "sap-sucking",
-  "targets": ["roots"],
+  "targets": [
+    "roots"
+  ],
   "environmentalRisk": {
-    "temperatureRange": [18, 26],
-    "humidityRange": [0.5, 0.9],
+    "temperatureRange": [
+      18,
+      26
+    ],
+    "humidityRange": [
+      0.5,
+      0.9
+    ],
     "overfertilizationRisk": 0.5
   },
   "populationDynamics": {
@@ -27,12 +36,24 @@
       "White waxy residue on roots",
       "Poor response to fertilization"
     ],
-    "monitoring": ["Root inspections during repotting", "Yellow sticky cards at substrate level"]
+    "monitoring": [
+      "Root inspections during repotting",
+      "Yellow sticky cards at substrate level"
+    ]
   },
   "controlOptions": {
-    "biological": ["Beneficial nematodes (Steinernema/ Heterorhabditis)"],
-    "cultural": ["Avoid overwatering and excess N", "Sterilize media/tools"],
-    "mechanical": ["Discard heavily infested media"],
-    "chemical": ["Drenches permitted by regulation (jurisdiction-dependent)"]
+    "biological": [
+      "Beneficial nematodes (Steinernema/ Heterorhabditis)"
+    ],
+    "cultural": [
+      "Avoid overwatering and excess N",
+      "Sterilize media/tools"
+    ],
+    "mechanical": [
+      "Discard heavily infested media"
+    ],
+    "chemical": [
+      "Drenches permitted by regulation (jurisdiction-dependent)"
+    ]
   }
 }

--- a/data/blueprints/pests/spider_mites.json
+++ b/data/blueprints/pests/spider_mites.json
@@ -1,12 +1,22 @@
 {
   "id": "7a887ad2-34ed-4284-9c86-b573aadffdb9",
-  "kind": "Pest",
+  "slug": "spider-mites",
+  "class": "pest.mite.spider",
   "name": "Spider Mites",
   "category": "sap-sucking",
-  "targets": ["leaves", "stems"],
+  "targets": [
+    "leaves",
+    "stems"
+  ],
   "environmentalRisk": {
-    "temperatureRange": [24, 32],
-    "humidityRange": [0.3, 0.6],
+    "temperatureRange": [
+      24,
+      32
+    ],
+    "humidityRange": [
+      0.3,
+      0.6
+    ],
     "lowAirflowRisk": 0.6,
     "dustyCanopyRisk": 0.5
   },
@@ -28,12 +38,26 @@
       "Webbing under leaves at high density",
       "Leaves bronzing and drying out"
     ],
-    "monitoring": ["Use hand lens (≥40x) under leaves", "Sticky traps for presence trends"]
+    "monitoring": [
+      "Use hand lens (\u226540x) under leaves",
+      "Sticky traps for presence trends"
+    ]
   },
   "controlOptions": {
-    "biological": ["Predatory mites (Phytoseiulus persimilis, Amblyseius californicus)"],
-    "cultural": ["Increase humidity short-term", "Improve airflow", "Quarantine new plants"],
-    "mechanical": ["Rinse undersides, remove heavily infested leaves"],
-    "chemical": ["Horticultural oils", "Soaps (rotate actives to avoid resistance)"]
+    "biological": [
+      "Predatory mites (Phytoseiulus persimilis, Amblyseius californicus)"
+    ],
+    "cultural": [
+      "Increase humidity short-term",
+      "Improve airflow",
+      "Quarantine new plants"
+    ],
+    "mechanical": [
+      "Rinse undersides, remove heavily infested leaves"
+    ],
+    "chemical": [
+      "Horticultural oils",
+      "Soaps (rotate actives to avoid resistance)"
+    ]
   }
 }

--- a/data/blueprints/pests/thrips.json
+++ b/data/blueprints/pests/thrips.json
@@ -1,12 +1,22 @@
 {
   "id": "4bb767d7-403e-49c9-aa10-b957dfc0e881",
-  "kind": "Pest",
+  "slug": "thrips",
+  "class": "pest.insect.thrips",
   "name": "Thrips",
   "category": "sap-sucking",
-  "targets": ["leaves", "flowers"],
+  "targets": [
+    "leaves",
+    "flowers"
+  ],
   "environmentalRisk": {
-    "temperatureRange": [20, 30],
-    "humidityRange": [0.3, 0.7]
+    "temperatureRange": [
+      20,
+      30
+    ],
+    "humidityRange": [
+      0.3,
+      0.7
+    ]
   },
   "populationDynamics": {
     "dailyReproductionRate": 0.3,
@@ -26,12 +36,26 @@
       "Black fecal spots",
       "Distorted new growth"
     ],
-    "monitoring": ["Blue sticky cards near canopy", "Tap test over white paper"]
+    "monitoring": [
+      "Blue sticky cards near canopy",
+      "Tap test over white paper"
+    ]
   },
   "controlOptions": {
-    "biological": ["Orius spp.", "Amblyseius cucumeris"],
-    "cultural": ["Remove weeds/volunteers", "Screen intakes"],
-    "mechanical": ["Sticky cards mass-trapping"],
-    "chemical": ["Spinosad where allowed", "Soaps and oils (rotate)"]
+    "biological": [
+      "Orius spp.",
+      "Amblyseius cucumeris"
+    ],
+    "cultural": [
+      "Remove weeds/volunteers",
+      "Screen intakes"
+    ],
+    "mechanical": [
+      "Sticky cards mass-trapping"
+    ],
+    "chemical": [
+      "Spinosad where allowed",
+      "Soaps and oils (rotate)"
+    ]
   }
 }

--- a/data/blueprints/pests/whiteflies.json
+++ b/data/blueprints/pests/whiteflies.json
@@ -1,12 +1,21 @@
 {
   "id": "ac38b09c-d963-4dd4-b105-54c8f4ba30b6",
-  "kind": "Pest",
+  "slug": "whiteflies",
+  "class": "pest.insect.whitefly",
   "name": "Whiteflies",
   "category": "sap-sucking",
-  "targets": ["leaves"],
+  "targets": [
+    "leaves"
+  ],
   "environmentalRisk": {
-    "temperatureRange": [22, 30],
-    "humidityRange": [0.4, 0.8]
+    "temperatureRange": [
+      22,
+      30
+    ],
+    "humidityRange": [
+      0.4,
+      0.8
+    ]
   },
   "populationDynamics": {
     "dailyReproductionRate": 0.28,
@@ -26,12 +35,25 @@
       "Sticky honeydew, sooty mold",
       "Leaf yellowing and drop"
     ],
-    "monitoring": ["Yellow sticky cards just above canopy", "Check leaf undersides for nymphs"]
+    "monitoring": [
+      "Yellow sticky cards just above canopy",
+      "Check leaf undersides for nymphs"
+    ]
   },
   "controlOptions": {
-    "biological": ["Encarsia formosa", "Eretmocerus spp."],
-    "cultural": ["Sanitation, remove lower leaves", "Screen air intakes"],
-    "mechanical": ["Vacuum adults routinely"],
-    "chemical": ["Soaps/oils (rotate modes)"]
+    "biological": [
+      "Encarsia formosa",
+      "Eretmocerus spp."
+    ],
+    "cultural": [
+      "Sanitation, remove lower leaves",
+      "Screen air intakes"
+    ],
+    "mechanical": [
+      "Vacuum adults routinely"
+    ],
+    "chemical": [
+      "Soaps/oils (rotate modes)"
+    ]
   }
 }

--- a/data/blueprints/roomPurposes/breakroom.json
+++ b/data/blueprints/roomPurposes/breakroom.json
@@ -1,6 +1,7 @@
 {
   "id": "5ab7d9ac-f14a-45d9-b5f9-908182ca4a02",
-  "type": "breakroom",
+  "slug": "breakroom",
+  "class": "room-purpose.core.breakroom",
   "name": "Break Room",
   "description": "A space for employees to rest and recover energy.",
   "economy": {

--- a/data/blueprints/roomPurposes/growroom.json
+++ b/data/blueprints/roomPurposes/growroom.json
@@ -1,6 +1,7 @@
 {
   "id": "2630459c-fc40-4e91-a69f-b47665b5a917",
-  "type": "growroom",
+  "slug": "growroom",
+  "class": "room-purpose.core.growroom",
   "name": "Grow Room",
   "description": "A room designed for cultivating plants under controlled conditions.",
   "economy": {

--- a/data/blueprints/roomPurposes/isolationroom.json
+++ b/data/blueprints/roomPurposes/isolationroom.json
@@ -1,6 +1,7 @@
 {
   "id": "828aa416-37be-4176-bfa6-9ce847e9dfd6",
-  "type": "isolationroom",
+  "slug": "isolation-room",
+  "class": "room-purpose.core.isolation",
   "name": "Isolation Room (Quarantine)",
   "description": "A special room to isolate ill plants from healthy plants.",
   "economy": {

--- a/data/blueprints/roomPurposes/laboratory.json
+++ b/data/blueprints/roomPurposes/laboratory.json
@@ -1,6 +1,7 @@
 {
   "id": "05566944-af3c-40f5-9d22-2cbe701457c7",
-  "type": "laboratory",
+  "slug": "laboratory",
+  "class": "room-purpose.core.laboratory",
   "name": "Laboratory",
   "description": "A facility for research and breeding new plant strains.",
   "economy": {

--- a/data/blueprints/roomPurposes/salesroom.json
+++ b/data/blueprints/roomPurposes/salesroom.json
@@ -1,6 +1,7 @@
 {
   "id": "828aa416-37be-4176-bfa6-9ce847e9dfd5",
-  "type": "salesroom",
+  "slug": "sales-room",
+  "class": "room-purpose.core.sales",
   "name": "Sales Room",
   "description": "A commercial space for selling harvested products.",
   "economy": {

--- a/data/blueprints/roomPurposes/workshop.json
+++ b/data/blueprints/roomPurposes/workshop.json
@@ -1,6 +1,7 @@
 {
   "id": "828aa416-37be-4176-bfa6-9ce847e9dfe6",
-  "type": "workshop",
+  "slug": "workshop",
+  "class": "room-purpose.core.workshop",
   "name": "Workshop",
   "description": "A space for repairing and improving devices.",
   "economy": {

--- a/data/blueprints/strains/ak-47.json
+++ b/data/blueprints/strains/ak-47.json
@@ -1,6 +1,7 @@
 {
   "id": "550e8400-e29b-41d4-a716-446655440000",
   "slug": "ak47",
+  "class": "strain.hybrid.sativa-dominant",
   "name": "AK-47",
   "lineage": {
     "parents": []
@@ -23,20 +24,90 @@
   },
   "envBands": {
     "default": {
-      "temp_C": { "green": [23, 27], "yellowLow": 21, "yellowHigh": 29 },
-      "rh_frac": { "green": [0.55, 0.7], "yellowLow": 0.45, "yellowHigh": 0.75 },
-      "co2_ppm": { "green": [900, 1200], "yellowLow": 700, "yellowHigh": 1400 },
-      "ppfd_umol_m2s": { "green": [500, 800], "yellowLow": 400, "yellowHigh": 1000 },
-      "vpd_kPa": { "green": [1.0, 1.4], "yellowLow": 0.8, "yellowHigh": 1.6 }
+      "temp_C": {
+        "green": [
+          23,
+          27
+        ],
+        "yellowLow": 21,
+        "yellowHigh": 29
+      },
+      "rh_frac": {
+        "green": [
+          0.55,
+          0.7
+        ],
+        "yellowLow": 0.45,
+        "yellowHigh": 0.75
+      },
+      "co2_ppm": {
+        "green": [
+          900,
+          1200
+        ],
+        "yellowLow": 700,
+        "yellowHigh": 1400
+      },
+      "ppfd_umol_m2s": {
+        "green": [
+          500,
+          800
+        ],
+        "yellowLow": 400,
+        "yellowHigh": 1000
+      },
+      "vpd_kPa": {
+        "green": [
+          1.0,
+          1.4
+        ],
+        "yellowLow": 0.8,
+        "yellowHigh": 1.6
+      }
     },
     "veg": {
-      "temp_C": { "green": [22, 26], "yellowLow": 20, "yellowHigh": 28 },
-      "rh_frac": { "green": [0.6, 0.7], "yellowLow": 0.5, "yellowHigh": 0.75 }
+      "temp_C": {
+        "green": [
+          22,
+          26
+        ],
+        "yellowLow": 20,
+        "yellowHigh": 28
+      },
+      "rh_frac": {
+        "green": [
+          0.6,
+          0.7
+        ],
+        "yellowLow": 0.5,
+        "yellowHigh": 0.75
+      }
     },
     "flower": {
-      "temp_C": { "green": [24, 28], "yellowLow": 22, "yellowHigh": 30 },
-      "rh_frac": { "green": [0.4, 0.55], "yellowLow": 0.35, "yellowHigh": 0.65 },
-      "co2_ppm": { "green": [1000, 1300], "yellowLow": 800, "yellowHigh": 1500 }
+      "temp_C": {
+        "green": [
+          24,
+          28
+        ],
+        "yellowLow": 22,
+        "yellowHigh": 30
+      },
+      "rh_frac": {
+        "green": [
+          0.4,
+          0.55
+        ],
+        "yellowLow": 0.35,
+        "yellowHigh": 0.65
+      },
+      "co2_ppm": {
+        "green": [
+          1000,
+          1300
+        ],
+        "yellowLow": 800,
+        "yellowHigh": 1500
+      }
     }
   },
   "stressTolerance": {
@@ -97,26 +168,59 @@
   },
   "environmentalPreferences": {
     "lightSpectrum": {
-      "vegetation": [400, 700],
-      "flowering": [300, 650]
+      "vegetation": [
+        400,
+        700
+      ],
+      "flowering": [
+        300,
+        650
+      ]
     },
     "lightIntensity": {
-      "vegetation": [400, 600],
-      "flowering": [600, 1000]
+      "vegetation": [
+        400,
+        600
+      ],
+      "flowering": [
+        600,
+        1000
+      ]
     },
     "lightCycle": {
-      "vegetation": [18, 6],
-      "flowering": [12, 12]
+      "vegetation": [
+        18,
+        6
+      ],
+      "flowering": [
+        12,
+        12
+      ]
     },
     "idealTemperature": {
-      "vegetation": [20, 28],
-      "flowering": [22, 30]
+      "vegetation": [
+        20,
+        28
+      ],
+      "flowering": [
+        22,
+        30
+      ]
     },
     "idealHumidity": {
-      "vegetation": [0.6, 0.7],
-      "flowering": [0.5, 0.6]
+      "vegetation": [
+        0.6,
+        0.7
+      ],
+      "flowering": [
+        0.5,
+        0.6
+      ]
     },
-    "phRange": [5.8, 6.2]
+    "phRange": [
+      5.8,
+      6.2
+    ]
   },
   "nutrientDemand": {
     "dailyNutrientDemand": {
@@ -170,15 +274,22 @@
       "maxStressForStageChange": 0.2
     }
   },
-  "harvestWindow": [5184000, 6480000],
+  "harvestWindow": [
+    5184000,
+    6480000
+  ],
   "harvestProperties": {
     "ripeningTime": 172800,
     "maxStorageTime": 432000,
-    "qualityDecayRate": 5.555555555555556e-6
+    "qualityDecayRate": 5.555555555555556e-06
   },
   "meta": {
     "description": "AK-47 is a classic hybrid cannabis strain known for its high THC levels and fast flowering. It combines strong sativa effects with compact indica growth.",
-    "advantages": ["High THC potential", "Reliable yields", "Adaptable to indoor systems"],
+    "advantages": [
+      "High THC potential",
+      "Reliable yields",
+      "Adaptable to indoor systems"
+    ],
     "disadvantages": [
       "Humidity-sensitive during flowering",
       "Not ideal for low-light environments"

--- a/data/blueprints/strains/northern-lights.json
+++ b/data/blueprints/strains/northern-lights.json
@@ -1,6 +1,7 @@
 {
   "id": "3f0f15f4-1b75-4196-b3f3-5f6b6b7cf7a7",
   "slug": "northern_lights",
+  "class": "strain.hybrid.sativa-dominant",
   "name": "Northern Lights",
   "photoperiodic": true,
   "vegDays": 28,
@@ -39,20 +40,90 @@
   },
   "envBands": {
     "default": {
-      "temp_C": { "green": [20, 26], "yellowLow": 18, "yellowHigh": 28 },
-      "rh_frac": { "green": [0.5, 0.65], "yellowLow": 0.4, "yellowHigh": 0.75 },
-      "co2_ppm": { "green": [750, 1100], "yellowLow": 600, "yellowHigh": 1300 },
-      "ppfd_umol_m2s": { "green": [400, 650], "yellowLow": 300, "yellowHigh": 800 },
-      "vpd_kPa": { "green": [0.8, 1.3], "yellowLow": 0.6, "yellowHigh": 1.5 }
+      "temp_C": {
+        "green": [
+          20,
+          26
+        ],
+        "yellowLow": 18,
+        "yellowHigh": 28
+      },
+      "rh_frac": {
+        "green": [
+          0.5,
+          0.65
+        ],
+        "yellowLow": 0.4,
+        "yellowHigh": 0.75
+      },
+      "co2_ppm": {
+        "green": [
+          750,
+          1100
+        ],
+        "yellowLow": 600,
+        "yellowHigh": 1300
+      },
+      "ppfd_umol_m2s": {
+        "green": [
+          400,
+          650
+        ],
+        "yellowLow": 300,
+        "yellowHigh": 800
+      },
+      "vpd_kPa": {
+        "green": [
+          0.8,
+          1.3
+        ],
+        "yellowLow": 0.6,
+        "yellowHigh": 1.5
+      }
     },
     "veg": {
-      "temp_C": { "green": [18, 24], "yellowLow": 16, "yellowHigh": 26 },
-      "rh_frac": { "green": [0.55, 0.7], "yellowLow": 0.45, "yellowHigh": 0.75 }
+      "temp_C": {
+        "green": [
+          18,
+          24
+        ],
+        "yellowLow": 16,
+        "yellowHigh": 26
+      },
+      "rh_frac": {
+        "green": [
+          0.55,
+          0.7
+        ],
+        "yellowLow": 0.45,
+        "yellowHigh": 0.75
+      }
     },
     "flower": {
-      "temp_C": { "green": [20, 26], "yellowLow": 18, "yellowHigh": 28 },
-      "rh_frac": { "green": [0.4, 0.55], "yellowLow": 0.35, "yellowHigh": 0.65 },
-      "co2_ppm": { "green": [800, 1200], "yellowLow": 650, "yellowHigh": 1400 }
+      "temp_C": {
+        "green": [
+          20,
+          26
+        ],
+        "yellowLow": 18,
+        "yellowHigh": 28
+      },
+      "rh_frac": {
+        "green": [
+          0.4,
+          0.55
+        ],
+        "yellowLow": 0.35,
+        "yellowHigh": 0.65
+      },
+      "co2_ppm": {
+        "green": [
+          800,
+          1200
+        ],
+        "yellowLow": 650,
+        "yellowHigh": 1400
+      }
     }
   },
   "stressTolerance": {
@@ -114,26 +185,59 @@
   },
   "environmentalPreferences": {
     "lightSpectrum": {
-      "vegetation": [400, 700],
-      "flowering": [300, 650]
+      "vegetation": [
+        400,
+        700
+      ],
+      "flowering": [
+        300,
+        650
+      ]
     },
     "lightIntensity": {
-      "vegetation": [400, 600],
-      "flowering": [600, 1000]
+      "vegetation": [
+        400,
+        600
+      ],
+      "flowering": [
+        600,
+        1000
+      ]
     },
     "lightCycle": {
-      "vegetation": [18, 6],
-      "flowering": [12, 12]
+      "vegetation": [
+        18,
+        6
+      ],
+      "flowering": [
+        12,
+        12
+      ]
     },
     "idealTemperature": {
-      "vegetation": [20, 28],
-      "flowering": [22, 30]
+      "vegetation": [
+        20,
+        28
+      ],
+      "flowering": [
+        22,
+        30
+      ]
     },
     "idealHumidity": {
-      "vegetation": [0.6, 0.7],
-      "flowering": [0.5, 0.6]
+      "vegetation": [
+        0.6,
+        0.7
+      ],
+      "flowering": [
+        0.5,
+        0.6
+      ]
     },
-    "phRange": [5.8, 6.2]
+    "phRange": [
+      5.8,
+      6.2
+    ]
   },
   "nutrientDemand": {
     "dailyNutrientDemand": {
@@ -187,16 +291,26 @@
       "maxStressForStageChange": 0.2
     }
   },
-  "harvestWindow": [4147200, 5184000],
+  "harvestWindow": [
+    4147200,
+    5184000
+  ],
   "harvestProperties": {
     "ripeningTime": 172800,
     "maxStorageTime": 432000,
-    "qualityDecayRate": 5.555555555555556e-6
+    "qualityDecayRate": 5.555555555555556e-06
   },
   "meta": {
     "description": "Northern Lights is a legendary indica strain prized for its resilience and fast flowering time.",
-    "advantages": ["Compact growth", "Resistant to stress", "Classic indica effects"],
-    "disadvantages": ["Moderate yields", "Prefers stable climates"],
+    "advantages": [
+      "Compact growth",
+      "Resistant to stress",
+      "Classic indica effects"
+    ],
+    "disadvantages": [
+      "Moderate yields",
+      "Prefers stable climates"
+    ],
     "notes": "Often used as a baseline in breeding projects."
   }
 }

--- a/data/blueprints/strains/skunk-1.json
+++ b/data/blueprints/strains/skunk-1.json
@@ -1,6 +1,7 @@
 {
   "id": "5a6e9e57-0b3a-4f9f-8f19-12f3f8ec3a0e",
   "slug": "skunk_1",
+  "class": "strain.hybrid.sativa-dominant",
   "name": "Skunk #1",
   "photoperiodic": true,
   "vegDays": 30,
@@ -39,22 +40,106 @@
   },
   "envBands": {
     "default": {
-      "temp_C": { "green": [22, 27], "yellowLow": 20, "yellowHigh": 29 },
-      "rh_frac": { "green": [0.5, 0.65], "yellowLow": 0.4, "yellowHigh": 0.75 },
-      "co2_ppm": { "green": [850, 1200], "yellowLow": 700, "yellowHigh": 1400 },
-      "ppfd_umol_m2s": { "green": [500, 750], "yellowLow": 400, "yellowHigh": 900 },
-      "vpd_kPa": { "green": [0.9, 1.4], "yellowLow": 0.7, "yellowHigh": 1.6 }
+      "temp_C": {
+        "green": [
+          22,
+          27
+        ],
+        "yellowLow": 20,
+        "yellowHigh": 29
+      },
+      "rh_frac": {
+        "green": [
+          0.5,
+          0.65
+        ],
+        "yellowLow": 0.4,
+        "yellowHigh": 0.75
+      },
+      "co2_ppm": {
+        "green": [
+          850,
+          1200
+        ],
+        "yellowLow": 700,
+        "yellowHigh": 1400
+      },
+      "ppfd_umol_m2s": {
+        "green": [
+          500,
+          750
+        ],
+        "yellowLow": 400,
+        "yellowHigh": 900
+      },
+      "vpd_kPa": {
+        "green": [
+          0.9,
+          1.4
+        ],
+        "yellowLow": 0.7,
+        "yellowHigh": 1.6
+      }
     },
     "veg": {
-      "temp_C": { "green": [21, 26], "yellowLow": 19, "yellowHigh": 28 },
-      "rh_frac": { "green": [0.55, 0.7], "yellowLow": 0.45, "yellowHigh": 0.75 },
-      "ppfd_umol_m2s": { "green": [450, 650], "yellowLow": 350, "yellowHigh": 750 }
+      "temp_C": {
+        "green": [
+          21,
+          26
+        ],
+        "yellowLow": 19,
+        "yellowHigh": 28
+      },
+      "rh_frac": {
+        "green": [
+          0.55,
+          0.7
+        ],
+        "yellowLow": 0.45,
+        "yellowHigh": 0.75
+      },
+      "ppfd_umol_m2s": {
+        "green": [
+          450,
+          650
+        ],
+        "yellowLow": 350,
+        "yellowHigh": 750
+      }
     },
     "flower": {
-      "temp_C": { "green": [23, 28], "yellowLow": 21, "yellowHigh": 30 },
-      "rh_frac": { "green": [0.4, 0.55], "yellowLow": 0.35, "yellowHigh": 0.65 },
-      "co2_ppm": { "green": [900, 1300], "yellowLow": 750, "yellowHigh": 1500 },
-      "ppfd_umol_m2s": { "green": [600, 850], "yellowLow": 500, "yellowHigh": 1000 }
+      "temp_C": {
+        "green": [
+          23,
+          28
+        ],
+        "yellowLow": 21,
+        "yellowHigh": 30
+      },
+      "rh_frac": {
+        "green": [
+          0.4,
+          0.55
+        ],
+        "yellowLow": 0.35,
+        "yellowHigh": 0.65
+      },
+      "co2_ppm": {
+        "green": [
+          900,
+          1300
+        ],
+        "yellowLow": 750,
+        "yellowHigh": 1500
+      },
+      "ppfd_umol_m2s": {
+        "green": [
+          600,
+          850
+        ],
+        "yellowLow": 500,
+        "yellowHigh": 1000
+      }
     }
   },
   "stressTolerance": {
@@ -116,26 +201,59 @@
   },
   "environmentalPreferences": {
     "lightSpectrum": {
-      "vegetation": [400, 700],
-      "flowering": [300, 650]
+      "vegetation": [
+        400,
+        700
+      ],
+      "flowering": [
+        300,
+        650
+      ]
     },
     "lightIntensity": {
-      "vegetation": [400, 600],
-      "flowering": [600, 1000]
+      "vegetation": [
+        400,
+        600
+      ],
+      "flowering": [
+        600,
+        1000
+      ]
     },
     "lightCycle": {
-      "vegetation": [18, 6],
-      "flowering": [12, 12]
+      "vegetation": [
+        18,
+        6
+      ],
+      "flowering": [
+        12,
+        12
+      ]
     },
     "idealTemperature": {
-      "vegetation": [20, 28],
-      "flowering": [22, 30]
+      "vegetation": [
+        20,
+        28
+      ],
+      "flowering": [
+        22,
+        30
+      ]
     },
     "idealHumidity": {
-      "vegetation": [0.6, 0.7],
-      "flowering": [0.5, 0.6]
+      "vegetation": [
+        0.6,
+        0.7
+      ],
+      "flowering": [
+        0.5,
+        0.6
+      ]
     },
-    "phRange": [5.8, 6.2]
+    "phRange": [
+      5.8,
+      6.2
+    ]
   },
   "nutrientDemand": {
     "dailyNutrientDemand": {
@@ -189,16 +307,26 @@
       "maxStressForStageChange": 0.2
     }
   },
-  "harvestWindow": [4752000, 5616000],
+  "harvestWindow": [
+    4752000,
+    5616000
+  ],
   "harvestProperties": {
     "ripeningTime": 172800,
     "maxStorageTime": 432000,
-    "qualityDecayRate": 5.555555555555556e-6
+    "qualityDecayRate": 5.555555555555556e-06
   },
   "meta": {
     "description": "Skunk #1 set the standard for modern hybrids with its skunky aroma and balanced growth.",
-    "advantages": ["Stable genetics", "Fast flowering", "Classic flavor"],
-    "disadvantages": ["Strong odor", "Can stretch in veg"],
+    "advantages": [
+      "Stable genetics",
+      "Fast flowering",
+      "Classic flavor"
+    ],
+    "disadvantages": [
+      "Strong odor",
+      "Can stretch in veg"
+    ],
     "notes": "Widely used as a benchmark strain since the 1970s."
   }
 }

--- a/data/blueprints/strains/sour-diesel.json
+++ b/data/blueprints/strains/sour-diesel.json
@@ -1,6 +1,7 @@
 {
   "id": "8b9a0b6c-2d6c-4f58-9c37-7a6c9d4aa5c2",
   "slug": "sour_diesel",
+  "class": "strain.hybrid.sativa-dominant",
   "name": "Sour Diesel",
   "photoperiodic": true,
   "vegDays": 36,
@@ -39,22 +40,106 @@
   },
   "envBands": {
     "default": {
-      "temp_C": { "green": [24, 28], "yellowLow": 22, "yellowHigh": 30 },
-      "rh_frac": { "green": [0.45, 0.6], "yellowLow": 0.35, "yellowHigh": 0.7 },
-      "co2_ppm": { "green": [900, 1350], "yellowLow": 750, "yellowHigh": 1500 },
-      "ppfd_umol_m2s": { "green": [650, 950], "yellowLow": 550, "yellowHigh": 1150 },
-      "vpd_kPa": { "green": [1.0, 1.5], "yellowLow": 0.8, "yellowHigh": 1.7 }
+      "temp_C": {
+        "green": [
+          24,
+          28
+        ],
+        "yellowLow": 22,
+        "yellowHigh": 30
+      },
+      "rh_frac": {
+        "green": [
+          0.45,
+          0.6
+        ],
+        "yellowLow": 0.35,
+        "yellowHigh": 0.7
+      },
+      "co2_ppm": {
+        "green": [
+          900,
+          1350
+        ],
+        "yellowLow": 750,
+        "yellowHigh": 1500
+      },
+      "ppfd_umol_m2s": {
+        "green": [
+          650,
+          950
+        ],
+        "yellowLow": 550,
+        "yellowHigh": 1150
+      },
+      "vpd_kPa": {
+        "green": [
+          1.0,
+          1.5
+        ],
+        "yellowLow": 0.8,
+        "yellowHigh": 1.7
+      }
     },
     "veg": {
-      "temp_C": { "green": [23, 27], "yellowLow": 21, "yellowHigh": 29 },
-      "rh_frac": { "green": [0.5, 0.65], "yellowLow": 0.4, "yellowHigh": 0.75 },
-      "ppfd_umol_m2s": { "green": [500, 750], "yellowLow": 400, "yellowHigh": 850 }
+      "temp_C": {
+        "green": [
+          23,
+          27
+        ],
+        "yellowLow": 21,
+        "yellowHigh": 29
+      },
+      "rh_frac": {
+        "green": [
+          0.5,
+          0.65
+        ],
+        "yellowLow": 0.4,
+        "yellowHigh": 0.75
+      },
+      "ppfd_umol_m2s": {
+        "green": [
+          500,
+          750
+        ],
+        "yellowLow": 400,
+        "yellowHigh": 850
+      }
     },
     "flower": {
-      "temp_C": { "green": [25, 29], "yellowLow": 23, "yellowHigh": 31 },
-      "rh_frac": { "green": [0.35, 0.5], "yellowLow": 0.3, "yellowHigh": 0.6 },
-      "co2_ppm": { "green": [950, 1400], "yellowLow": 800, "yellowHigh": 1600 },
-      "ppfd_umol_m2s": { "green": [700, 1000], "yellowLow": 600, "yellowHigh": 1200 }
+      "temp_C": {
+        "green": [
+          25,
+          29
+        ],
+        "yellowLow": 23,
+        "yellowHigh": 31
+      },
+      "rh_frac": {
+        "green": [
+          0.35,
+          0.5
+        ],
+        "yellowLow": 0.3,
+        "yellowHigh": 0.6
+      },
+      "co2_ppm": {
+        "green": [
+          950,
+          1400
+        ],
+        "yellowLow": 800,
+        "yellowHigh": 1600
+      },
+      "ppfd_umol_m2s": {
+        "green": [
+          700,
+          1000
+        ],
+        "yellowLow": 600,
+        "yellowHigh": 1200
+      }
     }
   },
   "stressTolerance": {
@@ -116,26 +201,59 @@
   },
   "environmentalPreferences": {
     "lightSpectrum": {
-      "vegetation": [400, 700],
-      "flowering": [300, 650]
+      "vegetation": [
+        400,
+        700
+      ],
+      "flowering": [
+        300,
+        650
+      ]
     },
     "lightIntensity": {
-      "vegetation": [400, 600],
-      "flowering": [600, 1000]
+      "vegetation": [
+        400,
+        600
+      ],
+      "flowering": [
+        600,
+        1000
+      ]
     },
     "lightCycle": {
-      "vegetation": [18, 6],
-      "flowering": [12, 12]
+      "vegetation": [
+        18,
+        6
+      ],
+      "flowering": [
+        12,
+        12
+      ]
     },
     "idealTemperature": {
-      "vegetation": [20, 28],
-      "flowering": [22, 30]
+      "vegetation": [
+        20,
+        28
+      ],
+      "flowering": [
+        22,
+        30
+      ]
     },
     "idealHumidity": {
-      "vegetation": [0.6, 0.7],
-      "flowering": [0.5, 0.6]
+      "vegetation": [
+        0.6,
+        0.7
+      ],
+      "flowering": [
+        0.5,
+        0.6
+      ]
     },
-    "phRange": [5.8, 6.2]
+    "phRange": [
+      5.8,
+      6.2
+    ]
   },
   "nutrientDemand": {
     "dailyNutrientDemand": {
@@ -189,16 +307,26 @@
       "maxStressForStageChange": 0.2
     }
   },
-  "harvestWindow": [5616000, 6912000],
+  "harvestWindow": [
+    5616000,
+    6912000
+  ],
   "harvestProperties": {
     "ripeningTime": 172800,
     "maxStorageTime": 432000,
-    "qualityDecayRate": 5.555555555555556e-6
+    "qualityDecayRate": 5.555555555555556e-06
   },
   "meta": {
     "description": "Sour Diesel delivers pungent aromas and energizing effects, popular among sativa enthusiasts.",
-    "advantages": ["High vigor", "Strong aroma", "Excellent for daytime use"],
-    "disadvantages": ["Long flowering period", "Requires ample light"],
+    "advantages": [
+      "High vigor",
+      "Strong aroma",
+      "Excellent for daytime use"
+    ],
+    "disadvantages": [
+      "Long flowering period",
+      "Requires ample light"
+    ],
     "notes": "Originates from the U.S. East Coast underground scene."
   }
 }

--- a/data/blueprints/strains/white-widow.json
+++ b/data/blueprints/strains/white-widow.json
@@ -1,6 +1,7 @@
 {
   "id": "550e8400-e29b-41d4-a716-446655440001",
   "slug": "white_widow",
+  "class": "strain.hybrid.balanced",
   "name": "White Widow",
   "lineage": {
     "parents": []
@@ -23,20 +24,90 @@
   },
   "envBands": {
     "default": {
-      "temp_C": { "green": [21, 26], "yellowLow": 19, "yellowHigh": 28 },
-      "rh_frac": { "green": [0.5, 0.65], "yellowLow": 0.4, "yellowHigh": 0.7 },
-      "co2_ppm": { "green": [800, 1150], "yellowLow": 650, "yellowHigh": 1350 },
-      "ppfd_umol_m2s": { "green": [450, 700], "yellowLow": 350, "yellowHigh": 850 },
-      "vpd_kPa": { "green": [0.9, 1.3], "yellowLow": 0.7, "yellowHigh": 1.5 }
+      "temp_C": {
+        "green": [
+          21,
+          26
+        ],
+        "yellowLow": 19,
+        "yellowHigh": 28
+      },
+      "rh_frac": {
+        "green": [
+          0.5,
+          0.65
+        ],
+        "yellowLow": 0.4,
+        "yellowHigh": 0.7
+      },
+      "co2_ppm": {
+        "green": [
+          800,
+          1150
+        ],
+        "yellowLow": 650,
+        "yellowHigh": 1350
+      },
+      "ppfd_umol_m2s": {
+        "green": [
+          450,
+          700
+        ],
+        "yellowLow": 350,
+        "yellowHigh": 850
+      },
+      "vpd_kPa": {
+        "green": [
+          0.9,
+          1.3
+        ],
+        "yellowLow": 0.7,
+        "yellowHigh": 1.5
+      }
     },
     "veg": {
-      "temp_C": { "green": [20, 25], "yellowLow": 18, "yellowHigh": 27 },
-      "rh_frac": { "green": [0.55, 0.68], "yellowLow": 0.45, "yellowHigh": 0.75 }
+      "temp_C": {
+        "green": [
+          20,
+          25
+        ],
+        "yellowLow": 18,
+        "yellowHigh": 27
+      },
+      "rh_frac": {
+        "green": [
+          0.55,
+          0.68
+        ],
+        "yellowLow": 0.45,
+        "yellowHigh": 0.75
+      }
     },
     "flower": {
-      "temp_C": { "green": [21, 26], "yellowLow": 19, "yellowHigh": 28 },
-      "rh_frac": { "green": [0.42, 0.58], "yellowLow": 0.35, "yellowHigh": 0.65 },
-      "co2_ppm": { "green": [850, 1200], "yellowLow": 700, "yellowHigh": 1400 }
+      "temp_C": {
+        "green": [
+          21,
+          26
+        ],
+        "yellowLow": 19,
+        "yellowHigh": 28
+      },
+      "rh_frac": {
+        "green": [
+          0.42,
+          0.58
+        ],
+        "yellowLow": 0.35,
+        "yellowHigh": 0.65
+      },
+      "co2_ppm": {
+        "green": [
+          850,
+          1200
+        ],
+        "yellowLow": 700,
+        "yellowHigh": 1400
+      }
     }
   },
   "stressTolerance": {
@@ -98,26 +169,59 @@
   },
   "environmentalPreferences": {
     "lightSpectrum": {
-      "vegetation": [400, 700],
-      "flowering": [300, 650]
+      "vegetation": [
+        400,
+        700
+      ],
+      "flowering": [
+        300,
+        650
+      ]
     },
     "lightIntensity": {
-      "vegetation": [350, 550],
-      "flowering": [550, 950]
+      "vegetation": [
+        350,
+        550
+      ],
+      "flowering": [
+        550,
+        950
+      ]
     },
     "lightCycle": {
-      "vegetation": [18, 6],
-      "flowering": [12, 12]
+      "vegetation": [
+        18,
+        6
+      ],
+      "flowering": [
+        12,
+        12
+      ]
     },
     "idealTemperature": {
-      "vegetation": [21, 27],
-      "flowering": [20, 26]
+      "vegetation": [
+        21,
+        27
+      ],
+      "flowering": [
+        20,
+        26
+      ]
     },
     "idealHumidity": {
-      "vegetation": [0.55, 0.65],
-      "flowering": [0.45, 0.55]
+      "vegetation": [
+        0.55,
+        0.65
+      ],
+      "flowering": [
+        0.45,
+        0.55
+      ]
     },
-    "phRange": [5.8, 6.2]
+    "phRange": [
+      5.8,
+      6.2
+    ]
   },
   "nutrientDemand": {
     "dailyNutrientDemand": {
@@ -171,16 +275,26 @@
       "maxStressForStageChange": 0.25
     }
   },
-  "harvestWindow": [5011200, 6048000],
+  "harvestWindow": [
+    5011200,
+    6048000
+  ],
   "harvestProperties": {
     "ripeningTime": 172800,
     "maxStorageTime": 432000,
-    "qualityDecayRate": 5.555555555555556e-6
+    "qualityDecayRate": 5.555555555555556e-06
   },
   "meta": {
     "description": "White Widow is a balanced hybrid strain, a cross between a Brazilian sativa landrace and a resin-heavy South Indian indica. It is known for its resin production and relatively easy growth.",
-    "advantages": ["High resin production", "Balanced effects", "Good for beginners"],
-    "disadvantages": ["Can be sensitive to nutrients", "Prefers stable temperatures"],
+    "advantages": [
+      "High resin production",
+      "Balanced effects",
+      "Good for beginners"
+    ],
+    "disadvantages": [
+      "Can be sensitive to nutrients",
+      "Prefers stable temperatures"
+    ],
     "notes": "A classic Dutch coffee-shop strain that remains popular worldwide."
   }
 }

--- a/data/blueprints/structures/cellar.json
+++ b/data/blueprints/structures/cellar.json
@@ -1,5 +1,7 @@
 {
   "id": "d96dd659-4678-4d5d-a97c-a590ab52c2f3",
+  "slug": "cellar",
+  "class": "structure.storage.cellar",
   "name": "Cellar",
   "footprint": {
     "length_m": 3,

--- a/data/blueprints/structures/medium_warehouse.json
+++ b/data/blueprints/structures/medium_warehouse.json
@@ -1,5 +1,7 @@
 {
   "id": "59ec5597-42f5-4e52-acb9-cb65d68fd72d",
+  "slug": "medium-warehouse",
+  "class": "structure.storage.medium-warehouse",
   "name": "Medium Warehouse",
   "footprint": {
     "length_m": 40,

--- a/data/blueprints/structures/shed.json
+++ b/data/blueprints/structures/shed.json
@@ -1,5 +1,7 @@
 {
   "id": "d96dd659-4678-4d5d-a97c-a590ab52c2f2",
+  "slug": "shed",
+  "class": "structure.storage.shed",
   "name": "Shed",
   "footprint": {
     "length_m": 6,

--- a/data/blueprints/structures/small_warehouse.json
+++ b/data/blueprints/structures/small_warehouse.json
@@ -1,5 +1,7 @@
 {
   "id": "43ee4095-627d-4a0c-860b-b10affbcf603",
+  "slug": "small-warehouse",
+  "class": "structure.storage.small-warehouse",
   "name": "Small Warehouse",
   "footprint": {
     "length_m": 20,

--- a/data/blueprints/substrates/coco_coir.json
+++ b/data/blueprints/substrates/coco_coir.json
@@ -1,9 +1,8 @@
 {
   "id": "285041f1-9586-4b43-b55c-0cb76f343037",
   "slug": "coco-coir",
-  "kind": "Substrate",
+  "class": "substrate.coco.coir",
   "name": "Coco Coir",
-  "type": "coco",
   "maxCycles": 4,
   "meta": {
     "description": "Buffered coco coir blend optimized for drain-to-waste or recirculating fertigation systems with multiple reuse cycles.",

--- a/data/blueprints/substrates/soil_multi_cycle.json
+++ b/data/blueprints/substrates/soil_multi_cycle.json
@@ -1,9 +1,8 @@
 {
   "id": "ebdb6d5e-fb3d-4db2-90a4-8e6c5be137f4",
   "slug": "soil-multi-cycle",
-  "kind": "Substrate",
+  "class": "substrate.soil.multi-cycle",
   "name": "Multi-Cycle Soil Mix",
-  "type": "soil",
   "maxCycles": 2,
   "meta": {
     "description": "Reconditionable soil blend that survives two full runs with proper amendment and sterilization between crops.",

--- a/data/blueprints/substrates/soil_single_cycle.json
+++ b/data/blueprints/substrates/soil_single_cycle.json
@@ -1,9 +1,8 @@
 {
   "id": "04c8b1a5-09cc-4d86-8dc6-9007a64de6f2",
   "slug": "soil-single-cycle",
-  "kind": "Substrate",
+  "class": "substrate.soil.single-cycle",
   "name": "Single-Cycle Soil Mix",
-  "type": "soil",
   "maxCycles": 1,
   "meta": {
     "description": "Pre-charged soil mix formulated for one-and-done harvests; ideal when designers prefer a fresh medium each run.",

--- a/docs/ADR/ADR-0009-blueprint-class-taxonomy.md
+++ b/docs/ADR/ADR-0009-blueprint-class-taxonomy.md
@@ -1,0 +1,38 @@
+# ADR-0009: Blueprint class taxonomy and validation
+
+## Status
+Accepted
+
+## Context
+Legacy blueprint JSON stored ad-hoc `kind` and `type` strings that were
+neither constrained by the engine nor referenced consistently across the
+simulation pipeline. As the number of blueprint families grows, loosely
+typed identifiers make it difficult to validate fixtures, reason about
+capabilities, or introduce class-specific parsing rules mandated by the
+Simulation Engine Contract (SEC v0.2.1). Recent SEC clarifications require
+a stable taxonomy that the backend can enforce when bootstrapping device
+behaviour and downstream content.
+
+## Decision
+- Introduce a canonical `class` discriminator on every blueprint under
+  `/data/blueprints/**` following the `<domain>.<effect>[.<variant>]`
+  pattern so files can be grouped deterministically by capability.
+- Remove the legacy `kind`/`type` fields from the data set and require
+  kebab-case `slug` identifiers to remain unique per class.
+- Extend the device blueprint schema to validate the new classes,
+  mandating effect-specific fields (e.g., dehumidifiers must expose latent
+  removal rates, CO₂ injectors must publish pulse parameters).
+- Capture the taxonomy in SEC/DD documentation so future blueprints can
+  align with the established hierarchy without reverse-engineering the
+  fixtures or the validator implementation.
+
+## Consequences
+- All existing blueprint JSON files were migrated to include `class` and
+  (where previously absent) `slug` attributes. Tests now parse the updated
+  fixtures to ensure taxonomy compliance.
+- Scenario loaders and integrations must refer to the `class` field rather
+  than the removed `kind`/`type` keys. Attempting to load blueprints that
+  omit class-specific settings now fails during schema validation.
+- Documentation and changelog updates communicate the taxonomy to engine
+  contributors, establishing a precedent for future blueprint additions
+  and migrations.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### #39 WB-032 blueprint taxonomy alignment
+- Added a canonical `<domain>.<effect>[.<variant>]` `class` discriminator and kebab-case
+  slugs across every blueprint JSON under `/data/blueprints/**`, removing legacy
+  `kind`/`type` identifiers while keeping slug uniqueness per class.
+- Extended the device blueprint schema to require the taxonomy, enforce slug format, and
+  validate effect-specific fields for cooling, CO₂ injection, humidity control,
+  dehumidification, airflow, and vegetative lighting classes.
+- Refreshed fixtures, unit tests, SEC/DD guidance, and a new ADR to document the
+  taxonomy-driven migration for future contributors.
+
 ### #38 WB-031 device read-model percent enrichment
 - Introduced a façade read-model mapper that forwards canonical device metrics
   while appending `qualityPercent`/`conditionPercent` derived via the SEC-mandated

--- a/docs/DD.md
+++ b/docs/DD.md
@@ -89,6 +89,11 @@ geometry bounds) before the tick pipeline consumes a scenario payload.
 
 **Blueprints are templates**; never mutated at runtime. **Prices are separated** from device blueprints.
 
+- **Blueprint taxonomy:** All blueprints expose `class` values using
+  `<domain>.<effect>[.<variant>]` plus a kebab-case `slug` unique within that class. The
+  backend validators rely on the taxonomy to select effect-specific rules (e.g. cooling,
+  dehumidification, lighting) while the data set retires the legacy `kind`/`type` fields.
+
 ### 4.2 Price Maps
 
 - `/data/prices/devicePrices.json` captures device **CapEx** (`capitalExpenditure`) and **maintenance** progression (`baseMaintenanceCostPerHour`, `costIncreasePer1000Hours`).

--- a/docs/SEC.md
+++ b/docs/SEC.md
@@ -232,6 +232,20 @@ The world is a tree with typed nodes and bounded geometry.
 
 Validation occurs at load time; on failure, the engine must not start. Validation schemas live with the engine domain types so the engine remains the single source of truth; see [ADR-0005](ADR/ADR-0005-validation-schema-centralization.md) for implementation details.
 
+### 3.0.1 Blueprint Taxonomy (STRICT)
+
+- Every blueprint under `/data/blueprints/**` **MUST** publish a `class` field in the
+  `<domain>.<effect>[.<variant>]` format plus a kebab-case `slug` that remains unique per
+  class. The taxonomy binds fixtures, runtime loaders, and documentation to the same
+  capability vocabulary.
+- Legacy `kind`/`type` identifiers are **removed**; integrations **MUST** read the new
+  `class` discriminator.
+- Device blueprint classes **drive validation**: cooling units declare cooling capacity
+  and temperature targets, dehumidifiers expose latent removal rates, CO₂ injectors
+  specify enrichment ranges, humidity controllers provide humidify/dehumidify rates,
+  airflow devices publish steady airflow, and grow lights define PPFD and spectrum
+  coverage.
+
 ### 3.1 Device Placement & Eligibility (STRICT)
 
 (unchanged; uses `allowedRoomPurposes` and `placementScope`)

--- a/packages/engine/src/backend/src/domain/blueprints/deviceBlueprint.ts
+++ b/packages/engine/src/backend/src/domain/blueprints/deviceBlueprint.ts
@@ -4,9 +4,22 @@ import { DEVICE_PLACEMENT_SCOPES, ROOM_PURPOSES } from '../entities.js';
 
 const nonEmptyString = z.string().trim().min(1, 'String fields must not be empty.');
 const finiteNumber = z.number().finite('Value must be a finite number.');
+const slugString = z
+  .string({ required_error: 'slug is required.' })
+  .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'Slug must be kebab-case (lowercase, digits, hyphen).');
 
 const placementScopeSchema = z.enum([...DEVICE_PLACEMENT_SCOPES]);
 const roomPurposeSchema = z.enum([...ROOM_PURPOSES]);
+const deviceClassSchema = z.enum([
+  'device.climate.cooling',
+  'device.climate.co2',
+  'device.climate.dehumidifier',
+  'device.climate.humidity-controller',
+  'device.airflow.exhaust',
+  'device.lighting.vegetative'
+]);
+
+type DeviceClass = z.infer<typeof deviceClassSchema>;
 
 /**
  * Canonical device blueprint contract enforced for JSON payloads.
@@ -14,9 +27,9 @@ const roomPurposeSchema = z.enum([...ROOM_PURPOSES]);
 const deviceBlueprintObjectSchema = z
   .object({
     id: z.string().uuid('Device blueprint id must be a UUID v4.'),
-    slug: nonEmptyString.optional(),
+    slug: slugString,
+    class: deviceClassSchema,
     name: nonEmptyString,
-    kind: nonEmptyString.optional(),
     placementScope: placementScopeSchema,
     allowedRoomPurposes: z
       .array(roomPurposeSchema, {
@@ -34,15 +47,107 @@ const deviceBlueprintObjectSchema = z
   })
   .passthrough();
 
-export const deviceBlueprintSchema = deviceBlueprintObjectSchema.superRefine((blueprint, ctx) => {
-    if (!blueprint.coverage_m2 && !blueprint.airflow_m3_per_h) {
+function ensureNestedField(
+  blueprint: Record<string, unknown>,
+  path: readonly (string | number)[],
+  ctx: z.RefinementCtx,
+  message: string
+): void {
+  let cursor: unknown = blueprint;
+
+  for (const segment of path) {
+    if (cursor && typeof cursor === 'object' && segment in (cursor as Record<string, unknown>)) {
+      cursor = (cursor as Record<string, unknown>)[segment as string];
+    } else {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        path: ['coverage_m2'],
-        message: 'Device blueprint must declare coverage_m2 or airflow_m3_per_h.'
+        message,
+        path: [...path]
       });
+      return;
     }
-  });
+  }
+
+  if (cursor === undefined || cursor === null) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message,
+      path: [...path]
+    });
+  }
+}
+
+const classSpecificValidators: Record<DeviceClass, (blueprint: Record<string, unknown>, ctx: z.RefinementCtx) => void> = {
+  'device.climate.cooling': (blueprint, ctx) => {
+    ensureNestedField(blueprint, ['coverage', 'maxArea_m2'], ctx, 'Cooling units require coverage.maxArea_m2.');
+    ensureNestedField(blueprint, ['limits', 'coolingCapacity_kW'], ctx, 'Cooling units require limits.coolingCapacity_kW.');
+    ensureNestedField(blueprint, ['settings', 'coolingCapacity'], ctx, 'Cooling units require settings.coolingCapacity.');
+    ensureNestedField(blueprint, ['settings', 'targetTemperature'], ctx, 'Cooling units require settings.targetTemperature.');
+    ensureNestedField(
+      blueprint,
+      ['settings', 'targetTemperatureRange'],
+      ctx,
+      'Cooling units require settings.targetTemperatureRange.'
+    );
+  },
+  'device.climate.co2': (blueprint, ctx) => {
+    ensureNestedField(blueprint, ['limits', 'maxCO2_ppm'], ctx, 'CO₂ injectors require limits.maxCO2_ppm.');
+    ensureNestedField(blueprint, ['settings', 'targetCO2'], ctx, 'CO₂ injectors require settings.targetCO2.');
+    ensureNestedField(blueprint, ['settings', 'pulsePpmPerTick'], ctx, 'CO₂ injectors require settings.pulsePpmPerTick.');
+  },
+  'device.climate.dehumidifier': (blueprint, ctx) => {
+    ensureNestedField(
+      blueprint,
+      ['limits', 'removalRate_kg_h'],
+      ctx,
+      'Dehumidifiers require limits.removalRate_kg_h.'
+    );
+    ensureNestedField(
+      blueprint,
+      ['settings', 'latentRemovalKgPerTick'],
+      ctx,
+      'Dehumidifiers require settings.latentRemovalKgPerTick.'
+    );
+  },
+  'device.climate.humidity-controller': (blueprint, ctx) => {
+    ensureNestedField(
+      blueprint,
+      ['settings', 'humidifyRateKgPerTick'],
+      ctx,
+      'Humidity controllers require settings.humidifyRateKgPerTick.'
+    );
+    ensureNestedField(
+      blueprint,
+      ['settings', 'dehumidifyRateKgPerTick'],
+      ctx,
+      'Humidity controllers require settings.dehumidifyRateKgPerTick.'
+    );
+  },
+  'device.airflow.exhaust': (blueprint, ctx) => {
+    ensureNestedField(blueprint, ['airflow_m3_per_h'], ctx, 'Exhaust fans require airflow_m3_per_h.');
+    ensureNestedField(blueprint, ['settings', 'airflow'], ctx, 'Exhaust fans require settings.airflow.');
+  },
+  'device.lighting.vegetative': (blueprint, ctx) => {
+    ensureNestedField(blueprint, ['coverage', 'maxArea_m2'], ctx, 'Grow lights require coverage.maxArea_m2.');
+    ensureNestedField(blueprint, ['settings', 'ppfd'], ctx, 'Grow lights require settings.ppfd.');
+    ensureNestedField(blueprint, ['settings', 'spectralRange'], ctx, 'Grow lights require settings.spectralRange.');
+  }
+};
+
+export const deviceBlueprintSchema = deviceBlueprintObjectSchema.superRefine((blueprint, ctx) => {
+  if (!blueprint.coverage_m2 && !blueprint.airflow_m3_per_h) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['coverage_m2'],
+      message: 'Device blueprint must declare coverage_m2 or airflow_m3_per_h.'
+    });
+  }
+
+  const validator = classSpecificValidators[blueprint.class as DeviceClass];
+  if (validator) {
+    validator(blueprint, ctx);
+  }
+});
 
 export type DeviceBlueprint = z.infer<typeof deviceBlueprintSchema>;
 


### PR DESCRIPTION
## Summary
- add `<domain>.<effect>[.<variant>]` class metadata and kebab-case slugs across blueprint JSON fixtures while removing legacy kind/type fields
- harden the device blueprint schema to require class-aware validation and extend unit coverage for taxonomy-driven parsing
- document the taxonomy with a new ADR plus SEC/DD/CHANGELOG updates

## Testing
- pnpm --filter engine test *(fails: workspace lacks vitest binary in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de76807f308325a641465021fb2ec4