### PR TITLE
Add light emitter stub and zone lighting telemetry

### DIFF
--- a/docs/ADR/ADR-0010-light-emitter-telemetry.md
+++ b/docs/ADR/ADR-0010-light-emitter-telemetry.md
@@ -1,0 +1,36 @@
+# ADR-0010: Zone lighting telemetry and light emitter stub
+
+## Status
+Accepted
+
+## Context
+The Simulation Engine Contract (SEC v0.2.1) specifies that lighting devices
+contribute photosynthetic photon flux density (PPFD) and daily light integral
+(DLI) metrics at the zone scope, yet the engine lacked concrete plumbing for
+those aggregates. Zones did not persist PPFD or per-tick DLI increments, the
+light emitter interface had no implementation, and validation could not guard
+lighting telemetry. Without these hooks, upcoming lighting pipeline stages and
+photoperiod analytics could not consume deterministic tick outputs or enforce
+non-negative values mandated by the contract.
+
+## Decision
+- Extend the `Zone` domain entity, schemas, and validation routines with
+  `ppfd_umol_m2s` and `dli_mol_m2d_inc` so lighting telemetry becomes part of the
+  canonical world snapshot and remains non-negative/finiteness guarded.
+- Implement `createLightEmitterStub` following the plateau-field behaviour from
+  the SEC: PPFD scales linearly with dimming, DLI derives from tick seconds, and
+  optional `power_W` inputs report watthour consumption for energy accounting.
+- Add deterministic Vitest coverage mirroring the consolidated stub reference
+  vectors (dimming clamps, DLI increments, edge-case validation) to preserve the
+  contract as future lighting features land.
+
+## Consequences
+- Zone fixtures, bootstrap harnesses, and validators now initialise lighting
+  telemetry fields, ensuring downstream systems observe zeroed values until
+  lighting devices contribute increments.
+- Device pipelines can rely on the stub to provide deterministic PPFD/DLI
+  outputs during early integration while maintaining SEC-aligned error handling
+  for invalid inputs.
+- Documentation (CHANGELOG and this ADR) now records the contract change, giving
+  contributors a clear reference for lighting telemetry expectations and testing
+  requirements.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### #46 WB-039 light emitter stub and zone lighting telemetry
+- Added `createLightEmitterStub` mirroring the plateau-field model from the SEC
+  so dimming factors linearly scale PPFD, DLI increments derive from tick
+  duration, and optional power draw reports watthour consumption.
+- Extended the zone domain model, schemas, and validation pipeline with
+  `ppfd_umol_m2s` and `dli_mol_m2d_inc` aggregates, ensuring lighting telemetry
+  is available for downstream orchestration layers and initialised in the demo
+  harness.
+- Shipped comprehensive Vitest coverage for the new stub including reference
+  vectors, dimming clamps, energy accounting, and edge-case validation, plus
+  documentation updates (ADR-0010) describing the contract change.
+
 ### #45 WB-038 thermal actuator stub with cooling & auto support
 - Added `createThermalActuatorStub` under `@/backend/src/stubs` to deliver
   deterministic heating, cooling, and auto-mode behaviour with structured

