### PR TITLE
Add thermal actuator stub for heating and cooling

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### #45 WB-038 thermal actuator stub with cooling & auto support
+- Added `createThermalActuatorStub` under `@/backend/src/stubs` to deliver
+  deterministic heating, cooling, and auto-mode behaviour with structured
+  outputs for downstream composition.
+- Reused the canonical dry-air physics helpers so both heating waste loads and
+  cooling capacity honour device efficiency and `max_*_W` clamps while guarding
+  invalid inputs.
+- Introduced dedicated Vitest coverage validating heating/cooling reference
+  vectors, auto-mode branching, output finiteness, and the documented edge
+  cases alongside a soft deprecation notice on the legacy heating helper.
+
 ### #44 WB-037 blueprint taxonomy guardrails clarified for contributors
 - Expanded SEC and DD blueprint sections with explicit directory conventions,
   JSON-source-of-truth language, and a required loader failure when paths and

--- a/packages/engine/src/backend/src/engine/thermo/heat.ts
+++ b/packages/engine/src/backend/src/engine/thermo/heat.ts
@@ -42,6 +42,14 @@ function resolveAirMassKg(zone: Pick<Zone, 'airMass_kg'>): number {
 }
 
 /**
+ * @deprecated Heating-only implementation (waste heat).
+ * For full thermal actuator support (heating, cooling, auto),
+ * use {@link createThermalActuatorStub} from `@/backend/src/stubs/ThermalActuatorStub.js`.
+ *
+ * This function will be refactored in Phase 4 to delegate to ThermalActuatorStub.
+ *
+ * @see packages/engine/src/backend/src/stubs/ThermalActuatorStub.ts
+ *
  * Converts waste electrical power produced by a device into a sensible heat
  * delta for the hosting zone.
  *

--- a/packages/engine/src/backend/src/stubs/ThermalActuatorStub.ts
+++ b/packages/engine/src/backend/src/stubs/ThermalActuatorStub.ts
@@ -1,0 +1,240 @@
+import {
+  CP_AIR_J_PER_KG_K,
+  HOURS_PER_TICK,
+  SECONDS_PER_HOUR
+} from '../constants/simConstants.js';
+import type {
+  IThermalActuator,
+  ThermalActuatorInputs,
+  ThermalActuatorOutputs
+} from '../domain/interfaces/IThermalActuator.js';
+import type { ZoneEnvironment } from '../domain/entities.js';
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  if (value <= 0) {
+    return 0;
+  }
+
+  if (value >= 1) {
+    return 1;
+  }
+
+  return value;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+
+  if (value < min) {
+    return min;
+  }
+
+  if (value > max) {
+    return max;
+  }
+
+  return value;
+}
+
+function resolveTickHours(tickHours: number | undefined): number {
+  if (typeof tickHours !== 'number') {
+    return HOURS_PER_TICK;
+  }
+
+  if (!Number.isFinite(tickHours) || tickHours <= 0) {
+    return HOURS_PER_TICK;
+  }
+
+  return tickHours;
+}
+
+function resolveAirMassKg(airMass_kg: number): number {
+  if (!Number.isFinite(airMass_kg) || airMass_kg <= 0) {
+    return 0;
+  }
+
+  return airMass_kg;
+}
+
+function ensureFiniteOutputs(outputs: ThermalActuatorOutputs): ThermalActuatorOutputs {
+  const { deltaT_K, energy_Wh, used_W } = outputs;
+
+  if (!Number.isFinite(deltaT_K) || !Number.isFinite(energy_Wh) || !Number.isFinite(used_W)) {
+    throw new Error('Thermal actuator outputs must be finite numbers.');
+  }
+
+  return outputs;
+}
+
+/**
+ * Factory producing a deterministic stub implementation of {@link IThermalActuator}.
+ *
+ * The stub mirrors the consolidated spec (Section 4.1 ThermalActuatorStub):
+ *
+ * - **Heating mode** converts unused electrical power (`wasteHeat_W`) into a
+ *   positive sensible heat delta based on the canonical dry-air properties.
+ * - **Cooling mode** removes sensible heat (`cooling_W`) while respecting the
+ *   provided cooling capacity limit, yielding a negative temperature delta.
+ * - **Auto mode** compares the requested setpoint against the current zone
+ *   environment and dynamically selects heating or cooling. Equal temperatures
+ *   short-circuit to a neutral effect.
+ *
+ * The implementation is intentionally pure to support composition with the
+ * {@link compose} helper and remains aligned with the legacy heating-only
+ * behaviour exposed by {@link applyDeviceHeat}.
+ */
+export function createThermalActuatorStub(): IThermalActuator {
+  return {
+    computeEffect(
+      inputs: ThermalActuatorInputs,
+      envState: ZoneEnvironment,
+      airMass_kg: number,
+      dt_h: number,
+    ): ThermalActuatorOutputs {
+      const efficiency = inputs.efficiency01;
+
+      if (!Number.isFinite(efficiency) || efficiency < 0 || efficiency > 1) {
+        throw new RangeError('Actuator efficiency must lie within [0,1].');
+      }
+
+      if (
+        typeof dt_h === 'number' &&
+        (!Number.isFinite(dt_h) || dt_h <= 0)
+      ) {
+        return { deltaT_K: 0, energy_Wh: 0, used_W: 0 };
+      }
+
+      const resolvedDt_h = resolveTickHours(dt_h);
+      const resolvedAirMass = resolveAirMassKg(airMass_kg);
+      const powerDraw_W = Math.max(0, inputs.power_W);
+
+      if (powerDraw_W === 0 || resolvedDt_h === 0 || resolvedAirMass === 0) {
+        return { deltaT_K: 0, energy_Wh: 0, used_W: 0 };
+      }
+
+      const mode = inputs.mode;
+
+      if (mode === 'auto') {
+        const setpoint = inputs.setpoint_C;
+
+        if (typeof setpoint !== 'number' || !Number.isFinite(setpoint)) {
+          throw new Error('Auto mode requires setpoint_C');
+        }
+
+        if (setpoint > envState.airTemperatureC) {
+          return ensureFiniteOutputs(
+            computeHeatingEffect(
+              powerDraw_W,
+              efficiency,
+              inputs.max_heat_W,
+              resolvedDt_h,
+              resolvedAirMass,
+            ),
+          );
+        }
+
+        if (setpoint < envState.airTemperatureC) {
+          return ensureFiniteOutputs(
+            computeCoolingEffect(
+              powerDraw_W,
+              efficiency,
+              inputs.max_cool_W,
+              resolvedDt_h,
+              resolvedAirMass,
+            ),
+          );
+        }
+
+        return { deltaT_K: 0, energy_Wh: 0, used_W: 0 };
+      }
+
+      if (mode === 'heat') {
+        return ensureFiniteOutputs(
+          computeHeatingEffect(
+            powerDraw_W,
+            efficiency,
+            inputs.max_heat_W,
+            resolvedDt_h,
+            resolvedAirMass,
+          ),
+        );
+      } else if (mode === 'cool') {
+        return ensureFiniteOutputs(
+          computeCoolingEffect(
+            powerDraw_W,
+            efficiency,
+            inputs.max_cool_W,
+            resolvedDt_h,
+            resolvedAirMass,
+          ),
+        );
+      }
+
+      throw new Error('Unsupported thermal actuator mode');
+    },
+  } satisfies IThermalActuator;
+}
+
+function computeHeatingEffect(
+  powerDraw_W: number,
+  efficiency01: number,
+  max_heat_W: number | undefined,
+  dt_h: number,
+  airMass_kg: number,
+): ThermalActuatorOutputs {
+  const effectiveMax =
+    typeof max_heat_W === 'number' && Number.isFinite(max_heat_W)
+      ? Math.max(0, max_heat_W)
+      : Infinity;
+  const wasteHeat_W = clamp(
+    powerDraw_W * (1 - clamp01(efficiency01)),
+    0,
+    effectiveMax,
+  );
+
+  if (wasteHeat_W === 0) {
+    return { deltaT_K: 0, energy_Wh: powerDraw_W * dt_h, used_W: 0 };
+  }
+
+  const joules = wasteHeat_W * dt_h * SECONDS_PER_HOUR;
+  const deltaT_K = joules / (airMass_kg * CP_AIR_J_PER_KG_K);
+
+  return {
+    deltaT_K,
+    energy_Wh: powerDraw_W * dt_h,
+    used_W: wasteHeat_W,
+  } satisfies ThermalActuatorOutputs;
+}
+
+function computeCoolingEffect(
+  powerDraw_W: number,
+  efficiency01: number,
+  max_cool_W: number | undefined,
+  dt_h: number,
+  airMass_kg: number,
+): ThermalActuatorOutputs {
+  const effectiveMax =
+    typeof max_cool_W === 'number' && Number.isFinite(max_cool_W)
+      ? Math.max(0, max_cool_W)
+      : Infinity;
+  const cooling_W = clamp(powerDraw_W * clamp01(efficiency01), 0, effectiveMax);
+
+  if (cooling_W === 0) {
+    return { deltaT_K: 0, energy_Wh: powerDraw_W * dt_h, used_W: 0 };
+  }
+
+  const joules = cooling_W * dt_h * SECONDS_PER_HOUR;
+  const deltaT_K = -joules / (airMass_kg * CP_AIR_J_PER_KG_K);
+
+  return {
+    deltaT_K,
+    energy_Wh: powerDraw_W * dt_h,
+    used_W: cooling_W,
+  } satisfies ThermalActuatorOutputs;
+}

