### PR TITLE
Integrate humidity and lighting device effects into pipeline

### DIFF
--- a/packages/engine/src/backend/src/domain/interfaces/index.ts
+++ b/packages/engine/src/backend/src/domain/interfaces/index.ts
@@ -19,3 +19,19 @@ export * from './IIrrigationService.js';
 export * from './IAirflowActuator.js';
 export * from './IFiltrationUnit.js';
 export * from './ISensor.js';
+
+export type {
+  IThermalActuator,
+  ThermalActuatorInputs,
+  ThermalActuatorOutputs
+} from './IThermalActuator.js';
+export type {
+  IHumidityActuator,
+  HumidityActuatorInputs,
+  HumidityActuatorOutputs
+} from './IHumidityActuator.js';
+export type {
+  ILightEmitter,
+  LightEmitterInputs,
+  LightEmitterOutputs
+} from './ILightEmitter.js';

--- a/packages/engine/src/backend/src/engine/thermo/heat.ts
+++ b/packages/engine/src/backend/src/engine/thermo/heat.ts
@@ -46,7 +46,9 @@ function resolveAirMassKg(zone: Pick<Zone, 'airMass_kg'>): number {
  * For full thermal actuator support (heating, cooling, auto),
  * use {@link createThermalActuatorStub} from `@/backend/src/stubs/ThermalActuatorStub.js`.
  *
- * This function will be refactored in Phase 4 to delegate to ThermalActuatorStub.
+ * This function has been replaced by ThermalActuatorStub in
+ * `applyDeviceEffects.ts` (Phase 6) and is retained for backward compatibility
+ * with external tests. It will be removed in a future phase.
  *
  * @see packages/engine/src/backend/src/stubs/ThermalActuatorStub.ts
  *

--- a/packages/engine/src/backend/src/stubs/index.ts
+++ b/packages/engine/src/backend/src/stubs/index.ts
@@ -11,3 +11,7 @@ export * from './HumidityActuatorStub.js';
 export * from './LightEmitterStub.js';
 export * from './NutrientBufferStub.js';
 export * from './IrrigationServiceStub.js';
+
+export { createThermalActuatorStub } from './ThermalActuatorStub.js';
+export { createHumidityActuatorStub } from './HumidityActuatorStub.js';
+export { createLightEmitterStub } from './LightEmitterStub.js';

--- a/packages/engine/tests/integration/pipeline/lightingEffects.integration.test.ts
+++ b/packages/engine/tests/integration/pipeline/lightingEffects.integration.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  HOURS_PER_TICK,
+  SECONDS_PER_HOUR
+} from '@/backend/src/constants/simConstants.js';
+import { runTick } from '@/backend/src/engine/Engine.js';
+import { createDemoWorld } from '@/backend/src/engine/testHarness.js';
+import {
+  createDeviceInstance,
+  type DeviceQualityPolicy,
+  type Uuid,
+  type ZoneDeviceInstance
+} from '@/backend/src/domain/world.js';
+
+function uuid(value: string): Uuid {
+  return value as Uuid;
+}
+
+const QUALITY_POLICY: DeviceQualityPolicy = {
+  sampleQuality01: (rng) => rng()
+};
+
+const WORLD_SEED = 'lighting-effects-seed';
+
+function deviceQuality(id: Uuid): number {
+  return createDeviceInstance(QUALITY_POLICY, WORLD_SEED, id).quality01;
+}
+
+describe('Tick pipeline — lighting effects', () => {
+  it('accumulates PPFD and DLI from lighting devices', () => {
+    const world = createDemoWorld();
+    const structure = world.company.structures[0];
+    const room = structure.rooms[0];
+    const zone = room.zones[0];
+
+    const deviceId = uuid('40000000-0000-0000-0000-000000000001');
+    const lightingDevice: ZoneDeviceInstance = {
+      id: deviceId,
+      slug: 'led-veg-light',
+      name: 'LED Veg Light',
+      blueprintId: uuid('40000000-0000-0000-0000-000000000002'),
+      placementScope: 'zone',
+      quality01: deviceQuality(deviceId),
+      condition01: 0.96,
+      powerDraw_W: 600,
+      dutyCycle01: 1,
+      efficiency01: 0.7,
+      coverage_m2: 1.2,
+      airflow_m3_per_h: 0,
+      sensibleHeatRemovalCapacity_W: 0
+    } satisfies ZoneDeviceInstance;
+
+    zone.devices = [lightingDevice];
+
+    const tickDurationHours = 0.25;
+    const { world: nextWorld } = runTick(world, { tickDurationHours });
+    const nextZone = nextWorld.company.structures[0].rooms[0].zones[0];
+
+    const expectedPPFD = lightingDevice.powerDraw_W * lightingDevice.efficiency01 * 2.5;
+    const expectedDLI = (expectedPPFD * tickDurationHours * SECONDS_PER_HOUR) / 1_000_000;
+
+    expect(nextZone.ppfd_umol_m2s).toBeCloseTo(expectedPPFD, 5);
+    expect(nextZone.dli_mol_m2d_inc).toBeCloseTo(expectedDLI, 5);
+  });
+
+  it('accumulates PPFD from multiple lights', () => {
+    const world = createDemoWorld();
+    const structure = world.company.structures[0];
+    const room = structure.rooms[0];
+    const zone = room.zones[0];
+
+    const deviceAId = uuid('40000000-0000-0000-0000-000000000003');
+    const deviceBId = uuid('40000000-0000-0000-0000-000000000004');
+
+    const lightA: ZoneDeviceInstance = {
+      id: deviceAId,
+      slug: 'veg-light-a',
+      name: 'Veg Light A',
+      blueprintId: uuid('40000000-0000-0000-0000-000000000005'),
+      placementScope: 'zone',
+      quality01: deviceQuality(deviceAId),
+      condition01: 0.94,
+      powerDraw_W: 500,
+      dutyCycle01: 1,
+      efficiency01: 0.65,
+      coverage_m2: 1,
+      airflow_m3_per_h: 0,
+      sensibleHeatRemovalCapacity_W: 0
+    } satisfies ZoneDeviceInstance;
+
+    const lightB: ZoneDeviceInstance = {
+      id: deviceBId,
+      slug: 'veg-light-b',
+      name: 'Veg Light B',
+      blueprintId: uuid('40000000-0000-0000-0000-000000000006'),
+      placementScope: 'zone',
+      quality01: deviceQuality(deviceBId),
+      condition01: 0.93,
+      powerDraw_W: 450,
+      dutyCycle01: 1,
+      efficiency01: 0.6,
+      coverage_m2: 1,
+      airflow_m3_per_h: 0,
+      sensibleHeatRemovalCapacity_W: 0
+    } satisfies ZoneDeviceInstance;
+
+    zone.devices = [lightA, lightB];
+
+    const { world: nextWorld } = runTick(world, {});
+    const nextZone = nextWorld.company.structures[0].rooms[0].zones[0];
+
+    const expectedPPFD =
+      lightA.powerDraw_W * lightA.efficiency01 * 2.5 +
+      lightB.powerDraw_W * lightB.efficiency01 * 2.5;
+    const expectedDLI = (expectedPPFD * HOURS_PER_TICK * SECONDS_PER_HOUR) / 1_000_000;
+
+    expect(nextZone.ppfd_umol_m2s).toBeCloseTo(expectedPPFD, 5);
+    expect(nextZone.dli_mol_m2d_inc).toBeCloseTo(expectedDLI, 5);
+  });
+
+  it('respects dimming factor from duty cycle', () => {
+    const world = createDemoWorld();
+    const structure = world.company.structures[0];
+    const room = structure.rooms[0];
+    const zone = room.zones[0];
+
+    const deviceId = uuid('40000000-0000-0000-0000-000000000007');
+    const dimmedLight: ZoneDeviceInstance = {
+      id: deviceId,
+      slug: 'dimmed-light',
+      name: 'Dimmed Light',
+      blueprintId: uuid('40000000-0000-0000-0000-000000000008'),
+      placementScope: 'zone',
+      quality01: deviceQuality(deviceId),
+      condition01: 0.91,
+      powerDraw_W: 400,
+      dutyCycle01: 0.5,
+      efficiency01: 0.6,
+      coverage_m2: 1,
+      airflow_m3_per_h: 0,
+      sensibleHeatRemovalCapacity_W: 0
+    } satisfies ZoneDeviceInstance;
+
+    zone.devices = [dimmedLight];
+
+    const { world: nextWorld } = runTick(world, {});
+    const nextZone = nextWorld.company.structures[0].rooms[0].zones[0];
+
+    const fullOutput = dimmedLight.powerDraw_W * dimmedLight.efficiency01 * 2.5;
+    const expectedPPFD = fullOutput * dimmedLight.dutyCycle01;
+    const expectedDLI = (expectedPPFD * HOURS_PER_TICK * SECONDS_PER_HOUR) / 1_000_000;
+
+    expect(nextZone.ppfd_umol_m2s).toBeCloseTo(expectedPPFD, 5);
+    expect(nextZone.dli_mol_m2d_inc).toBeCloseTo(expectedDLI, 5);
+  });
+
+  it('returns zero effect when coverage is zero', () => {
+    const world = createDemoWorld();
+    const structure = world.company.structures[0];
+    const room = structure.rooms[0];
+    const zone = room.zones[0];
+
+    const deviceId = uuid('40000000-0000-0000-0000-000000000009');
+    const invalidLight: ZoneDeviceInstance = {
+      id: deviceId,
+      slug: 'invalid-light',
+      name: 'Invalid Light',
+      blueprintId: uuid('40000000-0000-0000-0000-000000000010'),
+      placementScope: 'zone',
+      quality01: deviceQuality(deviceId),
+      condition01: 0.9,
+      powerDraw_W: 500,
+      dutyCycle01: 1,
+      efficiency01: 0.6,
+      coverage_m2: 0,
+      airflow_m3_per_h: 0,
+      sensibleHeatRemovalCapacity_W: 0
+    } satisfies ZoneDeviceInstance;
+
+    zone.devices = [invalidLight];
+
+    const { world: nextWorld } = runTick(world, {});
+    const nextZone = nextWorld.company.structures[0].rooms[0].zones[0];
+
+    expect(nextZone.ppfd_umol_m2s).toBe(0);
+    expect(nextZone.dli_mol_m2d_inc).toBe(0);
+  });
+});

