### PR TITLE
Add nutrient buffer and irrigation service stubs

### DIFF
--- a/packages/engine/src/backend/src/stubs/IrrigationServiceStub.ts
+++ b/packages/engine/src/backend/src/stubs/IrrigationServiceStub.ts
@@ -1,0 +1,194 @@
+import { HOURS_PER_TICK } from '../constants/simConstants.js';
+import type {
+  IIrrigationService,
+  IrrigationEvent,
+  IrrigationServiceInputs,
+  IrrigationServiceOutputs,
+} from '../domain/interfaces/IIrrigationService.js';
+import type {
+  INutrientBuffer,
+  NutrientBufferInputs,
+} from '../domain/interfaces/INutrientBuffer.js';
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+
+  if (value < min) {
+    return min;
+  }
+
+  if (value > max) {
+    return max;
+  }
+
+  return value;
+}
+
+function resolveTickHours(tickHours: number | undefined): number {
+  if (typeof tickHours !== 'number') {
+    return HOURS_PER_TICK;
+  }
+
+  if (!Number.isFinite(tickHours) || tickHours <= 0) {
+    return HOURS_PER_TICK;
+  }
+
+  return tickHours;
+}
+
+function multiplyNutrientRecord(
+  record: Record<string, number>,
+  factor: number,
+): Record<string, number> {
+  const scaled: Record<string, number> = {};
+
+  if (!Number.isFinite(factor) || factor <= 0) {
+    return scaled;
+  }
+
+  for (const [key, value] of Object.entries(record)) {
+    if (Number.isFinite(value) && value > 0) {
+      scaled[key] = value * factor;
+    }
+  }
+
+  return scaled;
+}
+
+function sumNutrientRecords(
+  ...records: Array<Record<string, number>>
+): Record<string, number> {
+  const summed: Record<string, number> = {};
+
+  for (const record of records) {
+    for (const [key, value] of Object.entries(record)) {
+      const current = summed[key] ?? 0;
+      summed[key] = Number.isFinite(value) ? current + value : current;
+    }
+  }
+
+  return summed;
+}
+
+function ensureFiniteOutputs(
+  outputs: IrrigationServiceOutputs,
+): IrrigationServiceOutputs {
+  if (!Number.isFinite(outputs.water_L)) {
+    throw new Error('Irrigation service outputs must contain a finite water total.');
+  }
+
+  for (const record of [outputs.nutrients_mg, outputs.uptake_mg, outputs.leached_mg]) {
+    for (const value of Object.values(record)) {
+      if (!Number.isFinite(value)) {
+        throw new Error('Irrigation service nutrient totals must be finite numbers.');
+      }
+    }
+  }
+
+  return outputs;
+}
+
+function zeroOutputs(): IrrigationServiceOutputs {
+  return { water_L: 0, nutrients_mg: {}, uptake_mg: {}, leached_mg: {} };
+}
+
+function aggregateEventNutrients(events: IrrigationEvent[]): {
+  water_L: number;
+  nutrients_mg: Record<string, number>;
+} {
+  let water_L = 0;
+  const nutrientTotals: Array<Record<string, number>> = [];
+
+  for (const event of events) {
+    const volume = Number.isFinite(event.water_L) ? Math.max(0, event.water_L) : 0;
+    water_L += volume;
+
+    if (volume === 0) {
+      continue;
+    }
+
+    nutrientTotals.push(multiplyNutrientRecord(event.concentrations_mg_per_L, volume));
+  }
+
+  return {
+    water_L,
+    nutrients_mg: nutrientTotals.length === 0 ? {} : sumNutrientRecords(...nutrientTotals),
+  };
+}
+
+function createBufferInputs(
+  inputs: IrrigationServiceInputs,
+  bufferState: Record<string, number>,
+  nutrients_mg: Record<string, number>,
+): NutrientBufferInputs {
+  const nutrientKeys = Object.keys(sumNutrientRecords(bufferState, nutrients_mg));
+  const capacity_mg: Record<string, number> = {};
+  const buffer_mg: Record<string, number> = {};
+
+  for (const key of nutrientKeys) {
+    capacity_mg[key] = Number.MAX_SAFE_INTEGER;
+    buffer_mg[key] = Number.isFinite(bufferState[key]) ? Math.max(0, bufferState[key]) : 0;
+  }
+
+  return {
+    capacity_mg,
+    buffer_mg,
+    flow_mg: nutrients_mg,
+    uptake_demand_mg: {},
+    leaching01: clamp(0.1, 0, 1),
+    nutrientSource: inputs.nutrientSource,
+  };
+}
+
+/**
+ * Phase 1 deterministic stub for {@link IIrrigationService} that aggregates
+ * irrigation events, translates delivered solution into nutrient mass, and
+ * delegates storage dynamics to the injected {@link INutrientBuffer} stub.
+ */
+export function createIrrigationServiceStub(
+  bufferStub: INutrientBuffer,
+): IIrrigationService {
+  return {
+    computeEffect(
+      inputs: IrrigationServiceInputs,
+      bufferState: Record<string, number>,
+      dt_h: number,
+    ): IrrigationServiceOutputs {
+      if (typeof dt_h === 'number' && (!Number.isFinite(dt_h) || dt_h <= 0)) {
+        return zeroOutputs();
+      }
+
+      const resolvedDt_h = resolveTickHours(dt_h);
+
+      if (!Number.isFinite(resolvedDt_h) || resolvedDt_h <= 0) {
+        return zeroOutputs();
+      }
+
+      const events = Array.isArray(inputs.events) ? inputs.events : [];
+
+      if (events.length === 0) {
+        return zeroOutputs();
+      }
+
+      const { water_L, nutrients_mg } = aggregateEventNutrients(events);
+
+      if (water_L === 0) {
+        return zeroOutputs();
+      }
+
+      const bufferInputs = createBufferInputs(inputs, bufferState, nutrients_mg);
+      const bufferResult = bufferStub.computeEffect(bufferInputs, resolvedDt_h);
+
+      const outputs: IrrigationServiceOutputs = {
+        water_L,
+        nutrients_mg,
+        uptake_mg: bufferResult.uptake_mg,
+        leached_mg: bufferResult.leached_mg,
+      };
+
+      return ensureFiniteOutputs(outputs);
+    },
+  } satisfies IIrrigationService;
+}