--- a/packages/engine/src/backend/src/domain/entities.ts
+++ b/packages/engine/src/backend/src/domain/entities.ts
@@ -202,6 +202,16 @@ export interface Zone extends DomainEntity, SluggedEntity, SpatialEntity {
   readonly airMass_kg: number;
   /** Environmental state describing the zone's well-mixed air mass. */
   readonly environment: ZoneEnvironment;
+  /**
+   * Photosynthetic photon flux density delivered to the zone canopy expressed
+   * in µmol·m⁻²·s⁻¹.
+   */
+  readonly ppfd_umol_m2s: number;
+  /**
+   * Daily light integral increment accumulated during the current tick
+   * expressed in mol·m⁻²·d⁻¹.
+   */
+  readonly dli_mol_m2d_inc: number;
 }
 
 /**

--- a/packages/engine/src/backend/src/domain/schemas.ts
+++ b/packages/engine/src/backend/src/domain/schemas.ts
@@ -155,7 +155,9 @@ const zoneBaseSchema = domainEntitySchema
     photoperiodPhase: z.enum(['vegetative', 'flowering']),
     plants: z.array(plantSchema).readonly(),
     devices: z.array(zoneDeviceSchema).readonly(),
-    environment: zoneEnvironmentSchema
+    environment: zoneEnvironmentSchema,
+    ppfd_umol_m2s: finiteNumber.min(0, 'ppfd_umol_m2s cannot be negative.'),
+    dli_mol_m2d_inc: finiteNumber.min(0, 'dli_mol_m2d_inc cannot be negative.')
   });
 
 export const zoneSchema: z.ZodType<Zone> = zoneBaseSchema.transform((zone) => ({

--- a/packages/engine/src/backend/src/domain/validation.ts
+++ b/packages/engine/src/backend/src/domain/validation.ts
@@ -357,6 +357,30 @@ function validateRoom(
       });
     }
 
+    if (!Number.isFinite(zone.ppfd_umol_m2s)) {
+      issues.push({
+        path: `${zonePath}.ppfd_umol_m2s`,
+        message: 'zone PPFD must be a finite number'
+      });
+    } else if (zone.ppfd_umol_m2s < 0) {
+      issues.push({
+        path: `${zonePath}.ppfd_umol_m2s`,
+        message: 'zone PPFD must be non-negative'
+      });
+    }
+
+    if (!Number.isFinite(zone.dli_mol_m2d_inc)) {
+      issues.push({
+        path: `${zonePath}.dli_mol_m2d_inc`,
+        message: 'zone DLI increment must be a finite number'
+      });
+    } else if (zone.dli_mol_m2d_inc < 0) {
+      issues.push({
+        path: `${zonePath}.dli_mol_m2d_inc`,
+        message: 'zone DLI increment must be non-negative'
+      });
+    }
+
     zone.devices.forEach((device, deviceIndex) => {
       validateDevice(
         device,

--- a/packages/engine/src/backend/src/engine/testHarness.ts
+++ b/packages/engine/src/backend/src/engine/testHarness.ts
@@ -67,6 +67,8 @@ const DEMO_WORLD: SimulationWorld = {
                 environment: {
                   airTemperatureC: 22
                 },
+                ppfd_umol_m2s: 0,
+                dli_mol_m2d_inc: 0,
                 plants: [],
                 devices: []
               }

--- a/packages/engine/src/backend/src/stubs/LightEmitterStub.ts
+++ b/packages/engine/src/backend/src/stubs/LightEmitterStub.ts
@@ -1,0 +1,136 @@
+import { HOURS_PER_TICK, SECONDS_PER_HOUR } from '../constants/simConstants.js';
+import type {
+  ILightEmitter,
+  LightEmitterInputs,
+  LightEmitterOutputs
+} from '../domain/interfaces/ILightEmitter.js';
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+
+  if (value < min) {
+    return min;
+  }
+
+  if (value > max) {
+    return max;
+  }
+
+  return value;
+}
+
+function clamp01(value: number): number {
+  return clamp(value, 0, 1);
+}
+
+function resolveTickHours(tickHours: number | undefined): number {
+  if (typeof tickHours !== 'number') {
+    return HOURS_PER_TICK;
+  }
+
+  if (!Number.isFinite(tickHours) || tickHours <= 0) {
+    return HOURS_PER_TICK;
+  }
+
+  return tickHours;
+}
+
+function ensureFiniteOutputs(outputs: LightEmitterOutputs): LightEmitterOutputs {
+  const { ppfd_effective_umol_m2s, dli_mol_m2d_inc, energy_Wh } = outputs;
+
+  if (
+    !Number.isFinite(ppfd_effective_umol_m2s) ||
+    !Number.isFinite(dli_mol_m2d_inc) ||
+    !Number.isFinite(energy_Wh ?? 0)
+  ) {
+    throw new Error('Light emitter outputs must be finite numbers.');
+  }
+
+  return outputs;
+}
+
+function resolveEnergyWh(
+  inputs: LightEmitterInputs,
+  dt_h: number
+): number | undefined {
+  const maybePower = (inputs as LightEmitterInputs & { power_W?: number }).power_W;
+
+  if (typeof maybePower === 'undefined') {
+    return undefined;
+  }
+
+  if (!Number.isFinite(maybePower)) {
+    throw new RangeError('power_W must be a finite number when provided.');
+  }
+
+  if (maybePower < 0) {
+    throw new RangeError('power_W must be non-negative when provided.');
+  }
+
+  if (dt_h === 0) {
+    return 0;
+  }
+
+  return maybePower * dt_h;
+}
+
+function zeroEffect(): LightEmitterOutputs {
+  return { ppfd_effective_umol_m2s: 0, dli_mol_m2d_inc: 0, energy_Wh: undefined };
+}
+
+export function createLightEmitterStub(): ILightEmitter {
+  return {
+    computeEffect(inputs: LightEmitterInputs, dt_h: number): LightEmitterOutputs {
+      const { ppfd_center_umol_m2s, coverage_m2, dim01 } = inputs;
+
+      if (!Number.isFinite(ppfd_center_umol_m2s)) {
+        throw new RangeError('ppfd_center_umol_m2s must be a finite number.');
+      }
+
+      if (ppfd_center_umol_m2s < 0) {
+        throw new RangeError('ppfd_center_umol_m2s must be non-negative.');
+      }
+
+      if (!Number.isFinite(coverage_m2)) {
+        throw new RangeError('coverage_m2 must be a finite number.');
+      }
+
+      if (coverage_m2 < 0) {
+        throw new RangeError('coverage_m2 must be non-negative.');
+      }
+
+      if (
+        typeof dt_h === 'number' &&
+        (!Number.isFinite(dt_h) || dt_h <= 0)
+      ) {
+        return zeroEffect();
+      }
+
+      const resolvedDt_h = resolveTickHours(dt_h);
+
+      if (resolvedDt_h === 0 || coverage_m2 === 0 || ppfd_center_umol_m2s === 0) {
+        return zeroEffect();
+      }
+
+      const dim = clamp01(dim01);
+
+      if (dim === 0) {
+        return zeroEffect();
+      }
+
+      const ppfd_effective_umol_m2s = ppfd_center_umol_m2s * dim;
+      const tickSeconds = resolvedDt_h * SECONDS_PER_HOUR;
+      const dli_mol_m2d_inc =
+        (ppfd_effective_umol_m2s * tickSeconds) / 1_000_000;
+      const energy_Wh = resolveEnergyWh(inputs, resolvedDt_h);
+
+      return ensureFiniteOutputs({
+        ppfd_effective_umol_m2s,
+        dli_mol_m2d_inc,
+        energy_Wh
+      });
+    }
+  } satisfies ILightEmitter;
+}

--- a/packages/engine/src/backend/src/stubs/index.ts
+++ b/packages/engine/src/backend/src/stubs/index.ts
@@ -8,7 +8,7 @@
  */
 export * from './ThermalActuatorStub.js';
 export * from './HumidityActuatorStub.js';
