### PR TITLE
Normalize irrigation compatibility slugs and add validation

### DIFF
--- a/data/blueprints/irrigationMethods/drip-inline-fertigation-basic.json
+++ b/data/blueprints/irrigationMethods/drip-inline-fertigation-basic.json
@@ -22,9 +22,9 @@
   },
   "compatibility": {
     "substrates": [
-      "soil",
-      "coco",
-      "rockwool"
+      "coco-coir",
+      "soil-single-cycle",
+      "soil-multi-cycle"
     ],
     "methods": [
       "sog",

--- a/data/blueprints/irrigationMethods/ebb-flow-table-small.json
+++ b/data/blueprints/irrigationMethods/ebb-flow-table-small.json
@@ -22,9 +22,7 @@
   },
   "compatibility": {
     "substrates": [
-      "coco",
-      "rockwool",
-      "perlite"
+      "coco-coir"
     ],
     "methods": [
       "sog",
@@ -50,6 +48,6 @@
       "Power dependency",
       "Not suitable for soil"
     ],
-    "notes": "Ideal for SOG/SCROG methods with coco or rockwool. Captured runoff reduces water costs."
+    "notes": "Ideal for SOG/SCROG methods with coco coir. Captured runoff reduces water costs."
   }
 }

--- a/data/blueprints/irrigationMethods/manual-watering-can.json
+++ b/data/blueprints/irrigationMethods/manual-watering-can.json
@@ -22,8 +22,9 @@
   },
   "compatibility": {
     "substrates": [
-      "soil",
-      "coco"
+      "soil-single-cycle",
+      "soil-multi-cycle",
+      "coco-coir"
     ],
     "methods": [
       "sog",

--- a/data/blueprints/irrigationMethods/top-feed-pump-timer.json
+++ b/data/blueprints/irrigationMethods/top-feed-pump-timer.json
@@ -22,9 +22,9 @@
   },
   "compatibility": {
     "substrates": [
-      "soil",
-      "coco",
-      "perlite"
+      "soil-single-cycle",
+      "soil-multi-cycle",
+      "coco-coir"
     ],
     "methods": [
       "sog",

--- a/docs/ADR/ADR-0003-irrigation-compatibility-source-of-truth.md
+++ b/docs/ADR/ADR-0003-irrigation-compatibility-source-of-truth.md
@@ -9,6 +9,7 @@ ADR-0002 shifted irrigation compatibility metadata from cultivation methods to s
 ## Decision
 - Remove `supportedIrrigationMethodIds` from substrate blueprints entirely.
 - Treat irrigation method blueprints as the canonical source of irrigation/substrate compatibility by continuing to require `compatibility.substrates`.
+- Require `compatibility.substrates` entries to reference the canonical substrate slug (or id) exported by the substrate blueprints; validation fails fast when a slug drifts.
 - Update SEC, DD, and TDD guidance so cultivation methods infer irrigation support by cross-referencing the substrate slug against irrigation methods that list it, avoiding redundant arrays on substrate definitions.
 - Mark ADR-0002 as superseded by this decision to preserve historical context.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### #41 WB-034 irrigation compatibility slug validation
+- Normalised every irrigation blueprint `compatibility.substrates` entry to the real substrate
+  slugs shipped under `/data/blueprints/substrates`, removing phantom media names and keeping
+  scenario metadata aligned with available inventory.
+- Added an irrigation blueprint parser that validates compatibility entries against the
+  known substrate slug set and fails fast when unknown media sneak in, with unit coverage
+  for the repository fixtures and regression cases.
+- Expanded cultivation compatibility tests so method defaults and substrate options resolve
+  to at least one compatible irrigation blueprint automatically, preventing future drift.
+
 ### #40 WB-033 substrate density enforcement
 - Enriched every substrate blueprint with `purchaseUnit`, `unitPrice_per_*`, `densityFactor_L_per_kg`,
   and explicit `reusePolicy` metadata aligned with SEC §7.5 so cultivation tooling can convert

--- a/packages/engine/src/backend/src/domain/blueprints/irrigationBlueprint.ts
+++ b/packages/engine/src/backend/src/domain/blueprints/irrigationBlueprint.ts
@@ -1,0 +1,85 @@
+import { z } from 'zod';
+
+const slugString = z
+  .string({ required_error: 'slug is required.' })
+  .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'Slug must be kebab-case (lowercase, digits, hyphen).');
+
+const nonEmptyString = z
+  .string({ required_error: 'value is required.' })
+  .trim()
+  .min(1, 'String fields must not be empty.');
+
+const classSchema = z
+  .string({ required_error: 'class is required.' })
+  .regex(
+    /^irrigation\.[a-z0-9]+(?:[.-][a-z0-9]+)*$/,
+    'class must begin with "irrigation." and use lowercase dot/kebab segments.'
+  );
+
+const compatibilitySchema = z.object({
+  substrates: z
+    .array(slugString, {
+      required_error: 'compatibility.substrates is required.',
+      invalid_type_error: 'compatibility.substrates must be an array of substrate slugs.'
+    })
+    .min(1, 'compatibility.substrates must contain at least one substrate slug.'),
+  methods: z
+    .array(nonEmptyString, {
+      invalid_type_error: 'compatibility.methods must be an array of strings.'
+    })
+    .default([])
+});
+
+const irrigationBlueprintBaseSchema = z
+  .object({
+    id: z.string().uuid('Irrigation blueprint id must be a UUID v4.'),
+    slug: slugString,
+    class: classSchema,
+    name: nonEmptyString,
+    description: nonEmptyString.optional(),
+    compatibility: compatibilitySchema,
+    meta: z.record(z.unknown()).optional()
+  })
+  .passthrough();
+
+export type IrrigationBlueprint = z.infer<typeof irrigationBlueprintBaseSchema>;
+
+export function createIrrigationBlueprintSchema(
+  knownSubstrateSlugs: ReadonlySet<string>
+): z.ZodType<IrrigationBlueprint> {
+  return irrigationBlueprintBaseSchema.superRefine((blueprint, ctx) => {
+    const { substrates } = blueprint.compatibility;
+
+    substrates.forEach((substrateSlug, index) => {
+      if (!knownSubstrateSlugs.has(substrateSlug)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['compatibility', 'substrates', index],
+          message: `compatibility.substrates[${String(
+            index
+          )}] references unknown substrate slug "${substrateSlug}"`
+        });
+      }
+    });
+  });
+}
+
+export interface ParseIrrigationBlueprintOptions {
+  readonly knownSubstrateSlugs: Iterable<string>;
+}
+
+export function parseIrrigationBlueprint(
+  input: unknown,
+  options: ParseIrrigationBlueprintOptions
+): IrrigationBlueprint {
+  if (!options?.knownSubstrateSlugs) {
+    throw new Error('knownSubstrateSlugs must be provided to validate irrigation compatibility.');
+  }
+
+  const slugSet =
+    options.knownSubstrateSlugs instanceof Set
+      ? (options.knownSubstrateSlugs as ReadonlySet<string>)
+      : new Set(options.knownSubstrateSlugs);
+
+  return createIrrigationBlueprintSchema(slugSet).parse(input);
+}