--- a/packages/engine/src/backend/src/stubs/NutrientBufferStub.ts
+++ b/packages/engine/src/backend/src/stubs/NutrientBufferStub.ts
@@ -1,0 +1,164 @@
+import { HOURS_PER_TICK } from '../constants/simConstants.js';
+import type {
+  INutrientBuffer,
+  NutrientBufferInputs,
+  NutrientBufferOutputs,
+} from '../domain/interfaces/INutrientBuffer.js';
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+
+  if (value < min) {
+    return min;
+  }
+
+  if (value > max) {
+    return max;
+  }
+
+  return value;
+}
+
+function resolveTickHours(tickHours: number | undefined): number {
+  if (typeof tickHours !== 'number') {
+    return HOURS_PER_TICK;
+  }
+
+  if (!Number.isFinite(tickHours) || tickHours <= 0) {
+    return HOURS_PER_TICK;
+  }
+
+  return tickHours;
+}
+
+function clampNutrientRecord(
+  record: Record<string, number>,
+  min: number,
+  max: number,
+): Record<string, number> {
+  const clamped: Record<string, number> = {};
+
+  for (const [key, value] of Object.entries(record)) {
+    clamped[key] = clamp(value, min, max);
+  }
+
+  return clamped;
+}
+
+function sumNutrientRecords(
+  ...records: Array<Record<string, number>>
+): Record<string, number> {
+  const summed: Record<string, number> = {};
+
+  for (const record of records) {
+    for (const [key, value] of Object.entries(record)) {
+      const current = summed[key] ?? 0;
+      summed[key] = Number.isFinite(value) ? current + value : current;
+    }
+  }
+
+  return summed;
+}
+
+function ensureFiniteOutputs(
+  outputs: NutrientBufferOutputs,
+): NutrientBufferOutputs {
+  for (const record of [outputs.uptake_mg, outputs.leached_mg, outputs.new_buffer_mg]) {
+    for (const value of Object.values(record)) {
+      if (!Number.isFinite(value)) {
+        throw new Error('Nutrient buffer outputs must be finite numbers.');
+      }
+    }
+  }
+
+  return outputs;
+}
+
+function zeroOutputs(): NutrientBufferOutputs {
+  return { uptake_mg: {}, leached_mg: {}, new_buffer_mg: {} };
+}
+
+/**
+ * Deterministic stub implementation of {@link INutrientBuffer} following the
+ * consolidated reference (Section 4.4 NutrientBufferStub).
+ *
+ * The flow is computed in four distinct phases per nutrient key:
+ *
+ * 1. **Leaching** removes a fraction of the incoming nutrient flow based on
+ *    {@link NutrientBufferInputs.leaching01}.
+ * 2. **Availability** adds the non-leached flow to the existing buffer.
+ * 3. **Uptake** clamps plant demand to the available amount to avoid
+ *    overdrawing the buffer.
+ * 4. **Buffer update** stores the residual nutrients back into the buffer,
+ *    respecting the declared capacity.
+ *
+ * Water inventory and moisture modelling remain out of scope for Phase 1; the
+ * implementation is intentionally pure for deterministic composition within the
+ * engine pipeline.
+ */
+export function createNutrientBufferStub(): INutrientBuffer {
+  return {
+    computeEffect(inputs: NutrientBufferInputs, dt_h: number): NutrientBufferOutputs {
+      if (typeof dt_h === 'number' && (!Number.isFinite(dt_h) || dt_h <= 0)) {
+        return zeroOutputs();
+      }
+
+      const resolvedDt_h = resolveTickHours(dt_h);
+
+      if (!Number.isFinite(resolvedDt_h) || resolvedDt_h <= 0) {
+        return zeroOutputs();
+      }
+
+      const { leaching01 } = inputs;
+
+      if (!Number.isFinite(leaching01) || leaching01 < 0 || leaching01 > 1) {
+        throw new RangeError('Nutrient leaching ratio must lie within [0,1].');
+      }
+
+      const capacity = clampNutrientRecord(inputs.capacity_mg, 0, Infinity);
+      const buffer = clampNutrientRecord(inputs.buffer_mg, 0, Infinity);
+      const flow = clampNutrientRecord(inputs.flow_mg, 0, Infinity);
+      const demand = clampNutrientRecord(inputs.uptake_demand_mg, 0, Infinity);
+
+      const nutrientKeys = Object.keys(sumNutrientRecords(capacity, buffer, flow, demand));
+
+      const leached_mg: Record<string, number> = {};
+      const uptake_mg: Record<string, number> = {};
+      const new_buffer_mg: Record<string, number> = {};
+
+      for (const key of nutrientKeys) {
+        const capacityValue = capacity[key] ?? Infinity;
+        const bufferValue = buffer[key] ?? 0;
+        const flowValue = flow[key] ?? 0;
+        const demandValue = demand[key] ?? 0;
+
+        const leached = clamp(flowValue * leaching01, 0, flowValue);
+        const available = Math.max(0, bufferValue + flowValue - leached);
+        const uptake = clamp(demandValue, 0, available);
+        const updatedBuffer = clamp(
+          bufferValue + flowValue - leached - uptake,
+          0,
+          Number.isFinite(capacityValue) ? capacityValue : Infinity,
+        );
+
+        if (leached > 0) {
+          leached_mg[key] = leached;
+        }
+
+        if (uptake > 0) {
+          uptake_mg[key] = uptake;
+        }
+
+        if (updatedBuffer > 0) {
+          new_buffer_mg[key] = updatedBuffer;
+        } else if (capacityValue === 0 || bufferValue + flowValue - leached - uptake <= 0) {
+          new_buffer_mg[key] = 0;
+        }
+      }
+
+      return ensureFiniteOutputs({ uptake_mg, leached_mg, new_buffer_mg });
+    },
+  } satisfies INutrientBuffer;
+}

