### PR TITLE
WB-035 Align blueprint taxonomy with filesystem

### DIFF
--- a/data/blueprints/device/airflow/exhaust/exhaust_fan_01.json
+++ b/data/blueprints/device/airflow/exhaust/exhaust_fan_01.json
@@ -1,0 +1,49 @@
+{
+  "id": "f5d5c5a0-1b2c-4d3e-8f9a-0b1c2d3e4f5a",
+  "slug": "exhaust-fan-4-inch",
+  "class": "device.airflow.exhaust",
+  "name": "Exhaust Fan 4-inch",
+  "placementScope": "zone",
+  "allowedRoomPurposes": [
+    "growroom"
+  ],
+  "power_W": 50,
+  "efficiency01": 0.7,
+  "coverage_m2": 5,
+  "airflow_m3_per_h": 170,
+  "quality": 0.7,
+  "complexity": 0.1,
+  "lifetime_h": 17520,
+  "coverage": {
+    "maxVolume_m3": 15.0,
+    "ventilationPattern": "exhaust"
+  },
+  "limits": {
+    "power_W": 50,
+    "airflow_m3_h": 200,
+    "minAirflow_m3_h": 100,
+    "maxStaticPressure_Pa": 150
+  },
+  "efficiencyDegeneration": 0.5,
+  "maintenance": {
+    "intervalDays": 30,
+    "hoursPerService": 0.25
+  },
+  "settings": {
+    "power": 0.05,
+    "airflow": 170
+  },
+  "meta": {
+    "description": "A simple and affordable exhaust fan with an airflow of 170 m\u00b3/h, perfect for small tents and grow areas. Effectively removes heat, humidity, and stale air by exchanging it with the ambient environment.",
+    "advantages": [
+      "Low cost",
+      "Low power consumption",
+      "Effective for small-scale climate control"
+    ],
+    "disadvantages": [
+      "Not as effective as an AC unit for large heat loads",
+      "Relies on ambient temperature for cooling"
+    ],
+    "notes": "Essential for any small grow setup to prevent heat and humidity buildup without the cost of a full climate unit."
+  }
+}

--- a/data/blueprints/device/climate/co2/co2injector-01.json
+++ b/data/blueprints/device/climate/co2/co2injector-01.json
@@ -1,0 +1,52 @@
+{
+  "id": "c701efa6-1e90-4f28-8934-ea9c584596e4",
+  "slug": "co2-pulse",
+  "class": "device.climate.co2",
+  "name": "CO2 Pulse",
+  "placementScope": "zone",
+  "allowedRoomPurposes": [
+    "growroom"
+  ],
+  "power_W": 50,
+  "efficiency01": 0.9,
+  "coverage_m2": 10,
+  "quality": 0.85,
+  "complexity": 0.15,
+  "lifetime_h": 8760,
+  "coverage": {
+    "maxVolume_m3": 30.0,
+    "distributionPattern": "point-source"
+  },
+  "limits": {
+    "power_W": 50,
+    "co2Rate_ppm_min": 200,
+    "maxCO2_ppm": 1500,
+    "minCO2_ppm": 350
+  },
+  "efficiencyDegeneration": 0.8,
+  "maintenance": {
+    "intervalDays": 60,
+    "hoursPerService": 0.75
+  },
+  "settings": {
+    "power": 0.05,
+    "targetCO2": 1100,
+    "targetCO2Range": [
+      400,
+      1500
+    ],
+    "hysteresis": 60,
+    "pulsePpmPerTick": 150
+  },
+  "meta": {
+    "description": "Automated CO2 injector for controlled enrichment.",
+    "advantages": [
+      "Precise dosing",
+      "Energy efficient"
+    ],
+    "disadvantages": [
+      "Requires CO2 supply",
+      "Overuse can harm plants"
+    ]
+  }
+}

--- a/data/blueprints/device/climate/cooling/climate_unit_01.json
+++ b/data/blueprints/device/climate/cooling/climate_unit_01.json
@@ -1,0 +1,59 @@
+{
+  "id": "7d3d3f1a-8c6f-4e9c-926d-5a2a4a3b6f1b",
+  "slug": "cool-air-split-3000",
+  "class": "device.climate.cooling",
+  "name": "CoolAir Split 3000",
+  "placementScope": "zone",
+  "allowedRoomPurposes": [
+    "growroom"
+  ],
+  "power_W": 1200,
+  "efficiency01": 0.65,
+  "coverage_m2": 25,
+  "airflow_m3_per_h": 350,
+  "quality": 0.9,
+  "complexity": 0.4,
+  "lifetime_h": 35040,
+  "coverage": {
+    "maxArea_m2": 25.0,
+    "airflowPattern": "directional"
+  },
+  "limits": {
+    "power_W": 1200,
+    "coolingCapacity_kW": 3.0,
+    "maxAirflow_m3_h": 400,
+    "minTemperature_C": 16,
+    "maxTemperature_C": 32
+  },
+  "efficiencyDegeneration": 1.8,
+  "maintenance": {
+    "intervalDays": 90,
+    "hoursPerService": 2.0
+  },
+  "settings": {
+    "power": 1.2,
+    "coolingCapacity": 1.6,
+    "airflow": 350,
+    "targetTemperature": 24,
+    "targetTemperatureRange": [
+      18,
+      30
+    ],
+    "cop": 3.2,
+    "hysteresisK": 0.8,
+    "fullPowerAtDeltaK": 2
+  },
+  "meta": {
+    "description": "High-performance climate control unit for clean indoor cultivation rooms; targeted cooling with moderate energy usage and solid airflow.",
+    "advantages": [
+      "Effective cooling for medium-sized rooms",
+      "Reliable airflow distribution",
+      "Energy-efficient at moderate loads"
+    ],
+    "disadvantages": [
+      "Higher maintenance costs over time",
+      "Limited precision for multi-zone systems"
+    ],
+    "notes": "Recommended for vegetative and early flowering stages in temperate climates."
+  }
+}

