### PR TITLE
Clarify blueprint taxonomy guardrails for contributors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,8 @@ Steer implementation so the codebase **conforms to SEC v0.2.1** while remaining 
 
 - **Blueprints** live under `/data/blueprints/**` (strains, devices, cultivationMethods, substrates, containers, …). **Never embed prices** in device blueprints.
     
+- **Contributors guardrail:** Blueprint JSON is the source of truth. Keep each file inside the taxonomy folder that mirrors its `class` (`device/climate/cooling/**`, etc.). The loader fails fast (`BlueprintTaxonomyMismatchError`) whenever the directory and JSON diverge.
+
 - **Price maps** live under `/data/prices/**`.
     
 - **Recurring monetary rates use per‑hour units** (SEC §3.6). **`*_per_tick` is forbidden.** Derive tick costs via tick hours.

--- a/docs/ADR/ADR-0009-blueprint-class-taxonomy.md
+++ b/docs/ADR/ADR-0009-blueprint-class-taxonomy.md
@@ -19,6 +19,10 @@ behaviour and downstream content.
   pattern so files can be grouped deterministically by capability, and
   mirror the taxonomy in the filesystem layout so discovery code can
   derive class metadata directly from the folder segments.
+- Treat the JSON payload as the **authoritative source** for taxonomy
+  metadata while using the filesystem as a guardrail: loaders compare the
+  declared `class` with the path-derived taxonomy and raise a
+  `BlueprintTaxonomyMismatchError` when contributors misplace files.
 - Remove the legacy `kind`/`type` fields from the data set and require
   kebab-case `slug` identifiers to remain unique per class.
 - Extend the device blueprint schema to validate the new classes,
@@ -35,6 +39,9 @@ behaviour and downstream content.
 - Scenario loaders and integrations must refer to the `class` field rather
   than the removed `kind`/`type` keys. Attempting to load blueprints that
   omit class-specific settings now fails during schema validation.
+- Repository tests enforce the directory taxonomy so misplaced files or
+  mismatched `class` declarations fail fast with descriptive loader errors
+  instead of drifting silently at runtime.
 - Documentation and changelog updates communicate the taxonomy to engine
   contributors, establishing a precedent for future blueprint additions
   and migrations.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### #44 WB-037 blueprint taxonomy guardrails clarified for contributors
+- Expanded SEC and DD blueprint sections with explicit directory conventions,
+  JSON-source-of-truth language, and a required loader failure when paths and
+  classes diverge.
+- Updated the TDD checklist and AGENTS guardrails to cover taxonomy-aware
+  tests and contributor guidance, ensuring misplaced blueprints fail fast in CI.
+- Added a vision-scope modding note plus ADR-0009/CHANGELOG updates so
+  documentation, governance, and implementation stay aligned.
+
 ### #43 WB-036 taxonomy-driven blueprint filesystem
 - Migrated every blueprint JSON under `/data/blueprints/**` into taxonomy-aligned
   directories whose segment names mirror the declared class (e.g.

--- a/docs/DD.md
+++ b/docs/DD.md
@@ -92,8 +92,12 @@ geometry bounds) before the tick pipeline consumes a scenario payload.
 - **Blueprint taxonomy:** All blueprints expose `class` values using
   `<domain>.<effect>[.<variant>]` plus a kebab-case `slug` unique within that class. Each
   directory segment under `/data/blueprints/**` mirrors the matching class segment so