--- a/packages/engine/src/backend/src/stubs/index.ts
+++ b/packages/engine/src/backend/src/stubs/index.ts
@@ -9,6 +9,5 @@
 export * from './ThermalActuatorStub.js';
 export * from './HumidityActuatorStub.js';
 export * from './LightEmitterStub.js';
-// Future exports:
-// export * from './NutrientBufferStub.js';
-// export * from './IrrigationServiceStub.js';
+export * from './NutrientBufferStub.js';
+export * from './IrrigationServiceStub.js';

--- a/packages/engine/tests/unit/stubs/IrrigationServiceStub.test.ts
+++ b/packages/engine/tests/unit/stubs/IrrigationServiceStub.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { HOURS_PER_TICK } from '@/backend/src/constants/simConstants.js';
+import { createIrrigationServiceStub } from '@/backend/src/stubs/IrrigationServiceStub.js';
+import { createNutrientBufferStub } from '@/backend/src/stubs/NutrientBufferStub.js';
+import type {
+  IrrigationEvent,
+  IrrigationServiceInputs,
+} from '@/backend/src/domain/interfaces/IIrrigationService.js';
+import type { INutrientBuffer } from '@/backend/src/domain/interfaces/INutrientBuffer.js';
+import type { Uuid } from '@/backend/src/domain/entities.js';
+
+const MOCK_ZONE_ID = 'zone-123' as Uuid;
+const MOCK_PLANT_ID = 'plant-456' as Uuid;
+const BASE_BUFFER_STATE: Record<string, number> = { N: 1_000, P: 500, K: 800 };
+
+function createEvent(overrides: Partial<IrrigationEvent> = {}): IrrigationEvent {
+  return {
+    water_L: 10,
+    concentrations_mg_per_L: { N: 50, P: 25, K: 40 },
+    targetZoneId: MOCK_ZONE_ID,
+    targetPlantId: MOCK_PLANT_ID,
+    ...overrides,
+  };
+}
+
+function createInputs(
+  overrides: Partial<IrrigationServiceInputs> = {},
+): IrrigationServiceInputs {
+  return {
+    events: [createEvent()],
+    nutrientSource: 'solution',
+    ...overrides,
+  };
+}
+
+describe('IrrigationServiceStub', () => {
+  const bufferStub = createNutrientBufferStub();
+  const stub = createIrrigationServiceStub(bufferStub);
+
+  it('aggregates a single irrigation event into water and nutrient totals', () => {
+    const inputs = createInputs();
+    const result = stub.computeEffect(inputs, BASE_BUFFER_STATE, HOURS_PER_TICK);
+
+    expect(result.water_L).toBeCloseTo(10, 5);
+    expect(result.nutrients_mg.N).toBeCloseTo(500, 5);
+    expect(result.nutrients_mg.P).toBeCloseTo(250, 5);
+    expect(result.nutrients_mg.K).toBeCloseTo(400, 5);
+  });
+
+  it('sums multiple events including partial nutrient profiles', () => {
+    const inputs = createInputs({
+      events: [
+        createEvent(),
+        createEvent({ water_L: 5, concentrations_mg_per_L: { N: 30, Ca: 10 } }),
+      ],
+    });
+
+    const result = stub.computeEffect(inputs, BASE_BUFFER_STATE, HOURS_PER_TICK);
+
+    expect(result.water_L).toBeCloseTo(15, 5);
+    expect(result.nutrients_mg.N).toBeCloseTo(650, 5);
+    expect(result.nutrients_mg.P).toBeCloseTo(250, 5);
+    expect(result.nutrients_mg.K).toBeCloseTo(400, 5);
+    expect(result.nutrients_mg.Ca).toBeCloseTo(50, 5);
+  });
+
+  it('delegates nutrient dynamics to the buffer stub', () => {
+    const inputs = createInputs({ events: [createEvent({ water_L: 8 })] });
+    const result = stub.computeEffect(inputs, BASE_BUFFER_STATE, HOURS_PER_TICK);
+
+    expect(result.leached_mg.N).toBeCloseTo(40, 5);
+    expect(result.uptake_mg.N ?? 0).toBe(0);
+  });
+
+  it('returns zeros when no events are provided', () => {
+    const inputs = createInputs({ events: [] });
+    const result = stub.computeEffect(inputs, BASE_BUFFER_STATE, HOURS_PER_TICK);
+
+    expect(result).toEqual({ water_L: 0, nutrients_mg: {}, uptake_mg: {}, leached_mg: {} });
+  });
+
+  it('returns zeros when dt is non-positive', () => {
+    const inputs = createInputs();
+    const result = stub.computeEffect(inputs, BASE_BUFFER_STATE, 0);
+
+    expect(result).toEqual({ water_L: 0, nutrients_mg: {}, uptake_mg: {}, leached_mg: {} });
+  });
+
+  it('supports injecting a mock nutrient buffer', () => {
+    const computeEffect = vi.fn().mockReturnValue({
+      uptake_mg: { N: 10 },
+      leached_mg: { N: 5 },
+      new_buffer_mg: { N: 995 },
+    });
+
+    const mockBufferStub: INutrientBuffer = {
+      computeEffect,
+    };
+
+    const irrigationStub = createIrrigationServiceStub(mockBufferStub);
+    const inputs = createInputs();
+    const result = irrigationStub.computeEffect(inputs, BASE_BUFFER_STATE, HOURS_PER_TICK);
+
+    expect(computeEffect).toHaveBeenCalled();
+    expect(result.uptake_mg.N).toBe(10);
+    expect(result.leached_mg.N).toBe(5);
+  });
+
+  it('leaves nutrient totals empty when concentrations are zero', () => {
+    const inputs = createInputs({
+      events: [createEvent({ water_L: 5, concentrations_mg_per_L: {} })],
+    });
+
+    const result = stub.computeEffect(inputs, BASE_BUFFER_STATE, HOURS_PER_TICK);
+
+    expect(result.water_L).toBe(5);
+    expect(result.nutrients_mg).toEqual({});
+  });
+});

