### PR TITLE
feat(engine): add humidity actuator stub

### DIFF
--- a/packages/engine/src/backend/src/domain/entities.ts
+++ b/packages/engine/src/backend/src/domain/entities.ts
@@ -210,6 +210,8 @@ export interface Zone extends DomainEntity, SluggedEntity, SpatialEntity {
 export interface ZoneEnvironment {
   /** Dry-bulb air temperature expressed in degrees Celsius. */
   readonly airTemperatureC: number;
+  /** Relative humidity expressed as a percentage on the canonical [0,100] scale. */
+  readonly relativeHumidity_pct: number;
 }
 
 /**

--- a/packages/engine/src/backend/src/domain/schemas.ts
+++ b/packages/engine/src/backend/src/domain/schemas.ts
@@ -129,7 +129,11 @@ const plantSchema: z.ZodType<Plant> = domainEntitySchema
   });
 
 const zoneEnvironmentSchema: z.ZodType<ZoneEnvironment> = z.object({
-  airTemperatureC: finiteNumber
+  airTemperatureC: finiteNumber,
+  relativeHumidity_pct: finiteNumber
+    .min(0, 'relativeHumidity_pct must be >= 0.')
+    .max(100, 'relativeHumidity_pct must be <= 100.')
+    .default(50)
 });
 
 function deriveZoneAirMassKg(zone: Pick<Zone, 'floorArea_m2' | 'height_m'>): number {

--- a/packages/engine/src/backend/src/engine/pipeline/applyDeviceEffects.ts
+++ b/packages/engine/src/backend/src/engine/pipeline/applyDeviceEffects.ts
@@ -9,6 +9,7 @@ import { applyDeviceHeat } from '../thermo/heat.js';
 
 export interface DeviceEffectsRuntime {
   readonly zoneTemperatureDeltaC: Map<Zone['id'], number>;
+  readonly zoneHumidityDeltaPct: Map<Zone['id'], number>;
   readonly zoneCoverageTotals_m2: Map<Zone['id'], number>;
   readonly zoneAirflowTotals_m3_per_h: Map<Zone['id'], number>;
   readonly zoneCoverageEffectiveness01: Map<Zone['id'], number>;
@@ -34,6 +35,7 @@ function setDeviceEffectsRuntime(
 export function ensureDeviceEffectsRuntime(ctx: EngineRunContext): DeviceEffectsRuntime {
   return setDeviceEffectsRuntime(ctx, {
     zoneTemperatureDeltaC: new Map(),
+    zoneHumidityDeltaPct: new Map(),
     zoneCoverageTotals_m2: new Map(),
     zoneAirflowTotals_m3_per_h: new Map(),
     zoneCoverageEffectiveness01: new Map(),

--- a/packages/engine/src/backend/src/stubs/HumidityActuatorStub.ts
+++ b/packages/engine/src/backend/src/stubs/HumidityActuatorStub.ts
@@ -1,0 +1,192 @@
+import { HOURS_PER_TICK } from '../constants/simConstants.js';
+import type {
+  HumidityActuatorInputs,
+  HumidityActuatorOutputs,
+  IHumidityActuator
+} from '../domain/interfaces/IHumidityActuator.js';
+import type { ZoneEnvironment } from '../domain/entities.js';
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+
+  if (value < min) {
+    return min;
+  }
+
+  if (value > max) {
+    return max;
+  }
+
+  return value;
+}
+
+function resolveTickHours(tickHours: number | undefined): number {
+  if (typeof tickHours !== 'number') {
+    return HOURS_PER_TICK;
+  }
+
+  if (!Number.isFinite(tickHours) || tickHours <= 0) {
+    return HOURS_PER_TICK;
+  }
+
+  return tickHours;
+}
+
+function resolveAirMassKg(airMass_kg: number): number {
+  if (!Number.isFinite(airMass_kg) || airMass_kg <= 0) {
+    return 0;
+  }
+
+  return airMass_kg;
+}
+
+function ensureFiniteOutputs(
+  outputs: HumidityActuatorOutputs
+): HumidityActuatorOutputs {
+  const { deltaRH_pct, water_g, energy_Wh } = outputs;
+
+  if (
+    !Number.isFinite(deltaRH_pct) ||
+    !Number.isFinite(water_g) ||
+    !Number.isFinite(energy_Wh ?? 0)
+  ) {
+    throw new Error('Humidity actuator outputs must be finite numbers.');
+  }
+
+  return outputs;
+}
+
+const HUMIDITY_LOOKUP: Array<{ readonly tempC: number; readonly factor: number }> = [
+  { tempC: 15, factor: 0.12 },
+  { tempC: 20, factor: 0.14 },
+  { tempC: 25, factor: 0.15 },
+  { tempC: 30, factor: 0.16 }
+];
+
+const HUMIDITY_FACTOR_MIN = 0.1;
+const HUMIDITY_FACTOR_MAX = 0.18;
+
+function getHumidityFactor_k_rh(tempC: number): number {
+  if (!Number.isFinite(tempC)) {
+    return 0.15;
+  }
+
+  if (tempC <= HUMIDITY_LOOKUP[0]!.tempC) {
+    return clamp(HUMIDITY_LOOKUP[0]!.factor, HUMIDITY_FACTOR_MIN, HUMIDITY_FACTOR_MAX);
+  }
+
+  for (let i = 1; i < HUMIDITY_LOOKUP.length; i += 1) {
+    const lower = HUMIDITY_LOOKUP[i - 1]!;
+    const upper = HUMIDITY_LOOKUP[i]!;
+
+    if (tempC <= upper.tempC) {
+      const span = upper.tempC - lower.tempC;
+      const ratio = span === 0 ? 0 : (tempC - lower.tempC) / span;
+      const interpolated = lower.factor + ratio * (upper.factor - lower.factor);
+
+      return clamp(interpolated, HUMIDITY_FACTOR_MIN, HUMIDITY_FACTOR_MAX);
+    }
+  }
+
+  return clamp(
+    HUMIDITY_LOOKUP[HUMIDITY_LOOKUP.length - 1]!.factor,
+    HUMIDITY_FACTOR_MIN,
+    HUMIDITY_FACTOR_MAX
+  );
+}
+
+function resolveCapacityGramsPerHour(
+  inputs: HumidityActuatorInputs
+): number {
+  const { capacity_g_per_h, capacity_L_per_h } = inputs;
+
+  if (typeof capacity_g_per_h === 'number') {
+    if (!Number.isFinite(capacity_g_per_h) || capacity_g_per_h < 0) {
+      throw new RangeError('capacity_g_per_h must be a non-negative finite number.');
+    }
+
+    return capacity_g_per_h;
+  }
+
+  if (typeof capacity_L_per_h === 'number') {
+    if (!Number.isFinite(capacity_L_per_h) || capacity_L_per_h < 0) {
+      throw new RangeError('capacity_L_per_h must be a non-negative finite number.');
+    }
+
+    return capacity_L_per_h * 1_000;
+  }
+
+  throw new Error('Humidity actuator requires capacity_g_per_h or capacity_L_per_h');
+}
+
+function clampTickCapacity(
+  capacity_g_per_h: number,
+  dt_h: number
+): number {
+  return clamp(capacity_g_per_h * dt_h, 0, Number.POSITIVE_INFINITY);
+}
+
+export function createHumidityActuatorStub(): IHumidityActuator {
+  return {
+    computeEffect(
+      inputs: HumidityActuatorInputs,
+      envState: ZoneEnvironment,
+      airMass_kg: number,
+      dt_h: number,
+    ): HumidityActuatorOutputs {
+      if (
+        typeof dt_h === 'number' &&
+        (!Number.isFinite(dt_h) || dt_h <= 0)
+      ) {
+        return { deltaRH_pct: 0, water_g: 0, energy_Wh: 0 };
+      }
+
+      const resolvedDt_h = resolveTickHours(dt_h);
+      const resolvedAirMass = resolveAirMassKg(airMass_kg);
+
+      if (resolvedDt_h === 0 || resolvedAirMass === 0) {
+        return { deltaRH_pct: 0, water_g: 0, energy_Wh: 0 };
+      }
+
+      const capacity_g_per_h = resolveCapacityGramsPerHour(inputs);
+
+      if (capacity_g_per_h === 0) {
+        return { deltaRH_pct: 0, water_g: 0, energy_Wh: 0 };
+      }
+
+      const tickCapacity_g = clampTickCapacity(capacity_g_per_h, resolvedDt_h);
+
+      if (tickCapacity_g === 0) {
+        return { deltaRH_pct: 0, water_g: 0, energy_Wh: 0 };
+      }
+
+      const mode = inputs.mode;
+
+      if (mode === 'dehumidify') {
+        const humidityFactor = getHumidityFactor_k_rh(envState.airTemperatureC);
+        const deltaRH_pct = -humidityFactor * (tickCapacity_g / resolvedAirMass);
+
+        return ensureFiniteOutputs({
+          deltaRH_pct,
+          water_g: tickCapacity_g,
+          energy_Wh: 0
+        });
+      }
+
+      if (mode === 'humidify') {
+        const humidityFactor = getHumidityFactor_k_rh(envState.airTemperatureC);
+        const deltaRH_pct = humidityFactor * (tickCapacity_g / resolvedAirMass);
+
+        return ensureFiniteOutputs({
+          deltaRH_pct,
+          water_g: -tickCapacity_g,
+          energy_Wh: 0
+        });
+      }
+
+      throw new Error('Unsupported humidity actuator mode');
+    }
+  } satisfies IHumidityActuator;
+}

--- a/packages/engine/src/backend/src/stubs/index.ts
+++ b/packages/engine/src/backend/src/stubs/index.ts
@@ -7,8 +7,8 @@
  * @see Consolidated Reference Document: Interfaces & Stubs (Engine v1, Phase 1)
  */
 export * from './ThermalActuatorStub.js';
+export * from './HumidityActuatorStub.js';
 // Future exports:
-// export * from './HumidityActuatorStub.js';
 // export * from './LightEmitterStub.js';
 // export * from './NutrientBufferStub.js';
 // export * from './IrrigationServiceStub.js';

--- a/packages/engine/tests/unit/stubs/HumidityActuatorStub.test.ts
+++ b/packages/engine/tests/unit/stubs/HumidityActuatorStub.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AIR_DENSITY_KG_PER_M3,
+  HOURS_PER_TICK
+} from '@/backend/src/constants/simConstants.js';
+import { createHumidityActuatorStub } from '@/backend/src/stubs/HumidityActuatorStub.js';
+import type { HumidityActuatorInputs } from '@/backend/src/domain/interfaces/IHumidityActuator.js';
+import type { ZoneEnvironment } from '@/backend/src/domain/entities.js';
+
+const ZONE_VOLUME_M3 = 50;
+const AIR_MASS_KG = ZONE_VOLUME_M3 * AIR_DENSITY_KG_PER_M3;
+const BASE_ENV_STATE: ZoneEnvironment = {
+  airTemperatureC: 25,
+  relativeHumidity_pct: 60
+};
+
+function createInputs(
+  overrides: Partial<HumidityActuatorInputs> = {}
+): HumidityActuatorInputs {
+  return {
+    mode: 'dehumidify',
+    capacity_g_per_h: 500,
+    ...overrides
+  };
+}
+
+describe('HumidityActuatorStub', () => {
+  const stub = createHumidityActuatorStub();
+
+  describe('dehumidify mode', () => {
+    it('matches the reference delta for a 500 g/h dehumidifier', () => {
+      const inputs = createInputs();
+      const result = stub.computeEffect(inputs, BASE_ENV_STATE, AIR_MASS_KG, HOURS_PER_TICK);
+
+      expect(result.water_g).toBeCloseTo(500, 5);
+      expect(result.deltaRH_pct).toBeLessThan(0);
+      expect(result.deltaRH_pct).toBeCloseTo(-1.25, 2);
+    });
+
+    it('removes water proportional to capacity and dt_h', () => {
+      const inputs = createInputs({ capacity_g_per_h: 1_000 });
+      const result = stub.computeEffect(inputs, BASE_ENV_STATE, AIR_MASS_KG, 0.5);
+
+      expect(result.water_g).toBeCloseTo(500, 5);
+      expect(result.deltaRH_pct).toBeLessThan(0);
+    });
+
+    it('converts capacity_L_per_h to grams correctly', () => {
+      const inputs = createInputs({ capacity_g_per_h: undefined, capacity_L_per_h: 1.8 });
+      const result = stub.computeEffect(inputs, BASE_ENV_STATE, AIR_MASS_KG, HOURS_PER_TICK);
+
+      expect(result.water_g).toBeCloseTo(1_800, 5);
+      expect(result.deltaRH_pct).toBeLessThan(0);
+    });
+  });
+
+  describe('humidify mode', () => {
+    it('produces a positive humidity delta and negative water tally', () => {
+      const inputs = createInputs({ mode: 'humidify', capacity_g_per_h: 300 });
+      const result = stub.computeEffect(inputs, BASE_ENV_STATE, AIR_MASS_KG, HOURS_PER_TICK);
+
+      expect(result.deltaRH_pct).toBeGreaterThan(0);
+      expect(result.water_g).toBeCloseTo(-300, 5);
+    });
+
+    it('scales inversely with air mass', () => {
+      const inputs = createInputs({ mode: 'humidify', capacity_g_per_h: 400 });
+      const resultHalfMass = stub.computeEffect(inputs, BASE_ENV_STATE, AIR_MASS_KG / 2, HOURS_PER_TICK);
+      const resultFullMass = stub.computeEffect(inputs, BASE_ENV_STATE, AIR_MASS_KG, HOURS_PER_TICK);
+
+      expect(resultHalfMass.deltaRH_pct).toBeGreaterThan(resultFullMass.deltaRH_pct);
+      expect(resultHalfMass.deltaRH_pct).toBeCloseTo(resultFullMass.deltaRH_pct * 2, 5);
+    });
+  });
+
+  describe('temperature dependency', () => {
+    it('increases magnitude with higher temperatures', () => {
+      const inputs = createInputs();
+      const coolState: ZoneEnvironment = { ...BASE_ENV_STATE, airTemperatureC: 15 };
+      const warmState: ZoneEnvironment = { ...BASE_ENV_STATE, airTemperatureC: 30 };
+
+      const coolResult = stub.computeEffect(inputs, coolState, AIR_MASS_KG, HOURS_PER_TICK);
+      const warmResult = stub.computeEffect(inputs, warmState, AIR_MASS_KG, HOURS_PER_TICK);
+
+      expect(Math.abs(warmResult.deltaRH_pct)).toBeGreaterThan(Math.abs(coolResult.deltaRH_pct));
+    });
+
+    it('interpolates between lookup points', () => {
+      const inputs = createInputs();
+      const lowerState: ZoneEnvironment = { ...BASE_ENV_STATE, airTemperatureC: 20 };
+      const midState: ZoneEnvironment = { ...BASE_ENV_STATE, airTemperatureC: 22.5 };
+      const upperState: ZoneEnvironment = { ...BASE_ENV_STATE, airTemperatureC: 25 };
+
+      const lower = stub.computeEffect(inputs, lowerState, AIR_MASS_KG, HOURS_PER_TICK);
+      const mid = stub.computeEffect(inputs, midState, AIR_MASS_KG, HOURS_PER_TICK);
+      const upper = stub.computeEffect(inputs, upperState, AIR_MASS_KG, HOURS_PER_TICK);
+
+      expect(Math.abs(mid.deltaRH_pct)).toBeGreaterThan(Math.abs(lower.deltaRH_pct));
+      expect(Math.abs(mid.deltaRH_pct)).toBeLessThan(Math.abs(upper.deltaRH_pct));
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns zeros when capacity is zero', () => {
+      const inputs = createInputs({ capacity_g_per_h: 0 });
+      const result = stub.computeEffect(inputs, BASE_ENV_STATE, AIR_MASS_KG, HOURS_PER_TICK);
+
+      expect(result).toEqual({ deltaRH_pct: 0, water_g: 0, energy_Wh: 0 });
+    });
+
+    it('returns zeros when air mass is zero', () => {
+      const inputs = createInputs();
+      const result = stub.computeEffect(inputs, BASE_ENV_STATE, 0, HOURS_PER_TICK);
+
+      expect(result).toEqual({ deltaRH_pct: 0, water_g: 0, energy_Wh: 0 });
+    });
+
+    it('returns zeros when dt_h is zero', () => {
+      const inputs = createInputs();
+      const result = stub.computeEffect(inputs, BASE_ENV_STATE, AIR_MASS_KG, 0);
+
+      expect(result).toEqual({ deltaRH_pct: 0, water_g: 0, energy_Wh: 0 });
+    });
+
+    it('throws when neither capacity field is provided', () => {
+      const inputs = createInputs({ capacity_g_per_h: undefined });
+
+      expect(() => stub.computeEffect(inputs, BASE_ENV_STATE, AIR_MASS_KG, HOURS_PER_TICK)).toThrow(
+        'Humidity actuator requires capacity_g_per_h or capacity_L_per_h'
+      );
+    });
+
+    it('throws when capacity is negative', () => {
+      const inputs = createInputs({ capacity_g_per_h: -10 });
+
+      expect(() => stub.computeEffect(inputs, BASE_ENV_STATE, AIR_MASS_KG, HOURS_PER_TICK)).toThrow(RangeError);
+    });
+
+    it('throws when mode is invalid', () => {
+      const inputs = createInputs({ mode: 'invalid' as never });
+
+      expect(() => stub.computeEffect(inputs, BASE_ENV_STATE, AIR_MASS_KG, HOURS_PER_TICK)).toThrow(
+        'Unsupported humidity actuator mode'
+      );
+    });
+  });
+
+  describe('output structure', () => {
+    it('always returns finite numeric outputs with zero energy coupling', () => {
+      const inputs = createInputs({ capacity_g_per_h: 750 });
+      const result = stub.computeEffect(inputs, BASE_ENV_STATE, AIR_MASS_KG, 0.75);
+
+      expect(Number.isFinite(result.deltaRH_pct)).toBe(true);
+      expect(Number.isFinite(result.water_g)).toBe(true);
+      expect(result.energy_Wh).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extend zone environment modeling with relative humidity and schema validation defaults
- introduce humidity actuator stub with temperature-aware humidity factor and publish via stubs barrel
- add coverage in device runtime scaffolding and comprehensive unit tests for the humidity actuator behaviour

## Testing
- pnpm --filter @wb/engine test

------
https://chatgpt.com/codex/tasks/task_e_68df4d0ec1ec83258ed2c0bf5b9a7e8b