--- a/data/blueprints/device/climate/dehumidifier/dehumidifier-01.json
+++ b/data/blueprints/device/climate/dehumidifier/dehumidifier-01.json
@@ -1,0 +1,46 @@
+{
+  "id": "7a639d3d-4750-440a-a200-f90d11dc3c62",
+  "slug": "drybox-200",
+  "class": "device.climate.dehumidifier",
+  "name": "DryBox 200",
+  "placementScope": "zone",
+  "allowedRoomPurposes": [
+    "growroom"
+  ],
+  "power_W": 300,
+  "efficiency01": 0.6,
+  "coverage_m2": 6.67,
+  "quality": 0.8,
+  "complexity": 0.25,
+  "lifetime_h": 26280,
+  "coverage": {
+    "maxVolume_m3": 20.0,
+    "removalPattern": "ambient"
+  },
+  "limits": {
+    "power_W": 300,
+    "removalRate_kg_h": 1.8,
+    "minHumidity_percent": 30,
+    "maxHumidity_percent": 90
+  },
+  "efficiencyDegeneration": 1.2,
+  "maintenance": {
+    "intervalDays": 45,
+    "hoursPerService": 1.0
+  },
+  "settings": {
+    "latentRemovalKgPerTick": 0.05,
+    "power": 0.3
+  },
+  "meta": {
+    "description": "Compact unit for reducing ambient humidity.",
+    "advantages": [
+      "Efficient moisture removal",
+      "Low energy consumption"
+    ],
+    "disadvantages": [
+      "Limited capacity for large rooms",
+      "Generates heat"
+    ]
+  }
+}

--- a/data/blueprints/device/climate/humidity-controller/humidity_control_unit_01.json
+++ b/data/blueprints/device/climate/humidity-controller/humidity_control_unit_01.json
@@ -1,0 +1,49 @@
+{
+  "id": "3d762260-88a5-4104-b03c-9860bbac34b6",
+  "slug": "humidity-control-unit-l1",
+  "class": "device.climate.humidity-controller",
+  "name": "Humidity Control Unit L1",
+  "placementScope": "zone",
+  "allowedRoomPurposes": [
+    "growroom"
+  ],
+  "power_W": 350,
+  "efficiency01": 0.6,
+  "coverage_m2": 8.33,
+  "quality": 0.8,
+  "complexity": 0.3,
+  "lifetime_h": 8760,
+  "coverage": {
+    "maxVolume_m3": 25.0,
+    "controlPattern": "dual-mode"
+  },
+  "limits": {
+    "power_W": 350,
+    "capacity_kg_h": 3.6,
+    "minHumidity_percent": 30,
+    "maxHumidity_percent": 85
+  },
+  "efficiencyDegeneration": 1.5,
+  "maintenance": {
+    "intervalDays": 45,
+    "hoursPerService": 1.25
+  },
+  "settings": {
+    "power": 0.35,
+    "humidifyRateKgPerTick": 0.1,
+    "dehumidifyRateKgPerTick": 0.1,
+    "targetHumidity": 0.6,
+    "hysteresis": 0.05
+  },
+  "meta": {
+    "description": "A standard unit to control humidity.",
+    "advantages": [
+      "Handles both humidification and dehumidification",
+      "Simple to operate"
+    ],
+    "disadvantages": [
+      "Limited capacity for large rooms",
+      "Requires regular maintenance"
+    ]
+  }
+}

--- a/data/blueprints/device/lighting/vegetative/veg_light_01.json
+++ b/data/blueprints/device/lighting/vegetative/veg_light_01.json
@@ -1,0 +1,54 @@
+{
+  "id": "3b5f6ad7-672e-47cd-9a24-f0cc45c4101e",
+  "slug": "led-veg-light-600",
+  "class": "device.lighting.vegetative",
+  "name": "LED VegLight 600",
+  "placementScope": "zone",
+  "allowedRoomPurposes": [
+    "growroom"
+  ],
+  "power_W": 600,
+  "efficiency01": 0.7,
+  "coverage_m2": 1.2,
+  "quality": 0.95,
+  "complexity": 0.2,
+  "lifetime_h": 52560,
+  "coverage": {
+    "maxArea_m2": 1.2,
+    "effectivePPFD_at_m": 0.6,
+    "beamProfile": "wide"
+  },
+  "limits": {
+    "power_W": 600,
+    "maxPPFD": 1200,
+    "minPPFD": 200
+  },
+  "efficiencyDegeneration": 2.5,
+  "maintenance": {
+    "intervalDays": 30,
+    "hoursPerService": 0.5
+  },
+  "settings": {
+    "power": 0.6,
+    "ppfd": 800,
+    "coverageArea": 1.2,
+    "spectralRange": [
+      400,
+      700
+    ],
+    "heatFraction": 0.3
+  },
+  "meta": {
+    "description": "Full-spectrum LED grow light optimized for the vegetative phase of cannabis plants. Balanced light distribution with low heat generation.",
+    "advantages": [
+      "High energy efficiency",
+      "Low heat output",
+      "Ideal for early growth stages"
+    ],
+    "disadvantages": [
+      "Limited effectiveness for flowering",
+      "Higher upfront cost compared to HPS"
+    ],
+    "notes": "Best used in enclosed environments with adequate canopy management."
+  }
+}