--- a/packages/engine/tests/integration/pipeline/multiEffectDevice.integration.test.ts
+++ b/packages/engine/tests/integration/pipeline/multiEffectDevice.integration.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CP_AIR_J_PER_KG_K,
+  HOURS_PER_TICK,
+  SECONDS_PER_HOUR
+} from '@/backend/src/constants/simConstants.js';
+import type { EngineRunContext } from '@/backend/src/engine/Engine.js';
+import { runTick } from '@/backend/src/engine/Engine.js';
+import { createDemoWorld } from '@/backend/src/engine/testHarness.js';
+import {
+  createDeviceInstance,
+  type DeviceQualityPolicy,
+  type Uuid,
+  type ZoneDeviceInstance
+} from '@/backend/src/domain/world.js';
+
+function uuid(value: string): Uuid {
+  return value as Uuid;
+}
+
+const QUALITY_POLICY: DeviceQualityPolicy = {
+  sampleQuality01: (rng) => rng()
+};
+
+const WORLD_SEED = 'multi-effect-seed';
+
+function deviceQuality(id: Uuid): number {
+  return createDeviceInstance(QUALITY_POLICY, WORLD_SEED, id).quality01;
+}
+
+describe('Tick pipeline — multi-effect devices', () => {
+  it('integrates thermal cooling and humidity removal in a single tick', () => {
+    const world = createDemoWorld();
+    const structure = world.company.structures[0];
+    const room = structure.rooms[0];
+    const zone = room.zones[0];
+
+    const baseFloorArea = zone.floorArea_m2;
+    const baseAirMass = zone.airMass_kg;
+
+    zone.floorArea_m2 = 25;
+    zone.airMass_kg = (baseAirMass / baseFloorArea) * zone.floorArea_m2;
+
+    zone.environment = {
+      ...zone.environment,
+      relativeHumidity_pct: 60
+    };
+
+    const initialTemperatureC = zone.environment.airTemperatureC;
+    const initialHumidity = zone.environment.relativeHumidity_pct;
+
+    const deviceId = uuid('30000000-0000-0000-0000-000000000001');
+    const multiEffectDevice: ZoneDeviceInstance = {
+      id: deviceId,
+      slug: 'cool-air-dehumidifier',
+      name: 'Cool Air Dehumidifier',
+      blueprintId: uuid('30000000-0000-0000-0000-000000000002'),
+      placementScope: 'zone',
+      quality01: deviceQuality(deviceId),
+      condition01: 0.95,
+      powerDraw_W: 1_200,
+      dutyCycle01: 1,
+      efficiency01: 0.65,
+      coverage_m2: 25,
+      airflow_m3_per_h: 350,
+      sensibleHeatRemovalCapacity_W: 3_000
+    } satisfies ZoneDeviceInstance;
+
+    zone.devices = [multiEffectDevice];
+
+    const ctx: EngineRunContext = {
+      tickDurationHours: 1
+    } satisfies EngineRunContext;
+
+    const { world: nextWorld } = runTick(world, ctx);
+    const nextZone = nextWorld.company.structures[0].rooms[0].zones[0];
+
+    const cooling_W = multiEffectDevice.powerDraw_W * multiEffectDevice.efficiency01;
+    const tickSeconds = (ctx.tickDurationHours ?? HOURS_PER_TICK) * SECONDS_PER_HOUR;
+    const expectedDeltaC =
+      (-cooling_W * tickSeconds) / (zone.airMass_kg * CP_AIR_J_PER_KG_K);
+
+    expect(nextZone.environment.airTemperatureC).toBeCloseTo(
+      initialTemperatureC + expectedDeltaC,
+      5
+    );
+    expect(nextZone.environment.relativeHumidity_pct).toBeLessThan(initialHumidity);
+    expect((ctx as Record<string, unknown>).__wb_deviceEffects).toBeUndefined();
+  });
+
+  it('accumulates effects from multiple devices', () => {
+    const world = createDemoWorld();
+    const structure = world.company.structures[0];
+    const room = structure.rooms[0];
+    const zone = room.zones[0];
+
+    zone.environment = {
+      ...zone.environment,
+      relativeHumidity_pct: 65
+    };
+
+    const heaterId = uuid('30000000-0000-0000-0000-000000000003');
+    const heater: ZoneDeviceInstance = {
+      id: heaterId,
+      slug: 'resistive-heater',
+      name: 'Resistive Heater',
+      blueprintId: uuid('30000000-0000-0000-0000-000000000004'),
+      placementScope: 'zone',
+      quality01: deviceQuality(heaterId),
+      condition01: 0.9,
+      powerDraw_W: 900,
+      dutyCycle01: 1,
+      efficiency01: 0.2,
+      coverage_m2: 60,
+      airflow_m3_per_h: 0,
+      sensibleHeatRemovalCapacity_W: 0
+    } satisfies ZoneDeviceInstance;
+
+    const dehumidifierId = uuid('30000000-0000-0000-0000-000000000005');
+    const dehumidifier: ZoneDeviceInstance = {
+      id: dehumidifierId,
+      slug: 'smart-dehumidifier',
+      name: 'Smart Dehumidifier',
+      blueprintId: uuid('30000000-0000-0000-0000-000000000006'),
+      placementScope: 'zone',
+      quality01: deviceQuality(dehumidifierId),
+      condition01: 0.92,
+      powerDraw_W: 450,
+      dutyCycle01: 1,
+      efficiency01: 0.5,
+      coverage_m2: 30,
+      airflow_m3_per_h: 0,
+      sensibleHeatRemovalCapacity_W: 0
+    } satisfies ZoneDeviceInstance;
+
+    zone.devices = [heater, dehumidifier];
+
+    const { world: nextWorld } = runTick(world, {});
+    const nextZone = nextWorld.company.structures[0].rooms[0].zones[0];
+
+    const tickSeconds = HOURS_PER_TICK * SECONDS_PER_HOUR;
+    const heaterWaste_W = heater.powerDraw_W * (1 - heater.efficiency01);
+    const expectedTemp =
+      zone.environment.airTemperatureC +
+      (heaterWaste_W * tickSeconds) / (zone.airMass_kg * CP_AIR_J_PER_KG_K);
+
+    expect(nextZone.environment.airTemperatureC).toBeCloseTo(expectedTemp, 5);
+    expect(nextZone.environment.relativeHumidity_pct).toBeLessThan(
+      zone.environment.relativeHumidity_pct
+    );
+  });
+
+  it('applies coverage effectiveness to thermal effects', () => {
+    const world = createDemoWorld();
+    const structure = world.company.structures[0];
+    const room = structure.rooms[0];
+    const zone = room.zones[0];
+
+    const originalFloorArea = zone.floorArea_m2;
+    const originalAirMass = zone.airMass_kg;
+
+    zone.floorArea_m2 = 20;
+    zone.airMass_kg = (originalAirMass / originalFloorArea) * zone.floorArea_m2;
+
+    const heaterId = uuid('30000000-0000-0000-0000-000000000007');
+    const partialCoverageHeater: ZoneDeviceInstance = {
+      id: heaterId,
+      slug: 'partial-heater',
+      name: 'Partial Coverage Heater',
+      blueprintId: uuid('30000000-0000-0000-0000-000000000008'),
+      placementScope: 'zone',
+      quality01: deviceQuality(heaterId),
+      condition01: 0.88,
+      powerDraw_W: 1_000,
+      dutyCycle01: 1,
+      efficiency01: 0.2,
+      coverage_m2: 10,
+      airflow_m3_per_h: 0,
+      sensibleHeatRemovalCapacity_W: 0
+    } satisfies ZoneDeviceInstance;
+
+    zone.devices = [partialCoverageHeater];
+
+    const { world: nextWorld } = runTick(world, {});
+    const nextZone = nextWorld.company.structures[0].rooms[0].zones[0];
+
+    const effectiveness01 = 0.5;
+    const wasteHeat_W = partialCoverageHeater.powerDraw_W * (1 - partialCoverageHeater.efficiency01);
+    const tickSeconds = HOURS_PER_TICK * SECONDS_PER_HOUR;
+    const unscaledDeltaC =
+      (wasteHeat_W * tickSeconds) / (zone.airMass_kg * CP_AIR_J_PER_KG_K);
+    const expectedTemp =
+      zone.environment.airTemperatureC + unscaledDeltaC * effectiveness01;
+
+    expect(nextZone.environment.airTemperatureC).toBeCloseTo(expectedTemp, 5);
+  });
+});


### PR DESCRIPTION
## Summary
- delegate device effect calculations to the thermal, humidity, and lighting stubs while tracking new runtime aggregates
- update zone environment hydration and lighting fields when applying device effects and keep legacy heat helper documented as deprecated
- add integration coverage for combined HVAC/dehumidification flows and several lighting scenarios

## Testing
- `pnpm --filter @wb/engine test` *(fails: vitest not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df56acbe148325987fd8a5653d7e86