### PR TITLE
Add irrigation nutrient buffering pipeline integration

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### #47 WB-040 irrigation and nutrient buffering pipeline
+- Extended the zone domain contract and Zod schemas with `nutrientBuffer_mg`
+  and `moisture01`, wiring the demo harness defaults so simulation snapshots
+  expose substrate inventory for irrigation logic.
+- Implemented the `applyIrrigationAndNutrients` pipeline stage using the
+  deterministic irrigation and nutrient buffer stubs, runtime context maps, and
+  diagnostics emission while updating zone nutrient buffers in the world tree.
+- Added an Engine run context hook for `irrigationEvents`, a comprehensive
+  integration suite covering single/multi-event aggregation, leaching,
+  persistence, and multi-zone isolation, plus documentation updates here.
+
 ### #46 WB-039 light emitter stub and zone lighting telemetry
 - Added `createLightEmitterStub` mirroring the plateau-field model from the SEC
   so dimming factors linearly scale PPFD, DLI increments derive from tick

--- a/packages/engine/src/backend/src/domain/entities.ts
+++ b/packages/engine/src/backend/src/domain/entities.ts
@@ -212,6 +212,16 @@ export interface Zone extends DomainEntity, SluggedEntity, SpatialEntity {
    * expressed in mol·m⁻²·d⁻¹.
    */
   readonly dli_mol_m2d_inc: number;
+  /**
+   * Nutrient buffer inventory for the zone's substrate expressed in milligrams per nutrient.
+   * Updated each tick by the irrigation and nutrients pipeline stage.
+   */
+  readonly nutrientBuffer_mg: Record<string, number>;
+  /**
+   * Substrate moisture proxy on the canonical [0,1] scale.
+   * Phase 1: Reserved for future moisture control integration.
+   */
+  readonly moisture01: number;
 }
 
 /**

--- a/packages/engine/src/backend/src/domain/schemas.ts
+++ b/packages/engine/src/backend/src/domain/schemas.ts
@@ -157,7 +157,14 @@ const zoneBaseSchema = domainEntitySchema
     devices: z.array(zoneDeviceSchema).readonly(),
     environment: zoneEnvironmentSchema,
     ppfd_umol_m2s: finiteNumber.min(0, 'ppfd_umol_m2s cannot be negative.'),
-    dli_mol_m2d_inc: finiteNumber.min(0, 'dli_mol_m2d_inc cannot be negative.')
+    dli_mol_m2d_inc: finiteNumber.min(0, 'dli_mol_m2d_inc cannot be negative.'),
+    nutrientBuffer_mg: z
+      .record(z.string(), finiteNumber.min(0, 'Nutrient buffer values cannot be negative.'))
+      .default({}),
+    moisture01: finiteNumber
+      .min(0, 'moisture01 must be >= 0.')
+      .max(1, 'moisture01 must be <= 1.')
+      .default(0.5)
   });
 
 export const zoneSchema: z.ZodType<Zone> = zoneBaseSchema.transform((zone) => ({

--- a/packages/engine/src/backend/src/engine/Engine.ts
+++ b/packages/engine/src/backend/src/engine/Engine.ts
@@ -1,4 +1,5 @@
 import type { SimulationWorld, Uuid } from '../domain/world.js';
+import type { IrrigationEvent } from '../domain/interfaces/IIrrigationService.js';
 import { applyDeviceEffects } from './pipeline/applyDeviceEffects.js';
 import { updateEnvironment } from './pipeline/updateEnvironment.js';
 import { applyIrrigationAndNutrients } from './pipeline/applyIrrigationAndNutrients.js';
@@ -27,6 +28,7 @@ export interface EngineDiagnosticsSink {
 export interface EngineRunContext {
   readonly instrumentation?: EngineInstrumentation;
   readonly diagnostics?: EngineDiagnosticsSink;
+  readonly irrigationEvents?: readonly IrrigationEvent[];
   readonly [key: string]: unknown;
 }
 

--- a/packages/engine/src/backend/src/engine/pipeline/applyIrrigationAndNutrients.ts
+++ b/packages/engine/src/backend/src/engine/pipeline/applyIrrigationAndNutrients.ts
@@ -1,13 +1,256 @@
-import type { SimulationWorld } from '../../domain/world.js';
-import type { EngineRunContext } from '../Engine.js';
+import { resolveTickHours } from './applyDeviceEffects.js';
+import { createIrrigationServiceStub, createNutrientBufferStub } from '../../stubs/index.js';
+import type { SimulationWorld, Zone } from '../../domain/world.js';
+import type { EngineDiagnostic, EngineRunContext } from '../Engine.js';
+import type {
+  IrrigationEvent,
+  IrrigationServiceInputs,
+} from '../../domain/interfaces/IIrrigationService.js';
+import type { NutrientBufferInputs } from '../../domain/interfaces/INutrientBuffer.js';
+
+export interface IrrigationNutrientsRuntime {
+  readonly zoneWaterDelivered_L: Map<Zone['id'], number>;
+  readonly zoneNutrientsDelivered_mg: Map<Zone['id'], Record<string, number>>;
+  readonly zoneNutrientsUptake_mg: Map<Zone['id'], Record<string, number>>;
+  readonly zoneNutrientsLeached_mg: Map<Zone['id'], Record<string, number>>;
+  readonly zoneBufferUpdates_mg: Map<Zone['id'], Record<string, number>>;
+}
+
+const IRRIGATION_RUNTIME_CONTEXT_KEY = '__wb_irrigationNutrients' as const;
+
+type Mutable<T> = { -readonly [K in keyof T]: T[K] };
+
+type IrrigationRuntimeCarrier = Mutable<EngineRunContext> & {
+  [IRRIGATION_RUNTIME_CONTEXT_KEY]?: IrrigationNutrientsRuntime;
+};
+
+function setIrrigationRuntime(
+  ctx: EngineRunContext,
+  runtime: IrrigationNutrientsRuntime
+): IrrigationNutrientsRuntime {
+  (ctx as IrrigationRuntimeCarrier)[IRRIGATION_RUNTIME_CONTEXT_KEY] = runtime;
+  return runtime;
+}
+
+export function ensureIrrigationNutrientsRuntime(
+  ctx: EngineRunContext
+): IrrigationNutrientsRuntime {
+  return setIrrigationRuntime(ctx, {
+    zoneWaterDelivered_L: new Map(),
+    zoneNutrientsDelivered_mg: new Map(),
+    zoneNutrientsUptake_mg: new Map(),
+    zoneNutrientsLeached_mg: new Map(),
+    zoneBufferUpdates_mg: new Map(),
+  });
+}
+
+export function getIrrigationNutrientsRuntime(
+  ctx: EngineRunContext
+): IrrigationNutrientsRuntime | undefined {
+  return (ctx as IrrigationRuntimeCarrier)[IRRIGATION_RUNTIME_CONTEXT_KEY];
+}
+
+export function clearIrrigationNutrientsRuntime(ctx: EngineRunContext): void {
+  delete (ctx as IrrigationRuntimeCarrier)[IRRIGATION_RUNTIME_CONTEXT_KEY];
+}
+
+const DEFAULT_LEACHING_RATIO = 0.1;
+
+function normalizeBufferState(buffer: Record<string, number>): Record<string, number> {
+  const normalized: Record<string, number> = {};
+
+  for (const [key, value] of Object.entries(buffer)) {
+    if (Number.isFinite(value) && value > 0) {
+      normalized[key] = value;
+    } else if (Number.isFinite(value) && value <= 0) {
+      normalized[key] = 0;
+    }
+  }
+
+  return normalized;
+}
+
+function createBufferInputs(
+  inputs: IrrigationServiceInputs,
+  bufferState: Record<string, number>,
+  nutrients_mg: Record<string, number>,
+): NutrientBufferInputs {
+  const keys = new Set<string>([
+    ...Object.keys(bufferState ?? {}),
+    ...Object.keys(nutrients_mg ?? {}),
+  ]);
+  const capacity_mg: Record<string, number> = {};
+  const buffer_mg: Record<string, number> = normalizeBufferState(bufferState ?? {});
+
+  for (const key of keys) {
+    capacity_mg[key] = Number.MAX_SAFE_INTEGER;
+
+    if (!(key in buffer_mg)) {
+      buffer_mg[key] = 0;
+    }
+  }
+
+  return {
+    capacity_mg,
+    buffer_mg,
+    flow_mg: { ...nutrients_mg },
+    uptake_demand_mg: {},
+    leaching01: DEFAULT_LEACHING_RATIO,
+    nutrientSource: inputs.nutrientSource,
+  } satisfies NutrientBufferInputs;
+}
+
+function emitIrrigationDiagnostic(
+  ctx: EngineRunContext,
+  zone: Zone,
+  outputs: {
+    readonly water_L: number;
+    readonly nutrients_mg: Record<string, number>;
+    readonly uptake_mg: Record<string, number>;
+    readonly leached_mg: Record<string, number>;
+  },
+): void {
+  if (outputs.water_L <= 0) {
+    return;
+  }
+
+  const diagnostic: EngineDiagnostic = {
+    scope: 'zone',
+    code: 'zone.irrigation.applied',
+    zoneId: zone.id,
+    message: `Zone "${zone.name}" received ${outputs.water_L.toFixed(2)} L water.`,
+    metadata: {
+      water_L: outputs.water_L,
+      nutrients_mg: outputs.nutrients_mg,
+      uptake_mg: outputs.uptake_mg,
+      leached_mg: outputs.leached_mg,
+    },
+  };
+
+  ctx.diagnostics?.emit(diagnostic);
+}
+
+function groupEventsByZone(
+  events: readonly IrrigationEvent[],
+): Map<Zone['id'], IrrigationEvent[]> {
+  const grouped = new Map<Zone['id'], IrrigationEvent[]>();
+
+  for (const event of events) {
+    const current = grouped.get(event.targetZoneId) ?? [];
+    current.push(event);
+    grouped.set(event.targetZoneId, current);
+  }
+
+  return grouped;
+}
 
 export function applyIrrigationAndNutrients(
   world: SimulationWorld,
-  ctx: EngineRunContext
+  ctx: EngineRunContext,
 ): SimulationWorld {
-  void ctx;
+  const events =
+    ((ctx as { irrigationEvents?: readonly IrrigationEvent[] }).irrigationEvents ?? []) as
+      | readonly IrrigationEvent[]
+      | [];
 
-  const nextWorld = { ...world } satisfies SimulationWorld;
+  if (events.length === 0) {
+    clearIrrigationNutrientsRuntime(ctx);
+    return world;
+  }
+
+  const runtime = ensureIrrigationNutrientsRuntime(ctx);
+  const dt_h = resolveTickHours(ctx);
+
+  const bufferStub = createNutrientBufferStub();
+  const irrigationStub = createIrrigationServiceStub(bufferStub);
+  const groupedEvents = groupEventsByZone(events);
+
+  let worldMutated = false;
+
+  for (const structure of world.company.structures) {
+    for (const room of structure.rooms) {
+      for (const zone of room.zones) {
+        const zoneEvents = groupedEvents.get(zone.id);
+
+        if (!zoneEvents || zoneEvents.length === 0) {
+          continue;
+        }
+
+        const inputs: IrrigationServiceInputs = {
+          events: zoneEvents,
+          nutrientSource: 'solution',
+        };
+        const bufferState = zone.nutrientBuffer_mg ?? {};
+        const outputs = irrigationStub.computeEffect(inputs, bufferState, dt_h);
+
+        if (outputs.water_L <= 0 && Object.keys(outputs.nutrients_mg).length === 0) {
+          continue;
+        }
+
+        const bufferInputs = createBufferInputs(inputs, bufferState, outputs.nutrients_mg);
+        const bufferResult = bufferStub.computeEffect(bufferInputs, dt_h);
+
+        runtime.zoneWaterDelivered_L.set(zone.id, outputs.water_L);
+        runtime.zoneNutrientsDelivered_mg.set(zone.id, { ...outputs.nutrients_mg });
+        runtime.zoneNutrientsUptake_mg.set(zone.id, { ...outputs.uptake_mg });
+        runtime.zoneNutrientsLeached_mg.set(zone.id, { ...outputs.leached_mg });
+        runtime.zoneBufferUpdates_mg.set(zone.id, { ...bufferResult.new_buffer_mg });
+
+        emitIrrigationDiagnostic(ctx, zone, outputs);
+
+        worldMutated = true;
+      }
+    }
+  }
+
+  if (!worldMutated) {
+    clearIrrigationNutrientsRuntime(ctx);
+    return world;
+  }
+
+  const nextStructures = world.company.structures.map((structure) => {
+    let structureChanged = false;
+
+    const nextRooms = structure.rooms.map((room) => {
+      let roomChanged = false;
+
+      const nextZones = room.zones.map((zone) => {
+        if (!runtime.zoneBufferUpdates_mg.has(zone.id)) {
+          return zone;
+        }
+
+        roomChanged = true;
+        structureChanged = true;
+
+        return {
+          ...zone,
+          nutrientBuffer_mg: runtime.zoneBufferUpdates_mg.get(zone.id) ?? zone.nutrientBuffer_mg,
+        } satisfies Zone;
+      });
+
+      if (!roomChanged) {
+        return room;
+      }
+
+      return { ...room, zones: nextZones } satisfies typeof room;
+    });
+
+    if (!structureChanged) {
+      return structure;
+    }
+
+    return { ...structure, rooms: nextRooms } satisfies typeof structure;
+  });
+
+  const nextWorld: SimulationWorld = {
+    ...world,
+    company: {
+      ...world.company,
+      structures: nextStructures,
+    },
+  };
+
+  clearIrrigationNutrientsRuntime(ctx);
 
   return nextWorld;
 }

--- a/packages/engine/src/backend/src/engine/testHarness.ts
+++ b/packages/engine/src/backend/src/engine/testHarness.ts
@@ -69,6 +69,12 @@ const DEMO_WORLD: SimulationWorld = {
                 },
                 ppfd_umol_m2s: 0,
                 dli_mol_m2d_inc: 0,
+                nutrientBuffer_mg: {
+                  N: 1000,
+                  P: 500,
+                  K: 800
+                },
+                moisture01: 0.5,
                 plants: [],
                 devices: []
               }

--- a/packages/engine/tests/integration/pipeline/irrigationNutrients.integration.test.ts
+++ b/packages/engine/tests/integration/pipeline/irrigationNutrients.integration.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest';
+
+import { runTick } from '@/backend/src/engine/Engine.js';
+import { createDemoWorld } from '@/backend/src/engine/testHarness.js';
+import type { IrrigationEvent } from '@/backend/src/domain/interfaces/IIrrigationService.js';
+import type { SimulationWorld, Uuid, Zone } from '@/backend/src/domain/world.js';
+
+function uuid(value: string): Uuid {
+  return value as Uuid;
+}
+
+const WORLD_SEED = 'irrigation-nutrients-seed';
+
+function setWorldSeed(world: SimulationWorld, seed: string): void {
+  (world as { seed: string }).seed = seed;
+}
+
+function setZoneBuffer(zone: Zone, buffer: Record<string, number>): void {
+  (zone as unknown as { nutrientBuffer_mg: Record<string, number> }).nutrientBuffer_mg = buffer;
+}
+
+describe('Tick pipeline — irrigation and nutrients', () => {
+  it('applies a single irrigation event and updates the nutrient buffer', () => {
+    const world = createDemoWorld();
+    setWorldSeed(world, WORLD_SEED);
+
+    const structure = world.company.structures[0];
+    const room = structure.rooms[0];
+    const zone = room.zones[0];
+
+    setZoneBuffer(zone, { N: 1000, P: 500, K: 800 });
+
+    const event: IrrigationEvent = {
+      water_L: 10,
+      concentrations_mg_per_L: { N: 50, P: 25, K: 40 },
+      targetZoneId: zone.id
+    };
+
+    const { world: nextWorld } = runTick(world, { irrigationEvents: [event] });
+    const nextZone = nextWorld.company.structures[0].rooms[0].zones[0];
+
+    expect(nextZone.nutrientBuffer_mg.N).toBeCloseTo(1450, 5);
+    expect(nextZone.nutrientBuffer_mg.P).toBeCloseTo(725, 5);
+    expect(nextZone.nutrientBuffer_mg.K).toBeCloseTo(1160, 5);
+  });
+
+  it('aggregates multiple irrigation events targeting the same zone', () => {
+    const world = createDemoWorld();
+    setWorldSeed(world, WORLD_SEED);
+
+    const zone = world.company.structures[0].rooms[0].zones[0];
+    setZoneBuffer(zone, { N: 500, P: 200, K: 300, Ca: 100 });
+
+    const events: IrrigationEvent[] = [
+      {
+        water_L: 10,
+        concentrations_mg_per_L: { N: 50, P: 25, K: 40 },
+        targetZoneId: zone.id
+      },
+      {
+        water_L: 5,
+        concentrations_mg_per_L: { N: 30, Ca: 10 },
+        targetZoneId: zone.id
+      }
+    ];
+
+    const { world: nextWorld } = runTick(world, { irrigationEvents: events });
+    const nextZone = nextWorld.company.structures[0].rooms[0].zones[0];
+
+    const expectedBuffer = {
+      N: 500 + 650 - 65,
+      P: 200 + 250 - 25,
+      K: 300 + 400 - 40,
+      Ca: 100 + 50 - 5
+    } as const;
+
+    expect(nextZone.nutrientBuffer_mg.N).toBeCloseTo(expectedBuffer.N, 5);
+    expect(nextZone.nutrientBuffer_mg.P).toBeCloseTo(expectedBuffer.P, 5);
+    expect(nextZone.nutrientBuffer_mg.K).toBeCloseTo(expectedBuffer.K, 5);
+    expect(nextZone.nutrientBuffer_mg.Ca).toBeCloseTo(expectedBuffer.Ca, 5);
+  });
+
+  it('computes leaching consistent with the nutrient buffer reference vector', () => {
+    const world = createDemoWorld();
+    setWorldSeed(world, WORLD_SEED);
+
+    const zone = world.company.structures[0].rooms[0].zones[0];
+    setZoneBuffer(zone, { N: 1000, P: 500, K: 800 });
+
+    const event: IrrigationEvent = {
+      water_L: 10,
+      concentrations_mg_per_L: { N: 50, P: 25, K: 40 },
+      targetZoneId: zone.id
+    };
+
+    const { world: nextWorld } = runTick(world, { irrigationEvents: [event] });
+    const nextZone = nextWorld.company.structures[0].rooms[0].zones[0];
+
+    const leachedN = 1000 + 500 - nextZone.nutrientBuffer_mg.N;
+    const leachedP = 500 + 250 - nextZone.nutrientBuffer_mg.P;
+    const leachedK = 800 + 400 - nextZone.nutrientBuffer_mg.K;
+
+    expect(leachedN).toBeCloseTo(50, 5);
+    expect(leachedP).toBeCloseTo(25, 5);
+    expect(leachedK).toBeCloseTo(40, 5);
+  });
+
+  it('persists buffer state across sequential ticks', () => {
+    const world = createDemoWorld();
+    setWorldSeed(world, WORLD_SEED);
+
+    const zone = world.company.structures[0].rooms[0].zones[0];
+    setZoneBuffer(zone, { N: 500 });
+
+    const firstEvent: IrrigationEvent = {
+      water_L: 10,
+      concentrations_mg_per_L: { N: 30 },
+      targetZoneId: zone.id
+    };
+
+    const { world: afterFirst } = runTick(world, { irrigationEvents: [firstEvent] });
+    const firstZone = afterFirst.company.structures[0].rooms[0].zones[0];
+
+    expect(firstZone.nutrientBuffer_mg.N).toBeCloseTo(500 + 300 - 30, 5);
+
+    const secondEvent: IrrigationEvent = {
+      water_L: 5,
+      concentrations_mg_per_L: { N: 20 },
+      targetZoneId: firstZone.id
+    };
+
+    const { world: afterSecond } = runTick(afterFirst, { irrigationEvents: [secondEvent] });
+    const secondZone = afterSecond.company.structures[0].rooms[0].zones[0];
+
+    const expectedSecondBuffer = (500 + 300 - 30) + 100 - 10;
+    expect(secondZone.nutrientBuffer_mg.N).toBeCloseTo(expectedSecondBuffer, 5);
+  });
+
+  it('returns the original world snapshot when no irrigation events are provided', () => {
+    const world = createDemoWorld();
+    setWorldSeed(world, WORLD_SEED);
+
+    const { world: nextWorld } = runTick(world, { irrigationEvents: [] });
+
+    expect(nextWorld).toBe(world);
+  });
+
+  it('updates multiple zones independently based on targeted events', () => {
+    const world = createDemoWorld();
+    setWorldSeed(world, WORLD_SEED);
+
+    const structure = world.company.structures[0];
+    const room = structure.rooms[0];
+    const zoneA = room.zones[0];
+
+    const zoneB: Zone = {
+      ...zoneA,
+      id: uuid('50000000-0000-0000-0000-000000000001'),
+      slug: 'zone-b',
+      name: 'Zone B',
+      nutrientBuffer_mg: { N: 200, P: 100 },
+      moisture01: zoneA.moisture01
+    } satisfies Zone;
+
+    (room.zones as unknown as Zone[]).push(zoneB);
+
+    const events: IrrigationEvent[] = [
+      {
+        water_L: 8,
+        concentrations_mg_per_L: { N: 40 },
+        targetZoneId: zoneA.id
+      },
+      {
+        water_L: 4,
+        concentrations_mg_per_L: { P: 30 },
+        targetZoneId: zoneB.id
+      }
+    ];
+
+    const { world: nextWorld } = runTick(world, { irrigationEvents: events });
+    const [nextZoneA, nextZoneB] = nextWorld.company.structures[0].rooms[0].zones;
+
+    expect(nextZoneA.nutrientBuffer_mg.N).toBeCloseTo(1000 + 320 - 32, 5);
+    expect(nextZoneB.nutrientBuffer_mg.P).toBeCloseTo(100 + 120 - 12, 5);
+    expect(nextZoneB.nutrientBuffer_mg.N).toBeCloseTo(200, 5);
+  });
+});


### PR DESCRIPTION
## Summary
- extend the zone domain contracts and validation schema with nutrient buffer and moisture scaffolding wired into the demo harness
- implement the irrigation and nutrient pipeline stage using the existing stubs, runtime context maps, and diagnostics while updating zone buffers
- add engine context plumbing for irrigation events plus a comprehensive integration test suite and changelog documentation

## Testing
- pnpm --filter engine test -- --runTestsByPath packages/engine/tests/integration/pipeline/irrigationNutrients.integration.test.ts *(fails: vitest binary not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df5ac75838832582970839cbcfe517