--- a/data/blueprints/irrigation/drip/inline-fertigation/drip-inline-fertigation-basic.json
+++ b/data/blueprints/irrigation/drip/inline-fertigation/drip-inline-fertigation-basic.json
@@ -1,0 +1,56 @@
+{
+  "id": "c8f3a2b1-7d4e-4c9a-b5e6-3f8a9c1d2e4f",
+  "slug": "drip-inline-fertigation-basic",
+  "class": "irrigation.drip.inline-fertigation",
+  "name": "Drip Inline Fertigation (Basic)",
+  "description": "Automated drip irrigation with inline nutrient injection. Balanced labor and uniformity.",
+  "mixing": "inline",
+  "couplesFertilizer": true,
+  "flow_L_per_min": 2.5,
+  "uniformity": 0.88,
+  "labor": {
+    "basis": "perZone",
+    "minutes": 5.0
+  },
+  "runoff": {
+    "defaultFraction": 0.1,
+    "capturesRunoff": false
+  },
+  "requirements": {
+    "power_kW": 0.15,
+    "minPressure_bar": 1.5
+  },
+  "compatibility": {
+    "substrates": [
+      "coco-coir",
+      "soil-single-cycle",
+      "soil-multi-cycle"
+    ],
+    "methods": [
+      "sog",
+      "scrog",
+      "basic_soil_pot"
+    ]
+  },
+  "maintenance": {
+    "inspectionEveryDays": 7,
+    "cleaningEveryDays": 30,
+    "clogsRisk": 0.15
+  },
+  "meta": {
+    "description": "Basic drip system with inline nutrient dosing. Requires water pressure and power for pump and injector.",
+    "advantages": [
+      "Good uniformity",
+      "Automated delivery",
+      "Reduced labor",
+      "Precise nutrient control"
+    ],
+    "disadvantages": [
+      "Requires maintenance",
+      "Clog risk",
+      "Initial setup cost",
+      "Pressure dependency"
+    ],
+    "notes": "Suitable for medium to large zones. Inspect emitters weekly to prevent clogs."
+  }
+}

--- a/data/blueprints/irrigation/ebb-flow/table/ebb-flow-table-small.json
+++ b/data/blueprints/irrigation/ebb-flow/table/ebb-flow-table-small.json
@@ -1,0 +1,53 @@
+{
+  "id": "d9e4b3c2-8e5f-5d0b-c6f7-4g9b0d2e3f5g",
+  "slug": "ebb-flow-table-small",
+  "class": "irrigation.ebb-flow.table",
+  "name": "Ebb & Flow Table (Small)",
+  "description": "Flood-and-drain table system with batch nutrient mixing. High uniformity, moderate labor.",
+  "mixing": "batch",
+  "couplesFertilizer": true,
+  "flow_L_per_min": 15.0,
+  "uniformity": 0.92,
+  "labor": {
+    "basis": "perZone",
+    "minutes": 8.0
+  },
+  "runoff": {
+    "defaultFraction": 0.05,
+    "capturesRunoff": true
+  },
+  "requirements": {
+    "power_kW": 0.25,
+    "minPressure_bar": 0.5
+  },
+  "compatibility": {
+    "substrates": [
+      "coco-coir"
+    ],
+    "methods": [
+      "sog",
+      "scrog"
+    ]
+  },
+  "maintenance": {
+    "inspectionEveryDays": 10,
+    "cleaningEveryDays": 21,
+    "clogsRisk": 0.08
+  },
+  "meta": {
+    "description": "Table-based flood-and-drain system. Nutrients are mixed in a reservoir and pumped to flood the table periodically.",
+    "advantages": [
+      "Excellent uniformity",
+      "Runoff capture and reuse",
+      "Efficient water use",
+      "Good for dense plantings"
+    ],
+    "disadvantages": [
+      "Higher setup cost",
+      "Requires reservoir management",
+      "Power dependency",
+      "Not suitable for soil"
+    ],
+    "notes": "Ideal for SOG/SCROG methods with coco coir. Captured runoff reduces water costs."
+  }
+}