-  loaders can derive taxonomy metadata from the filesystem itself. The backend validators
-  rely on the taxonomy to select effect-specific rules (e.g. cooling, dehumidification,
+  loaders can derive taxonomy metadata from the filesystem itself. JSON stays
+  authoritative for metadata; filesystem placement provides expectations only. When the
+  folder taxonomy and JSON `class` disagree, the loader throws a
+  `BlueprintTaxonomyMismatchError` and rejects the payload so contributors correct the
+  placement instead of allowing divergent runtime behaviour. The backend validators rely
+  on the taxonomy to select effect-specific rules (e.g. cooling, dehumidification,
   lighting) while the data set retires the legacy `kind`/`type` fields.
 
 ### 4.2 Price Maps

--- a/docs/SEC.md
+++ b/docs/SEC.md
@@ -238,6 +238,16 @@ Validation occurs at load time; on failure, the engine must not start. Validatio
   `<domain>.<effect>[.<variant>]` format plus a kebab-case `slug` that remains unique per
   class. The taxonomy binds fixtures, runtime loaders, and documentation to the same
   capability vocabulary.
+- Directory segments under `/data/blueprints/**` **SHALL** mirror the declared `class`
+  segments (`device/climate/cooling/foo.json` ⇒ `class = "device.climate.cooling"`).
+  Contributors **MUST NOT** invent bespoke folder names; taxonomy folders are the only
+  acceptable location for blueprints.
+- JSON remains the **single source of truth** for blueprint metadata. Loaders **SHALL**
+  trust the JSON payload first, using the filesystem only to derive expectations and to
+  surface mismatches when contributors misplace files.
+- Loaders **MUST** raise a hard failure (e.g. `BlueprintTaxonomyMismatchError`) when the
+  path-derived taxonomy and the JSON `class` diverge, preventing silent drift between
+  fixtures and runtime logic.
 - Legacy `kind`/`type` identifiers are **removed**; integrations **MUST** read the new
   `class` discriminator.
 - Device blueprint classes **drive validation**: cooling units declare cooling capacity

--- a/docs/TDD.md
+++ b/docs/TDD.md
@@ -62,7 +62,7 @@ src/
 - **Coverage threshold:** 90% lines/branches in `engine/` and `facade/`; 80% overall.
     
 - **Snapshot location:** `__snapshots__` next to specs (only for low‑volatility payloads; prefer golden JSON files for world states).
-    
+- **Blueprint fixtures:** Repository fixtures **MUST** live inside the taxonomy folders that mirror their `class` segments (`device/climate/cooling/**`, etc.). Specs walk `/data/blueprints/**` to assert the folder-derived taxonomy matches the JSON declaration and fail fast when contributors park files elsewhere.
 
 ---
 
@@ -73,7 +73,9 @@ src/
 - **Schema:** Validate with **Zod** at façade boundaries and as test helpers.
     
 - **Prices** live under `/data/prices/**`; ensure no prices leak into device blueprints.
-    
+- **Taxonomy validation:** Unit tests assert that any mismatch between a blueprint's directory taxonomy and its JSON `class` raises a `BlueprintTaxonomyMismatchError` (or equivalent). Misplaced files must fail the loader guard immediately.
+
+- **Fixture layout check:** Repository-level specs enumerate blueprint folders and ensure no stray directories exist outside the sanctioned taxonomy tree. Tests fail if contributors invent ad-hoc folders.
 
 ```ts
 // tests/unit/schema/zoneSchema.spec.ts

--- a/docs/VISION_SCOPE.md
+++ b/docs/VISION_SCOPE.md
@@ -8,6 +8,8 @@
 
 **Elevator Pitch.** _Weed Breed_ is a modular, deterministic cultivation & economy simulation. Players plan **Company → Structure → Room → Zone → Plant**, configure climate & devices, balance **cost vs. yield**, and complete cycles from **seeding → harvest → post‑harvest**. The system is open and content‑driven via **JSON blueprints**, enabling modders and researchers to contribute.
 
+> **Modding note:** Blueprint JSON stays authoritative for metadata, but every file **must** live in the taxonomy folders that mirror its declared `class` (`device/climate/cooling/**`, etc.). Misplaced files or path/class mismatches are rejected by the loader so the runtime and data set never drift.
+
 **Why now?** Few titles combine **physically plausible climate & plant physiology**, **deterministic reproducibility**, and a **meaningful economy loop**. _Weed Breed_ fills this gap.
 
 **Guiding Principles.**


### PR DESCRIPTION
## Summary
- expand the SEC and DD blueprint taxonomy guidance with explicit folder conventions, JSON-authority notes, and hard-fail expectations when loaders detect path/class mismatches
- update the TDD checklist, AGENTS guardrail, and vision scope to direct contributors and modders to keep blueprints inside taxonomy folders while treating JSON as the source of truth
- refresh ADR-0009 and the changelog so governance docs mirror the clarified loader behaviour and repository guardrails

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68de8e07e21483259fada650d7915053