--- a/packages/engine/src/backend/src/stubs/index.ts
+++ b/packages/engine/src/backend/src/stubs/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Phase 1 Stub Implementations (Engine v1)
+ *
+ * Deterministic, referential stub implementations for stackable device effects.
+ * Each stub provides pure functions with predefined test vectors for validation.
+ *
+ * @see Consolidated Reference Document: Interfaces & Stubs (Engine v1, Phase 1)
+ */
+export * from './ThermalActuatorStub.js';
+// Future exports:
+// export * from './HumidityActuatorStub.js';
+// export * from './LightEmitterStub.js';
+// export * from './NutrientBufferStub.js';
+// export * from './IrrigationServiceStub.js';

--- a/packages/engine/tests/unit/stubs/ThermalActuatorStub.test.ts
+++ b/packages/engine/tests/unit/stubs/ThermalActuatorStub.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AIR_DENSITY_KG_PER_M3,
+  CP_AIR_J_PER_KG_K,
+  HOURS_PER_TICK,
+  SECONDS_PER_HOUR
+} from '@/backend/src/constants/simConstants.js';
+import { createThermalActuatorStub } from '@/backend/src/stubs/ThermalActuatorStub.js';
+import type { ThermalActuatorInputs } from '@/backend/src/domain/interfaces/IThermalActuator.js';
+import type { ZoneEnvironment } from '@/backend/src/domain/entities.js';
+
+const ZONE_VOLUME_M3 = 50;
+const AIR_MASS_KG = ZONE_VOLUME_M3 * AIR_DENSITY_KG_PER_M3;
+const BASE_ENV_STATE: ZoneEnvironment = { airTemperatureC: 22 };
+
+function createInputs(overrides: Partial<ThermalActuatorInputs> = {}): ThermalActuatorInputs {
+  return {
+    power_W: 1_000,
+    efficiency01: 0.9,
+    mode: 'heat',
+    ...overrides
+  };
+}
+
+describe('ThermalActuatorStub', () => {
+  const stub = createThermalActuatorStub();
+
+  describe('heating mode', () => {
+    it('matches the reference delta for a 1000 W heater at 90% efficiency', () => {
+      const inputs = createInputs();
+      const result = stub.computeEffect(inputs, BASE_ENV_STATE, AIR_MASS_KG, HOURS_PER_TICK);
+
+      expect(result.used_W).toBeCloseTo(100, 5);
+      expect(result.energy_Wh).toBeCloseTo(1_000, 5);
+
+      const expectedDelta =
+        (result.used_W * HOURS_PER_TICK * SECONDS_PER_HOUR) / (AIR_MASS_KG * CP_AIR_J_PER_KG_K);
+      expect(result.deltaT_K).toBeGreaterThan(0);
+      expect(result.deltaT_K).toBeCloseTo(expectedDelta, 1);
+    });
+
+    it('respects the max_heat_W cap', () => {
+      const inputs = createInputs({ max_heat_W: 40 });
+      const result = stub.computeEffect(inputs, BASE_ENV_STATE, AIR_MASS_KG, HOURS_PER_TICK);
+
+      expect(result.used_W).toBe(40);
+      expect(result.deltaT_K).toBeCloseTo(
+        (40 * HOURS_PER_TICK * SECONDS_PER_HOUR) / (AIR_MASS_KG * CP_AIR_J_PER_KG_K),
+      );
+    });
+
+    it('produces no heat when efficiency equals one', () => {
+      const inputs = createInputs({ efficiency01: 1 });
+      const result = stub.computeEffect(inputs, BASE_ENV_STATE, AIR_MASS_KG, HOURS_PER_TICK);
+
+      expect(result.deltaT_K).toBe(0);
+      expect(result.used_W).toBe(0);
+      expect(result.energy_Wh).toBeCloseTo(1_000, 5);
+    });
+  });
+
+  describe('cooling mode', () => {
+    it('produces a negative temperature delta proportional to cooling load', () => {
+      const inputs = createInputs({ power_W: 3_000, efficiency01: 0.65, mode: 'cool', max_cool_W: 3_000 });
+      const result = stub.computeEffect(inputs, BASE_ENV_STATE, AIR_MASS_KG, HOURS_PER_TICK);
+
+      expect(result.used_W).toBeCloseTo(1_950, 5);
+      expect(result.energy_Wh).toBeCloseTo(3_000, 5);
+      expect(result.deltaT_K).toBeLessThan(0);
+      const expectedDelta =
+        -(result.used_W * HOURS_PER_TICK * SECONDS_PER_HOUR) / (AIR_MASS_KG * CP_AIR_J_PER_KG_K);
+      expect(result.deltaT_K).toBeCloseTo(expectedDelta, 5);
+    });
+
+    it('respects the max_cool_W cap', () => {
+      const inputs = createInputs({ power_W: 3_000, efficiency01: 0.9, mode: 'cool', max_cool_W: 1_200 });
+      const result = stub.computeEffect(inputs, BASE_ENV_STATE, AIR_MASS_KG, HOURS_PER_TICK);
+
+      expect(result.used_W).toBe(1_200);
+      const expectedDelta =
+        -(1_200 * HOURS_PER_TICK * SECONDS_PER_HOUR) / (AIR_MASS_KG * CP_AIR_J_PER_KG_K);
+      expect(result.deltaT_K).toBeCloseTo(expectedDelta, 5);
+    });
+
+    it('returns zero effect when efficiency equals zero', () => {
+      const inputs = createInputs({ mode: 'cool', efficiency01: 0, power_W: 2_000 });
+      const result = stub.computeEffect(inputs, BASE_ENV_STATE, AIR_MASS_KG, HOURS_PER_TICK);
+
+      expect(result.deltaT_K).toBe(0);
+      expect(result.used_W).toBe(0);
+    });
+  });
+
+  describe('auto mode', () => {
+    it('heats when the setpoint exceeds the current temperature', () => {
+      const inputs = createInputs({ mode: 'auto', setpoint_C: BASE_ENV_STATE.airTemperatureC + 2 });
+      const result = stub.computeEffect(inputs, BASE_ENV_STATE, AIR_MASS_KG, HOURS_PER_TICK);
+
+      expect(result.deltaT_K).toBeGreaterThan(0);
+    });
+
+    it('cools when the setpoint is below the current temperature', () => {
+      const inputs = createInputs({ mode: 'auto', setpoint_C: BASE_ENV_STATE.airTemperatureC - 2, efficiency01: 0.5 });
+      const result = stub.computeEffect(inputs, BASE_ENV_STATE, AIR_MASS_KG, HOURS_PER_TICK);
+
+      expect(result.deltaT_K).toBeLessThan(0);
+    });
+
+    it('returns neutral effect when the setpoint equals the current temperature', () => {
+      const inputs = createInputs({ mode: 'auto', setpoint_C: BASE_ENV_STATE.airTemperatureC });
+      const result = stub.computeEffect(inputs, BASE_ENV_STATE, AIR_MASS_KG, HOURS_PER_TICK);
+
+      expect(result.deltaT_K).toBe(0);
+      expect(result.used_W).toBe(0);
+    });
+
+    it('throws when setpoint is omitted', () => {
+      const inputs = createInputs({ mode: 'auto' });
+
+      expect(() => stub.computeEffect(inputs, BASE_ENV_STATE, AIR_MASS_KG, HOURS_PER_TICK)).toThrowError(
+        'Auto mode requires setpoint_C'
+      );
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns zeros when power draw is zero', () => {
+      const inputs = createInputs({ power_W: 0 });
+      const result = stub.computeEffect(inputs, BASE_ENV_STATE, AIR_MASS_KG, HOURS_PER_TICK);
+
+      expect(result).toEqual({ deltaT_K: 0, energy_Wh: 0, used_W: 0 });
+    });
+
+    it('returns zeros when air mass is zero', () => {
+      const inputs = createInputs();
+      const result = stub.computeEffect(inputs, BASE_ENV_STATE, 0, HOURS_PER_TICK);
+
+      expect(result).toEqual({ deltaT_K: 0, energy_Wh: 0, used_W: 0 });
+    });
+
+    it('returns zeros when dt_h is zero', () => {
+      const inputs = createInputs();
+      const result = stub.computeEffect(inputs, BASE_ENV_STATE, AIR_MASS_KG, 0);
+
+      expect(result).toEqual({ deltaT_K: 0, energy_Wh: 0, used_W: 0 });
+    });
+
+    it('throws when efficiency falls outside [0,1]', () => {
+      const inputs = createInputs({ efficiency01: 1.2 });
+
+      expect(() => stub.computeEffect(inputs, BASE_ENV_STATE, AIR_MASS_KG, HOURS_PER_TICK)).toThrowError(RangeError);
+    });
+
+    it('clamps negative power to zero', () => {
+      const inputs = createInputs({ power_W: -500 });
+      const result = stub.computeEffect(inputs, BASE_ENV_STATE, AIR_MASS_KG, HOURS_PER_TICK);
+
+      expect(result).toEqual({ deltaT_K: 0, energy_Wh: 0, used_W: 0 });
+    });
+  });
+
+  describe('output structure', () => {
+    it('always returns finite numeric outputs and energy consistency', () => {
+      const inputs = createInputs({ power_W: 1_500, efficiency01: 0.25 });
+      const result = stub.computeEffect(inputs, BASE_ENV_STATE, AIR_MASS_KG, 0.5);
+
+      expect(Number.isFinite(result.deltaT_K)).toBe(true);
+      expect(Number.isFinite(result.energy_Wh)).toBe(true);
+      expect(Number.isFinite(result.used_W)).toBe(true);
+      expect(result.energy_Wh).toBeCloseTo(inputs.power_W * 0.5, 5);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a deterministic ThermalActuator stub that supports heating, cooling, and auto modes with structured outputs
- exercise the new stub with unit tests covering mode selection, capacity limits, and edge cases
- expose the stub through a stubs barrel, document the change in the changelog, and deprecate the legacy heating helper comment-only

## Testing
- pnpm --filter @wb/engine test

------
https://chatgpt.com/codex/tasks/task_e_68df498dd9f88325bf808bcbe012aefa