--- a/data/blueprints/irrigation/manual/can/manual-watering-can.json
+++ b/data/blueprints/irrigation/manual/can/manual-watering-can.json
@@ -1,0 +1,55 @@
+{
+  "id": "b7a5d5fa-6561-4a1c-93c8-2d3f9a11c201",
+  "slug": "manual-watering-can",
+  "class": "irrigation.manual.can",
+  "name": "Watering Can",
+  "description": "Hand watering with premixed nutrients; highest labor, lowest capex.",
+  "mixing": "batch",
+  "couplesFertilizer": true,
+  "flow_L_per_min": 4,
+  "uniformity": 0.75,
+  "labor": {
+    "basis": "perPlant",
+    "minutes": 1.0
+  },
+  "runoff": {
+    "defaultFraction": 0.15,
+    "capturesRunoff": false
+  },
+  "requirements": {
+    "power_kW": 0,
+    "minPressure_bar": 0
+  },
+  "compatibility": {
+    "substrates": [
+      "soil-single-cycle",
+      "soil-multi-cycle",
+      "coco-coir"
+    ],
+    "methods": [
+      "sog",
+      "scrog",
+      "basic_soil_pot"
+    ]
+  },
+  "maintenance": {
+    "inspectionEveryDays": 14,
+    "cleaningEveryDays": 90,
+    "clogsRisk": 0.0
+  },
+  "meta": {
+    "description": "Simple hand watering with a can. Mix nutrients in batches before application. No automation, maximum flexibility.",
+    "advantages": [
+      "Zero capex",
+      "No power required",
+      "Works everywhere",
+      "Easy to adjust per plant"
+    ],
+    "disadvantages": [
+      "High labor cost",
+      "Inconsistent uniformity",
+      "Time-consuming for large zones"
+    ],
+    "notes": "Default fallback method for all zones. Ideal for small-scale or experimental setups."
+  }
+}

--- a/data/blueprints/irrigation/top-feed/timer/top-feed-pump-timer.json
+++ b/data/blueprints/irrigation/top-feed/timer/top-feed-pump-timer.json
@@ -1,0 +1,56 @@
+{
+  "id": "e0f5c4d3-9f6g-6e1c-d7g8-5h0c1e3f4g6h",
+  "slug": "top-feed-pump-timer",
+  "class": "irrigation.top-feed.timer",
+  "name": "Top-Feed Pump (Timer)",
+  "description": "Timer-controlled top-feed system with batch nutrient mixing. Automated delivery with moderate uniformity.",
+  "mixing": "batch",
+  "couplesFertilizer": true,
+  "flow_L_per_min": 3.5,
+  "uniformity": 0.82,
+  "labor": {
+    "basis": "perZone",
+    "minutes": 6.0
+  },
+  "runoff": {
+    "defaultFraction": 0.12,
+    "capturesRunoff": false
+  },
+  "requirements": {
+    "power_kW": 0.1,
+    "minPressure_bar": 0.8
+  },
+  "compatibility": {
+    "substrates": [
+      "soil-single-cycle",
+      "soil-multi-cycle",
+      "coco-coir"
+    ],
+    "methods": [
+      "sog",
+      "scrog",
+      "basic_soil_pot"
+    ]
+  },
+  "maintenance": {
+    "inspectionEveryDays": 7,
+    "cleaningEveryDays": 45,
+    "clogsRisk": 0.12
+  },
+  "meta": {
+    "description": "Simple top-feed system with timer control. Nutrients are mixed in a reservoir and pumped to plants on schedule.",
+    "advantages": [
+      "Low setup cost",
+      "Automated delivery",
+      "Works with most substrates",
+      "Easy to install"
+    ],
+    "disadvantages": [
+      "Moderate uniformity",
+      "Timer calibration needed",
+      "No runoff capture",
+      "Clog risk"
+    ],
+    "notes": "Good entry-level automation. Requires regular timer adjustments based on plant growth stage."
+  }
+}

--- a/data/blueprints/substrate/coco/coir/coco_coir.json
+++ b/data/blueprints/substrate/coco/coir/coco_coir.json
@@ -1,0 +1,27 @@
+{
+  "id": "285041f1-9586-4b43-b55c-0cb76f343037",
+  "slug": "coco-coir",
+  "class": "substrate.coco.coir",
+  "name": "Coco Coir",
+  "maxCycles": 4,
+  "purchaseUnit": "liter",
+  "unitPrice_per_L": 0.55,
+  "densityFactor_L_per_kg": 8.5,
+  "reusePolicy": {
+    "maxCycles": 4,
+    "sterilizationTaskCode": "overhaul_zone_substrate",
+    "sterilizationInterval_cycles": 1
+  },
+  "meta": {
+    "description": "Buffered coco coir blend optimized for drain-to-waste or recirculating fertigation systems with multiple reuse cycles.",
+    "advantages": [
+      "Excellent aeration drives rapid root development",
+      "Handles high-frequency fertigation without compaction",
+      "Reusable across four cycles with proper flushing"
+    ],
+    "disadvantages": [
+      "Demands precise nutrient and EC management",
+      "Dries quickly without automated irrigation"
+    ]
+  }
+}