+export * from './LightEmitterStub.js';
 // Future exports:
-// export * from './LightEmitterStub.js';
 // export * from './NutrientBufferStub.js';
 // export * from './IrrigationServiceStub.js';

--- a/packages/engine/tests/unit/stubs/LightEmitterStub.test.ts
+++ b/packages/engine/tests/unit/stubs/LightEmitterStub.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  HOURS_PER_TICK,
+  SECONDS_PER_HOUR
+} from '@/backend/src/constants/simConstants.js';
+import { createLightEmitterStub } from '@/backend/src/stubs/LightEmitterStub.js';
+import type { LightEmitterInputs } from '@/backend/src/domain/interfaces/ILightEmitter.js';
+
+function createInputs(overrides: Partial<LightEmitterInputs> = {}): LightEmitterInputs {
+  return {
+    ppfd_center_umol_m2s: 600,
+    coverage_m2: 1.2,
+    dim01: 1,
+    ...overrides
+  } satisfies LightEmitterInputs;
+}
+
+describe('LightEmitterStub', () => {
+  const stub = createLightEmitterStub();
+
+  describe('reference test vector', () => {
+    it('matches the reference delta for 600 µmol·m⁻²·s⁻¹ over 0.25 h', () => {
+      const inputs = createInputs();
+      const result = stub.computeEffect(inputs, 0.25);
+
+      expect(result.ppfd_effective_umol_m2s).toBeCloseTo(600, 5);
+      expect(result.dli_mol_m2d_inc).toBeCloseTo(0.54, 2);
+    });
+  });
+
+  describe('dimming factor', () => {
+    it('scales PPFD linearly with dim01', () => {
+      const inputs = createInputs({ dim01: 0.5 });
+      const result = stub.computeEffect(inputs, HOURS_PER_TICK);
+
+      expect(result.ppfd_effective_umol_m2s).toBeCloseTo(300, 5);
+      const expectedDli = (300 * HOURS_PER_TICK * SECONDS_PER_HOUR) / 1_000_000;
+      expect(result.dli_mol_m2d_inc).toBeCloseTo(expectedDli, 5);
+    });
+
+    it('returns zero effect when dim01 is zero', () => {
+      const inputs = createInputs({ dim01: 0 });
+      const result = stub.computeEffect(inputs, HOURS_PER_TICK);
+
+      expect(result).toEqual({
+        ppfd_effective_umol_m2s: 0,
+        dli_mol_m2d_inc: 0,
+        energy_Wh: undefined
+      });
+    });
+
+    it('clamps dim01 to the [0,1] interval', () => {
+      const highDim = stub.computeEffect(createInputs({ dim01: 1.5 }), HOURS_PER_TICK);
+      const lowDim = stub.computeEffect(createInputs({ dim01: -0.2 }), HOURS_PER_TICK);
+
+      expect(highDim.ppfd_effective_umol_m2s).toBeCloseTo(600, 5);
+      expect(lowDim.ppfd_effective_umol_m2s).toBe(0);
+    });
+  });
+
+  describe('DLI calculation', () => {
+    it('accumulates DLI proportionally to the tick duration', () => {
+      const fullHour = stub.computeEffect(createInputs(), 1);
+      const halfHour = stub.computeEffect(createInputs(), 0.5);
+
+      expect(halfHour.dli_mol_m2d_inc).toBeCloseTo(fullHour.dli_mol_m2d_inc / 2, 5);
+    });
+
+    it('converts PPFD to mol·m⁻²·d⁻¹ increments', () => {
+      const inputs = createInputs({ ppfd_center_umol_m2s: 800 });
+      const dt = 0.75;
+      const result = stub.computeEffect(inputs, dt);
+      const expectedDli = (800 * dt * SECONDS_PER_HOUR) / 1_000_000;
+
+      expect(result.dli_mol_m2d_inc).toBeCloseTo(expectedDli, 5);
+    });
+  });
+
+  describe('energy accounting', () => {
+    it('returns undefined energy when no power draw is provided', () => {
+      const inputs = createInputs();
+      const result = stub.computeEffect(inputs, HOURS_PER_TICK);
+
+      expect(result.energy_Wh).toBeUndefined();
+    });
+
+    it('tracks energy when power_W is supplied', () => {
+      const inputs = {
+        ...createInputs(),
+        power_W: 600
+      } as LightEmitterInputs & { power_W: number };
+      const dt = 0.5;
+      const result = stub.computeEffect(inputs, dt);
+
+      expect(result.energy_Wh).toBeCloseTo(600 * dt, 5);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns zeros when PPFD is zero', () => {
+      const result = stub.computeEffect(createInputs({ ppfd_center_umol_m2s: 0 }), HOURS_PER_TICK);
+
+      expect(result).toEqual({
+        ppfd_effective_umol_m2s: 0,
+        dli_mol_m2d_inc: 0,
+        energy_Wh: undefined
+      });
+    });
+
+    it('returns zeros when coverage is zero', () => {
+      const result = stub.computeEffect(createInputs({ coverage_m2: 0 }), HOURS_PER_TICK);
+
+      expect(result).toEqual({
+        ppfd_effective_umol_m2s: 0,
+        dli_mol_m2d_inc: 0,
+        energy_Wh: undefined
+      });
+    });
+
+    it('returns zeros when dt_h is zero', () => {
+      const result = stub.computeEffect(createInputs(), 0);
+
+      expect(result).toEqual({
+        ppfd_effective_umol_m2s: 0,
+        dli_mol_m2d_inc: 0,
+        energy_Wh: undefined
+      });
+    });
+
+    it('returns zeros when dim01 is non-finite', () => {
+      const result = stub.computeEffect(createInputs({ dim01: Number.NaN }), HOURS_PER_TICK);
+
+      expect(result).toEqual({
+        ppfd_effective_umol_m2s: 0,
+        dli_mol_m2d_inc: 0,
+        energy_Wh: undefined
+      });
+    });
+
+    it('throws when PPFD is negative', () => {
+      expect(() => stub.computeEffect(createInputs({ ppfd_center_umol_m2s: -1 }), HOURS_PER_TICK)).toThrowError(
+        RangeError
+      );
+    });
+
+    it('throws when coverage is negative', () => {
+      expect(() => stub.computeEffect(createInputs({ coverage_m2: -0.1 }), HOURS_PER_TICK)).toThrowError(RangeError);
+    });
+
+    it('throws when provided power_W is non-finite', () => {
+      const inputs = {
+        ...createInputs(),
+        power_W: Number.NaN
+      } as LightEmitterInputs & { power_W: number };
+
+      expect(() => stub.computeEffect(inputs, HOURS_PER_TICK)).toThrowError(RangeError);
+    });
+  });
+
+  describe('output structure', () => {
+    it('always returns finite PPFD and DLI values', () => {
+      const inputs = {
+        ...createInputs({ ppfd_center_umol_m2s: 450, dim01: 0.8 }),
+        power_W: 450
+      } as LightEmitterInputs & { power_W: number };
+      const result = stub.computeEffect(inputs, 0.5);
+
+      expect(Number.isFinite(result.ppfd_effective_umol_m2s)).toBe(true);
+      expect(Number.isFinite(result.dli_mol_m2d_inc)).toBe(true);
+      expect(Number.isFinite(result.energy_Wh ?? 0)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- implement the plateau-field light emitter stub with dimming clamps, DLI conversion, and optional energy reporting
- extend the zone entity, schema, validation, and demo harness with PPFD/DLI telemetry fields required by the SEC
- cover the new behaviour with Vitest unit tests and document the contract change in the changelog and ADR-0010

## Testing
- pnpm --filter @wb/engine test *(fails: vitest executable is unavailable in the container image)*

------
https://chatgpt.com/codex/tasks/task_e_68df4fd540c08325a4755f941deef2d6