--- a/packages/engine/src/backend/src/domain/world.ts
+++ b/packages/engine/src/backend/src/domain/world.ts
@@ -3,6 +3,7 @@ export * from './schemas.js';
 export * from './validation.js';
 export * from './blueprints/deviceBlueprint.js';
 export * from './blueprints/substrateBlueprint.js';
+export * from './blueprints/irrigationBlueprint.js';
 export * from './pricing/devicePriceMap.js';
 export * from '../device/createDeviceInstance.js';
 export * from '../device/condition.js';

--- a/packages/engine/tests/unit/domain/cultivationIrrigationCompatibility.test.ts
+++ b/packages/engine/tests/unit/domain/cultivationIrrigationCompatibility.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import dripInline from '../../../../../data/blueprints/irrigationMethods/drip-inline-fertigation-basic.json' assert { type: 'json' };
+import ebbFlow from '../../../../../data/blueprints/irrigationMethods/ebb-flow-table-small.json' assert { type: 'json' };
+import manualCan from '../../../../../data/blueprints/irrigationMethods/manual-watering-can.json' assert { type: 'json' };
+import topFeed from '../../../../../data/blueprints/irrigationMethods/top-feed-pump-timer.json' assert { type: 'json' };
+import cocoCoir from '../../../../../data/blueprints/substrates/coco_coir.json' assert { type: 'json' };
+import soilMulti from '../../../../../data/blueprints/substrates/soil_multi_cycle.json' assert { type: 'json' };
+import soilSingle from '../../../../../data/blueprints/substrates/soil_single_cycle.json' assert { type: 'json' };
+import basicSoilPot from '../../../../../data/blueprints/cultivationMethods/basic_soil_pot.json' assert { type: 'json' };
+import scrog from '../../../../../data/blueprints/cultivationMethods/scrog.json' assert { type: 'json' };
+import sog from '../../../../../data/blueprints/cultivationMethods/sog.json' assert { type: 'json' };
+
+import { parseIrrigationBlueprint, type IrrigationBlueprint } from '@/backend/src/domain/world.js';
+
+type CultivationBlueprint = typeof basicSoilPot;
+
+describe('irrigation compatibility coverage', () => {
+  const substrateSlugs = new Set([
+    cocoCoir.slug as string,
+    soilMulti.slug as string,
+    soilSingle.slug as string
+  ]);
+
+  const irrigationFixtures = [dripInline, ebbFlow, manualCan, topFeed] as const;
+  const irrigationBlueprints = irrigationFixtures.map((fixture) =>
+    parseIrrigationBlueprint(fixture, { knownSubstrateSlugs: substrateSlugs })
+  );
+
+  const cultivationMethods = [basicSoilPot, scrog, sog] as const satisfies readonly CultivationBlueprint[];
+
+  const compatibilityIndex = new Map<string, IrrigationBlueprint[]>();
+  irrigationBlueprints.forEach((blueprint) => {
+    blueprint.compatibility.substrates.forEach((substrateSlug) => {
+      const existing = compatibilityIndex.get(substrateSlug) ?? [];
+      existing.push(blueprint);
+      compatibilityIndex.set(substrateSlug, existing);
+    });
+  });
+
+  function resolveCompatibleIrrigation(substrateSlug: string): IrrigationBlueprint | undefined {
+    const compatible = compatibilityIndex.get(substrateSlug);
+    return compatible?.[0];
+  }
+
+  it('covers every cultivation substrate with at least one irrigation method', () => {
+    cultivationMethods.forEach((method) => {
+      method.substrates.forEach((substrateSlug: string) => {
+        const compatibleMethods = compatibilityIndex.get(substrateSlug);
+        expect(compatibleMethods, `No irrigation method exposes substrate ${substrateSlug}`).toBeDefined();
+        expect(compatibleMethods?.length ?? 0).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  it('resolves default cultivation substrates to an irrigation method automatically', () => {
+    cultivationMethods.forEach((method) => {
+      const defaultSubstrate = method.meta?.defaults?.substrateSlug as string | undefined;
+      expect(defaultSubstrate, `Cultivation method ${method.slug} is missing a default substrate`).toBeTruthy();
+
+      if (!defaultSubstrate) {
+        return;
+      }
+
+      const resolved = resolveCompatibleIrrigation(defaultSubstrate);
+      expect(resolved, `No irrigation method compatible with ${defaultSubstrate}`).toBeTruthy();
+    });
+  });
+});

--- a/packages/engine/tests/unit/domain/irrigationBlueprintSchema.test.ts
+++ b/packages/engine/tests/unit/domain/irrigationBlueprintSchema.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import dripInline from '../../../../../data/blueprints/irrigationMethods/drip-inline-fertigation-basic.json' assert { type: 'json' };
+import ebbFlow from '../../../../../data/blueprints/irrigationMethods/ebb-flow-table-small.json' assert { type: 'json' };
+import manualCan from '../../../../../data/blueprints/irrigationMethods/manual-watering-can.json' assert { type: 'json' };
+import topFeed from '../../../../../data/blueprints/irrigationMethods/top-feed-pump-timer.json' assert { type: 'json' };
+import cocoCoir from '../../../../../data/blueprints/substrates/coco_coir.json' assert { type: 'json' };
+import soilMulti from '../../../../../data/blueprints/substrates/soil_multi_cycle.json' assert { type: 'json' };
+import soilSingle from '../../../../../data/blueprints/substrates/soil_single_cycle.json' assert { type: 'json' };
+
+import { parseIrrigationBlueprint } from '@/backend/src/domain/world.js';
+
+describe('parseIrrigationBlueprint', () => {
+  const substrateSlugs = new Set([
+    cocoCoir.slug as string,
+    soilMulti.slug as string,
+    soilSingle.slug as string
+  ]);
+
+  const fixtures = [dripInline, ebbFlow, manualCan, topFeed] as const;
+
+  it('parses repository irrigation blueprints without modification', () => {
+    fixtures.forEach((fixture) => {
+      expect(() =>
+        parseIrrigationBlueprint(fixture, { knownSubstrateSlugs: substrateSlugs })
+      ).not.toThrow();
+    });
+  });
+
+  it('rejects blueprints referencing unknown substrate slugs', () => {
+    const invalid = JSON.parse(JSON.stringify(manualCan)) as typeof manualCan;
+    invalid.compatibility.substrates = [...invalid.compatibility.substrates, 'unknown-substrate'];
+
+    expect(() =>
+      parseIrrigationBlueprint(invalid, { knownSubstrateSlugs: substrateSlugs })
+    ).toThrow(/unknown substrate slug/);
+  });
+});


### PR DESCRIPTION
## Summary
- align irrigation method blueprint compatibility substrates with the actual substrate slugs shipped in the repository
- add an irrigation blueprint parser that validates compatibility slugs against the known substrate set and export it via the domain barrel
- extend unit coverage to exercise irrigation compatibility validation, cultivation method defaults, and document the slug expectation in the ADR/CHANGELOG

## Testing
- pnpm --filter @wb/engine test *(fails: `vitest` not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de8270f2d08325a55ad097e231bf6f