--- a/data/blueprints/substrate/soil/multi-cycle/soil_multi_cycle.json
+++ b/data/blueprints/substrate/soil/multi-cycle/soil_multi_cycle.json
@@ -1,0 +1,27 @@
+{
+  "id": "ebdb6d5e-fb3d-4db2-90a4-8e6c5be137f4",
+  "slug": "soil-multi-cycle",
+  "class": "substrate.soil.multi-cycle",
+  "name": "Multi-Cycle Soil Mix",
+  "maxCycles": 2,
+  "purchaseUnit": "liter",
+  "unitPrice_per_L": 0.035,
+  "densityFactor_L_per_kg": 1.25,
+  "reusePolicy": {
+    "maxCycles": 2,
+    "sterilizationTaskCode": "overhaul_zone_substrate",
+    "sterilizationInterval_cycles": 1
+  },
+  "meta": {
+    "description": "Reconditionable soil blend that survives two full runs with proper amendment and sterilization between crops.",
+    "advantages": [
+      "Supports two reuse cycles with consistent structure",
+      "Balanced water retention keeps irrigation predictable",
+      "Cation exchange capacity stabilizes nutrient delivery"
+    ],
+    "disadvantages": [
+      "Needs re-amendment between harvests",
+      "Heavier medium increases handling effort"
+    ]
+  }
+}

--- a/data/blueprints/substrate/soil/single-cycle/soil_single_cycle.json
+++ b/data/blueprints/substrate/soil/single-cycle/soil_single_cycle.json
@@ -1,0 +1,25 @@
+{
+  "id": "04c8b1a5-09cc-4d86-8dc6-9007a64de6f2",
+  "slug": "soil-single-cycle",
+  "class": "substrate.soil.single-cycle",
+  "name": "Single-Cycle Soil Mix",
+  "maxCycles": 1,
+  "purchaseUnit": "liter",
+  "unitPrice_per_L": 0.025,
+  "densityFactor_L_per_kg": 1.4,
+  "reusePolicy": {
+    "maxCycles": 1
+  },
+  "meta": {
+    "description": "Pre-charged soil mix formulated for one-and-done harvests; ideal when designers prefer a fresh medium each run.",
+    "advantages": [
+      "Arrives with a balanced nutrient charge",
+      "High buffering capacity smooths pH swings",
+      "Familiar handling for soil-focused operators"
+    ],
+    "disadvantages": [
+      "Needs full replacement after a single cycle",
+      "Spent media can harbor pests if disposal is delayed"
+    ]
+  }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,8 +1,21 @@
 # Changelog
 
+### #42 WB-035 blueprint taxonomy guardrails align filesystem & class strings
+- Reorganised device, irrigation, and substrate blueprints under taxonomy-aligned
+  folders (e.g. `/data/blueprints/device/climate/cooling/**`) so directory
+  segments encode `<domain>.<effect>[.<variant>]`.
+- Extended the device, irrigation, and substrate schema parsers to accept the
+  blueprint file path, derive the expected taxonomy, and raise descriptive
+  errors when JSON `class` declarations drift from their folders.
+- Replaced the hard-coded device class enum with taxonomy validation while
+  keeping slug uniqueness per class via an opt-in registry for loaders.
+- Updated unit tests to load repository fixtures using absolute paths and
+  documented the guard in the tests, ensuring regressions trip immediately when
+  files land in the wrong folder.
+
 ### #41 WB-034 irrigation compatibility slug validation
 - Normalised every irrigation blueprint `compatibility.substrates` entry to the real substrate
-  slugs shipped under `/data/blueprints/substrates`, removing phantom media names and keeping
+  slugs shipped under `/data/blueprints/substrate`, removing phantom media names and keeping
   scenario metadata aligned with available inventory.
 - Added an irrigation blueprint parser that validates compatibility entries against the
   known substrate slug set and fails fast when unknown media sneak in, with unit coverage

--- a/docs/prompts/codex-issues.md
+++ b/docs/prompts/codex-issues.md
@@ -46,7 +46,7 @@
 > **GUARDRAILS & CHECKS**
 >
 > * No initial water/nutrient stockpiles; water is metered, nutrients via irrigation method.
-> * Add `irrigationMethods` blueprints, `cultivationMethods` with containers & substrates (incl. density L↔kg factor).
+> * Add `irrigation` blueprints, `cultivationMethods` with containers & substrates (incl. density L↔kg factor).
 > * Devices: power→heat coupling; quality01/condition01 on [0,1].
 > * Photoperiod hooks prepared (veg/flower switch).
 > * Everything typed, tests passing.

--- a/packages/engine/src/backend/src/domain/blueprints/taxonomy.ts
+++ b/packages/engine/src/backend/src/domain/blueprints/taxonomy.ts
@@ -1,0 +1,123 @@
+import path from 'node:path';
+
+const DEFAULT_BLUEPRINTS_ROOT = path.resolve('data/blueprints');
+const TAXONOMY_SEGMENT_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export interface BlueprintTaxonomyFromPath {
+  readonly className: string;
+  readonly domain: string;
+  readonly effect: string;
+  readonly variants: readonly string[];
+  readonly relativePath: string;
+}
+
+export interface BlueprintPathOptions {
+  readonly blueprintsRoot?: string;
+}
+
+export class BlueprintPathError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BlueprintPathError';
+  }
+}
+
+export class BlueprintClassMismatchError extends Error {
+  constructor(
+    readonly filePath: string,
+    readonly expectedClass: string,
+    readonly actualClass: string
+  ) {
+    super(
+      `Blueprint class mismatch for "${filePath}": expected "${expectedClass}" derived from the folder taxonomy, received "${actualClass}".`
+    );
+    this.name = 'BlueprintClassMismatchError';
+  }
+}
+
+function normaliseBlueprintRoot(root?: string): string {
+  if (!root) {
+    return DEFAULT_BLUEPRINTS_ROOT;
+  }
+
+  return path.isAbsolute(root) ? path.normalize(root) : path.resolve(root);
+}
+
+function toTaxonomySegment(raw: string): string {
+  const normalised = raw.trim().replace(/[\s_]+/g, '-').toLowerCase();
+  const collapsed = normalised.replace(/-+/g, '-');
+
+  if (!TAXONOMY_SEGMENT_PATTERN.test(collapsed)) {
+    throw new BlueprintPathError(
+      `Path segment "${raw}" must be lowercase kebab-case to participate in the taxonomy.`
+    );
+  }
+
+  return collapsed;
+}
+
+function toRelativeBlueprintPath(filePath: string, root: string): string {
+  const relative = path.relative(root, filePath);
+
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new BlueprintPathError(
+      `Blueprint file "${filePath}" must reside under "${root}" to derive taxonomy metadata.`
+    );
+  }
+
+  return relative.split(path.sep).filter(Boolean).join('/');
+}
+
+export function deriveBlueprintClassFromPath(
+  filePath: string,
+  options?: BlueprintPathOptions
+): BlueprintTaxonomyFromPath {
+  if (!filePath) {
+    throw new BlueprintPathError('Blueprint file path is required to derive taxonomy metadata.');
+  }
+
+  const absolutePath = path.isAbsolute(filePath) ? path.normalize(filePath) : path.resolve(filePath);
+  const root = normaliseBlueprintRoot(options?.blueprintsRoot);
+  const relativePath = toRelativeBlueprintPath(absolutePath, root);
+  const segments = relativePath.split('/');
+
+  if (segments.length < 3) {
+    throw new BlueprintPathError(
+      `Blueprint path "${relativePath}" must include at least <domain>/<effect>/<file>.`
+    );
+  }
+
+  const directorySegments = segments.slice(0, -1);
+
+  if (directorySegments.length < 2) {
+    throw new BlueprintPathError(
+      `Blueprint path "${relativePath}" must declare both domain and effect folders.`
+    );
+  }
+
+  const [domainSegment, effectSegment, ...rest] = directorySegments;
+  const domain = toTaxonomySegment(domainSegment);
+  const effect = toTaxonomySegment(effectSegment);
+  const variants = rest.map(toTaxonomySegment);
+  const className = [domain, effect, ...variants].join('.');
+
+  return {
+    className,
+    domain,
+    effect,
+    variants,
+    relativePath
+  } satisfies BlueprintTaxonomyFromPath;
+}
+
+export function assertBlueprintClassMatchesPath(
+  declaredClass: string,
+  filePath: string,
+  options?: BlueprintPathOptions
+): void {
+  const derived = deriveBlueprintClassFromPath(filePath, options);
+
+  if (declaredClass !== derived.className) {
+    throw new BlueprintClassMismatchError(derived.relativePath, derived.className, declaredClass);
+  }
+}