--- a/packages/engine/tests/unit/stubs/NutrientBufferStub.test.ts
+++ b/packages/engine/tests/unit/stubs/NutrientBufferStub.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import { HOURS_PER_TICK } from '@/backend/src/constants/simConstants.js';
+import { createNutrientBufferStub } from '@/backend/src/stubs/NutrientBufferStub.js';
+import type { NutrientBufferInputs } from '@/backend/src/domain/interfaces/INutrientBuffer.js';
+
+const BASE_CAPACITY_MG: Record<string, number> = { N: 10_000, P: 5_000, K: 8_000 };
+const BASE_BUFFER_MG: Record<string, number> = { N: 1_000, P: 500, K: 800 };
+
+function createInputs(
+  overrides: Partial<NutrientBufferInputs> = {},
+): NutrientBufferInputs {
+  return {
+    capacity_mg: BASE_CAPACITY_MG,
+    buffer_mg: BASE_BUFFER_MG,
+    flow_mg: { N: 500, P: 250, K: 400 },
+    uptake_demand_mg: { N: 300, P: 150, K: 200 },
+    leaching01: 0.1,
+    nutrientSource: 'substrate',
+    ...overrides,
+  };
+}
+
+describe('NutrientBufferStub', () => {
+  const stub = createNutrientBufferStub();
+
+  it('matches the reference vector for nitrogen', () => {
+    const inputs = createInputs();
+    const result = stub.computeEffect(inputs, HOURS_PER_TICK);
+
+    expect(result.uptake_mg.N).toBeCloseTo(300, 5);
+    expect(result.leached_mg.N).toBeCloseTo(50, 5);
+    expect(result.new_buffer_mg.N).toBeCloseTo(1_150, 5);
+  });
+
+  it('processes nutrients independently across keys', () => {
+    const inputs = createInputs({
+      flow_mg: { N: 600, K: 100 },
+      uptake_demand_mg: { N: 200, K: 80 },
+    });
+
+    const result = stub.computeEffect(inputs, HOURS_PER_TICK);
+
+    expect(result.uptake_mg).toMatchObject({ N: 200, K: 80 });
+    expect(result.leached_mg.N).toBeCloseTo(60, 5);
+    expect(result.leached_mg.K).toBeCloseTo(10, 5);
+  });
+
+  it('clamps uptake to available nutrients', () => {
+    const inputs = createInputs({
+      buffer_mg: { N: 10 },
+      flow_mg: { N: 10 },
+      uptake_demand_mg: { N: 100 },
+    });
+
+    const result = stub.computeEffect(inputs, HOURS_PER_TICK);
+
+    expect(result.uptake_mg.N).toBeLessThanOrEqual(20);
+    expect(result.new_buffer_mg.N).toBeGreaterThanOrEqual(0);
+  });
+
+  it('clamps new buffer to capacity', () => {
+    const inputs = createInputs({
+      buffer_mg: { N: 9_900 },
+      flow_mg: { N: 5_000 },
+      uptake_demand_mg: { N: 0 },
+    });
+
+    const result = stub.computeEffect(inputs, HOURS_PER_TICK);
+
+    expect(result.new_buffer_mg.N).toBeLessThanOrEqual(BASE_CAPACITY_MG.N);
+  });
+
+  it('returns zero outputs when dt is non-positive', () => {
+    const inputs = createInputs();
+    expect(stub.computeEffect(inputs, 0)).toEqual({
+      uptake_mg: {},
+      leached_mg: {},
+      new_buffer_mg: {},
+    });
+  });
+
+  it('throws when leaching ratio falls outside [0,1]', () => {
+    const inputs = createInputs({ leaching01: 1.5 });
+
+    expect(() => stub.computeEffect(inputs, HOURS_PER_TICK)).toThrow(RangeError);
+  });
+
+  it('handles empty nutrient records', () => {
+    const inputs = createInputs({
+      capacity_mg: {},
+      buffer_mg: {},
+      flow_mg: {},
+      uptake_demand_mg: {},
+    });
+
+    const result = stub.computeEffect(inputs, HOURS_PER_TICK);
+
+    expect(result.uptake_mg).toEqual({});
+    expect(result.leached_mg).toEqual({});
+    expect(result.new_buffer_mg).toEqual({});
+  });
+
+  it('ensures outputs remain finite numbers', () => {
+    const inputs = createInputs({
+      flow_mg: { N: 1_000_000 },
+      uptake_demand_mg: { N: 0 },
+    });
+
+    const result = stub.computeEffect(inputs, HOURS_PER_TICK);
+
+    expect(Number.isFinite(result.leached_mg.N)).toBe(true);
+    expect(Number.isFinite(result.new_buffer_mg.N)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a deterministic nutrient buffer stub implementing the four-phase leaching/uptake flow
- introduce an irrigation service stub that aggregates events and delegates nutrient handling to the buffer
- expand the stub index exports and add unit tests covering the new buffer and irrigation stubs

## Testing
- pnpm --filter @wb/engine test *(fails: vitest binary unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df53ea04a8832598981a633c233f3c