--- a/packages/engine/tests/unit/domain/cultivationIrrigationCompatibility.test.ts
+++ b/packages/engine/tests/unit/domain/cultivationIrrigationCompatibility.test.ts
@@ -1,12 +1,14 @@
+import { fileURLToPath } from 'node:url';
+
 import { describe, expect, it } from 'vitest';
 
-import dripInline from '../../../../../data/blueprints/irrigationMethods/drip-inline-fertigation-basic.json' assert { type: 'json' };
-import ebbFlow from '../../../../../data/blueprints/irrigationMethods/ebb-flow-table-small.json' assert { type: 'json' };
-import manualCan from '../../../../../data/blueprints/irrigationMethods/manual-watering-can.json' assert { type: 'json' };
-import topFeed from '../../../../../data/blueprints/irrigationMethods/top-feed-pump-timer.json' assert { type: 'json' };
-import cocoCoir from '../../../../../data/blueprints/substrates/coco_coir.json' assert { type: 'json' };
-import soilMulti from '../../../../../data/blueprints/substrates/soil_multi_cycle.json' assert { type: 'json' };
-import soilSingle from '../../../../../data/blueprints/substrates/soil_single_cycle.json' assert { type: 'json' };
+import dripInline from '../../../../../data/blueprints/irrigation/drip/inline-fertigation/drip-inline-fertigation-basic.json' assert { type: 'json' };
+import ebbFlow from '../../../../../data/blueprints/irrigation/ebb-flow/table/ebb-flow-table-small.json' assert { type: 'json' };
+import manualCan from '../../../../../data/blueprints/irrigation/manual/can/manual-watering-can.json' assert { type: 'json' };
+import topFeed from '../../../../../data/blueprints/irrigation/top-feed/timer/top-feed-pump-timer.json' assert { type: 'json' };
+import cocoCoir from '../../../../../data/blueprints/substrate/coco/coir/coco_coir.json' assert { type: 'json' };
+import soilMulti from '../../../../../data/blueprints/substrate/soil/multi-cycle/soil_multi_cycle.json' assert { type: 'json' };
+import soilSingle from '../../../../../data/blueprints/substrate/soil/single-cycle/soil_single_cycle.json' assert { type: 'json' };
 import basicSoilPot from '../../../../../data/blueprints/cultivationMethods/basic_soil_pot.json' assert { type: 'json' };
 import scrog from '../../../../../data/blueprints/cultivationMethods/scrog.json' assert { type: 'json' };
 import sog from '../../../../../data/blueprints/cultivationMethods/sog.json' assert { type: 'json' };
@@ -22,9 +24,49 @@ describe('irrigation compatibility coverage', () => {
     soilSingle.slug as string
   ]);
 
-  const irrigationFixtures = [dripInline, ebbFlow, manualCan, topFeed] as const;
+  const irrigationFixtures = [
+    {
+      data: dripInline,
+      path: fileURLToPath(
+        new URL(
+          '../../../../../data/blueprints/irrigation/drip/inline-fertigation/drip-inline-fertigation-basic.json',
+          import.meta.url
+        )
+      )
+    },
+    {
+      data: ebbFlow,
+      path: fileURLToPath(
+        new URL(
+          '../../../../../data/blueprints/irrigation/ebb-flow/table/ebb-flow-table-small.json',
+          import.meta.url
+        )
+      )
+    },
+    {
+      data: manualCan,
+      path: fileURLToPath(
+        new URL(
+          '../../../../../data/blueprints/irrigation/manual/can/manual-watering-can.json',
+          import.meta.url
+        )
+      )
+    },
+    {
+      data: topFeed,
+      path: fileURLToPath(
+        new URL(
+          '../../../../../data/blueprints/irrigation/top-feed/timer/top-feed-pump-timer.json',
+          import.meta.url
+        )
+      )
+    }
+  ] as const;
   const irrigationBlueprints = irrigationFixtures.map((fixture) =>
-    parseIrrigationBlueprint(fixture, { knownSubstrateSlugs: substrateSlugs })
+    parseIrrigationBlueprint(fixture.data, {
+      knownSubstrateSlugs: substrateSlugs,
+      filePath: fixture.path
+    })
   );
 
   const cultivationMethods = [basicSoilPot, scrog, sog] as const satisfies readonly CultivationBlueprint[];

--- a/packages/engine/tests/unit/domain/irrigationBlueprintSchema.test.ts
+++ b/packages/engine/tests/unit/domain/irrigationBlueprintSchema.test.ts
@@ -1,12 +1,14 @@
+import { fileURLToPath } from 'node:url';
+
 import { describe, expect, it } from 'vitest';
 
-import dripInline from '../../../../../data/blueprints/irrigationMethods/drip-inline-fertigation-basic.json' assert { type: 'json' };
-import ebbFlow from '../../../../../data/blueprints/irrigationMethods/ebb-flow-table-small.json' assert { type: 'json' };
-import manualCan from '../../../../../data/blueprints/irrigationMethods/manual-watering-can.json' assert { type: 'json' };
-import topFeed from '../../../../../data/blueprints/irrigationMethods/top-feed-pump-timer.json' assert { type: 'json' };
-import cocoCoir from '../../../../../data/blueprints/substrates/coco_coir.json' assert { type: 'json' };
-import soilMulti from '../../../../../data/blueprints/substrates/soil_multi_cycle.json' assert { type: 'json' };
-import soilSingle from '../../../../../data/blueprints/substrates/soil_single_cycle.json' assert { type: 'json' };
+import dripInline from '../../../../../data/blueprints/irrigation/drip/inline-fertigation/drip-inline-fertigation-basic.json' assert { type: 'json' };
+import ebbFlow from '../../../../../data/blueprints/irrigation/ebb-flow/table/ebb-flow-table-small.json' assert { type: 'json' };
+import manualCan from '../../../../../data/blueprints/irrigation/manual/can/manual-watering-can.json' assert { type: 'json' };
+import topFeed from '../../../../../data/blueprints/irrigation/top-feed/timer/top-feed-pump-timer.json' assert { type: 'json' };
+import cocoCoir from '../../../../../data/blueprints/substrate/coco/coir/coco_coir.json' assert { type: 'json' };
+import soilMulti from '../../../../../data/blueprints/substrate/soil/multi-cycle/soil_multi_cycle.json' assert { type: 'json' };
+import soilSingle from '../../../../../data/blueprints/substrate/soil/single-cycle/soil_single_cycle.json' assert { type: 'json' };
 
 import { parseIrrigationBlueprint } from '@/backend/src/domain/world.js';
 
@@ -17,12 +19,52 @@ describe('parseIrrigationBlueprint', () => {
     soilSingle.slug as string
   ]);
 
-  const fixtures = [dripInline, ebbFlow, manualCan, topFeed] as const;
+  const fixtures = [
+    {
+      data: dripInline,
+      path: fileURLToPath(
+        new URL(
+          '../../../../../data/blueprints/irrigation/drip/inline-fertigation/drip-inline-fertigation-basic.json',
+          import.meta.url
+        )
+      )
+    },
+    {
+      data: ebbFlow,
+      path: fileURLToPath(
+        new URL(
+          '../../../../../data/blueprints/irrigation/ebb-flow/table/ebb-flow-table-small.json',
+          import.meta.url
+        )
+      )
+    },
+    {
+      data: manualCan,
+      path: fileURLToPath(
+        new URL(
+          '../../../../../data/blueprints/irrigation/manual/can/manual-watering-can.json',
+          import.meta.url
+        )
+      )
+    },
+    {
+      data: topFeed,
+      path: fileURLToPath(
+        new URL(
+          '../../../../../data/blueprints/irrigation/top-feed/timer/top-feed-pump-timer.json',
+          import.meta.url
+        )
+      )
+    }
+  ] as const;
 
   it('parses repository irrigation blueprints without modification', () => {
     fixtures.forEach((fixture) => {
       expect(() =>
-        parseIrrigationBlueprint(fixture, { knownSubstrateSlugs: substrateSlugs })
+        parseIrrigationBlueprint(fixture.data, {
+          knownSubstrateSlugs: substrateSlugs,
+          filePath: fixture.path
+        })
       ).not.toThrow();
     });
   });
@@ -32,7 +74,7 @@ describe('parseIrrigationBlueprint', () => {
     invalid.compatibility.substrates = [...invalid.compatibility.substrates, 'unknown-substrate'];
 
     expect(() =>
-      parseIrrigationBlueprint(invalid, { knownSubstrateSlugs: substrateSlugs })
+      parseIrrigationBlueprint(invalid, { knownSubstrateSlugs: substrateSlugs, filePath: fixtures[2].path })
     ).toThrow(/unknown substrate slug/);
   });
 });

--- a/packages/engine/tests/unit/domain/substrateBlueprintSchema.test.ts
+++ b/packages/engine/tests/unit/domain/substrateBlueprintSchema.test.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from 'node:url';
+
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -7,16 +9,30 @@ import {
   substrateBlueprintSchema
 } from '@/backend/src/domain/world.js';
 
-import cocoCoir from '../../../../../data/blueprints/substrates/coco_coir.json' assert { type: 'json' };
-import soilMulti from '../../../../../data/blueprints/substrates/soil_multi_cycle.json' assert { type: 'json' };
-import soilSingle from '../../../../../data/blueprints/substrates/soil_single_cycle.json' assert { type: 'json' };
+import cocoCoir from '../../../../../data/blueprints/substrate/coco/coir/coco_coir.json' assert { type: 'json' };
+import soilMulti from '../../../../../data/blueprints/substrate/soil/multi-cycle/soil_multi_cycle.json' assert { type: 'json' };
+import soilSingle from '../../../../../data/blueprints/substrate/soil/single-cycle/soil_single_cycle.json' assert { type: 'json' };
+
+const cocoCoirPath = fileURLToPath(
+  new URL('../../../../../data/blueprints/substrate/coco/coir/coco_coir.json', import.meta.url)
+);
+const soilMultiPath = fileURLToPath(
+  new URL('../../../../../data/blueprints/substrate/soil/multi-cycle/soil_multi_cycle.json', import.meta.url)
+);
+const soilSinglePath = fileURLToPath(
+  new URL('../../../../../data/blueprints/substrate/soil/single-cycle/soil_single_cycle.json', import.meta.url)
+);
+
+const substrateFixtures = [
+  { data: cocoCoir, path: cocoCoirPath },
+  { data: soilMulti, path: soilMultiPath },
+  { data: soilSingle, path: soilSinglePath }
+] as const;
 
 describe('substrateBlueprintSchema', () => {
   it('parses repository substrate blueprints without modification', () => {
-    const fixtures = [cocoCoir, soilMulti, soilSingle];
-
-    for (const fixture of fixtures) {
-      expect(() => parseSubstrateBlueprint(fixture)).not.toThrow();
+    for (const fixture of substrateFixtures) {
+      expect(() => parseSubstrateBlueprint(fixture.data, { filePath: fixture.path })).not.toThrow();
     }
   });
 
@@ -62,7 +78,7 @@ describe('substrateBlueprintSchema', () => {
   });
 
   it('converts mass and volume using the declared density factor', () => {
-    const parsed = parseSubstrateBlueprint(cocoCoir);
+    const parsed = parseSubstrateBlueprint(cocoCoir, { filePath: cocoCoirPath });
 
     const massKg = convertSubstrateVolumeLToMassKg(parsed, 85);
     expect(massKg).toBeCloseTo(10, 5);


### PR DESCRIPTION
## Summary
- reorganize device, irrigation, and substrate blueprint folders to encode <domain>.<effect>[.<variant>] in the filesystem
- add a shared taxonomy helper so device, substrate, and irrigation parsers validate JSON classes against their paths and keep per-class slug uniqueness
- update unit tests and docs to consume the new path metadata and document the guardrail

## Testing
- pnpm --filter @wb/engine test *(fails: vitest not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de854db2fc83259385c5ca8dd9d83e