### PR TITLE
feat: surface blueprint-driven device effects

### DIFF
--- a/data/blueprints/device/airflow/exhaust/exhaust-fan-4-inch.json
+++ b/data/blueprints/device/airflow/exhaust/exhaust-fan-4-inch.json
@@ -11,6 +11,9 @@
   "efficiency01": 0.7,
   "coverage_m2": 5,
   "airflow_m3_per_h": 170,
+  "effects": [
+    "airflow"
+  ],
   "quality": 0.7,
   "complexity": 0.1,
   "lifetime_h": 17520,

--- a/data/blueprints/device/climate/cooling/cool-air-split-3000.json
+++ b/data/blueprints/device/climate/cooling/cool-air-split-3000.json
@@ -11,6 +11,19 @@
   "efficiency01": 0.65,
   "coverage_m2": 25,
   "airflow_m3_per_h": 350,
+  "effects": [
+    "thermal",
+    "humidity",
+    "airflow"
+  ],
+  "thermal": {
+    "mode": "cool",
+    "max_cool_W": 3000
+  },
+  "humidity": {
+    "mode": "dehumidify",
+    "capacity_g_per_h": 500
+  },
   "quality": 0.9,
   "complexity": 0.4,
   "lifetime_h": 35040,

--- a/data/blueprints/device/climate/dehumidifier/drybox-200.json
+++ b/data/blueprints/device/climate/dehumidifier/drybox-200.json
@@ -10,6 +10,17 @@
   "power_W": 300,
   "efficiency01": 0.6,
   "coverage_m2": 6.67,
+  "effects": [
+    "humidity",
+    "thermal"
+  ],
+  "humidity": {
+    "mode": "dehumidify",
+    "capacity_g_per_h": 1800
+  },
+  "thermal": {
+    "mode": "heat"
+  },
   "quality": 0.8,
   "complexity": 0.25,
   "lifetime_h": 26280,

--- a/data/blueprints/device/climate/humidity-controller/humidity-control-unit-l1.json
+++ b/data/blueprints/device/climate/humidity-controller/humidity-control-unit-l1.json
@@ -10,6 +10,13 @@
   "power_W": 350,
   "efficiency01": 0.6,
   "coverage_m2": 8.33,
+  "effects": [
+    "humidity"
+  ],
+  "humidity": {
+    "mode": "dehumidify",
+    "capacity_g_per_h": 1000
+  },
   "quality": 0.8,
   "complexity": 0.3,
   "lifetime_h": 8760,
@@ -44,6 +51,7 @@
     "disadvantages": [
       "Limited capacity for large rooms",
       "Requires regular maintenance"
-    ]
+    ],
+    "notes": "Phase 1: Dehumidify-only. Phase 2: Dynamic mode switching based on setpoint."
   }
 }

--- a/data/blueprints/device/lighting/vegetative/led-veg-light-600.json
+++ b/data/blueprints/device/lighting/vegetative/led-veg-light-600.json
@@ -10,6 +10,17 @@
   "power_W": 600,
   "efficiency01": 0.7,
   "coverage_m2": 1.2,
+  "effects": [
+    "lighting",
+    "thermal"
+  ],
+  "lighting": {
+    "ppfd_center_umol_m2s": 800,
+    "photonEfficacy_umol_per_J": 2.5
+  },
+  "thermal": {
+    "mode": "heat"
+  },
   "quality": 0.95,
   "complexity": 0.2,
   "lifetime_h": 52560,

--- a/docs/ADR/ADR-0011-device-effects-stacking.md
+++ b/docs/ADR/ADR-0011-device-effects-stacking.md
@@ -1,0 +1,66 @@
+# ADR-0011: Device Effects Stacking and Multi-Interface Composition
+
+- **Status:** Accepted
+- **Date:** 2024-05-05
+- **Authors:** Simulation Engine Team
+
+## Context
+
+Devices in the cultivation simulator frequently exhibit multiple simultaneous effects—for example, split air-conditioners that cool and dehumidify, or lighting fixtures that emit photons while adding sensible heat. Prior to this decision, the engine relied on implicit heuristics:
+
+- Cooling capability inferred from `sensibleHeatRemovalCapacity_W`.
+- Humidity control detected via slug/name matching (e.g., "dehumid").
+- Lighting PPFD derived from electrical power and a hard-coded photon efficacy.
+
+The runtime pipeline consumes `DeviceInstance` objects exclusively; no runtime registry exposes blueprint metadata once the world is initialised. Consequently, effect-specific configuration declared on blueprints was inaccessible when evaluating device stubs, forcing the aforementioned heuristics and making multi-effect modelling brittle. The consolidated references for Engine v1 Phase 1 identified the need for explicit effect declaration (Patterns A–E) while ADR-0009 already established a taxonomy for blueprint validation. To achieve deterministic, testable effect stacking we must surface blueprint intent directly on the `DeviceInstance` model.
+
+## Decision
+
+1. **Blueprint layer**
+   - Extend `deviceBlueprintSchema` with an optional `effects: string[]` enumerating supported effect interfaces (`thermal`, `humidity`, `lighting`, `airflow`, `filtration`).
+   - Introduce optional effect configuration objects: `thermal`, `humidity`, and `lighting`, each capturing mode and capacity parameters required by the corresponding actuator stubs.
+   - Validate that whenever an effect is declared in `effects`, the matching config block is present.
+
+2. **Instance layer**
+   - Extend `DeviceInstance` with optional `effects` and `effectConfigs` fields mirroring the blueprint declarations.
+   - Update `createDeviceInstance` to copy and deep-freeze these structures at creation time, ensuring deterministic runtime access without mutating blueprint JSON.
+
+3. **Pipeline integration**
+   - Modify `applyDeviceEffects` to consume `device.effects` and `device.effectConfigs` before falling back to legacy heuristics. This unlocks explicit thermal/heating modes, humidity capacities, and lighting PPFD sourced from blueprints while maintaining backward compatibility.
+
+4. **Data migration & tests**
+   - Migrate representative device blueprints (cooling split AC, dehumidifier, lighting fixture, exhaust fan, humidity controller) to declare explicit effects/configs.
+   - Update unit and integration tests to assert effect-config copying, pipeline behaviour for multi-effect devices, and heuristic fallbacks for legacy content.
+
+## Consequences
+
+### Positive
+- Enables explicit modelling of multi-effect devices (Patterns A–E) without relying on brittle slug heuristics.
+- Improves determinism and observability: effect parameters originate from validated blueprint data, simplifying testing and diagnostics.
+- Provides a foundation for future effects (e.g., filtration, nutrient dosing) by extending the `effects` enumeration and schema.
+
+### Negative
+- Introduces limited data duplication: effect configuration now lives in both blueprint JSON and the instantiated device snapshot.
+- Requires ongoing blueprint migrations to populate `effects` arrays and configs, increasing authoring effort during transition.
+- Slightly increases `createDeviceInstance` complexity due to deep-freezing and copying logic.
+
+### Neutral
+- Legacy blueprints without `effects` continue to operate via existing heuristics, ensuring incremental adoption.
+- Runtime pipeline retains per-device stub evaluation; broader stub composition optimisations remain out of scope.
+
+## Alternatives Considered
+
+1. **Runtime blueprint registry**
+   - Rejected due to added lookup complexity, memory overhead, and the need for synchronised caches across simulation workers.
+
+2. **Deriving effects from taxonomy classes**
+   - Rejected because class hierarchies cannot express composite devices (e.g., cooling + dehumidification) without exploding the taxonomy.
+
+3. **Immediate stub composition via `compose()` helper**
+   - Deferred; while feasible, it does not remove the need for explicit configuration metadata and would increase pipeline complexity prematurely.
+
+## References
+
+- Consolidated reference: *Interfaces & Stubs — Consolidated (Engine v1, Phase 1)*.
+- ADR-0009: Blueprint class taxonomy and validation.
+- SEC §6: Device behaviour, efficiency, and energy accounting.

--- a/packages/engine/src/backend/src/device/createDeviceInstance.ts
+++ b/packages/engine/src/backend/src/device/createDeviceInstance.ts
@@ -1,4 +1,12 @@
-import type { Uuid } from '../domain/entities.js';
+import {
+  type DeviceEffectConfigs,
+  type DeviceEffectType,
+  type Uuid
+} from '../domain/entities.js';
+import {
+  toDeviceInstanceEffectConfigs,
+  type DeviceBlueprint
+} from '../domain/blueprints/deviceBlueprint.js';
 import { createRng, type RandomNumberGenerator } from '../util/rng.js';
 
 export interface DeviceQualityPolicy {
@@ -7,22 +15,36 @@ export interface DeviceQualityPolicy {
 
 export interface DeviceInstanceSeededAttributes {
   readonly quality01: number;
+  readonly effects?: readonly DeviceEffectType[];
+  readonly effectConfigs?: DeviceEffectConfigs;
 }
 
 export function createDeviceInstance(
   qualityPolicy: DeviceQualityPolicy,
   seed: string,
-  id: Uuid
+  id: Uuid,
+  blueprint: DeviceBlueprint
 ): DeviceInstanceSeededAttributes {
   if (!qualityPolicy) {
     throw new Error('qualityPolicy must be provided');
   }
 
+  if (!blueprint) {
+    throw new Error('blueprint must be provided');
+  }
+
   const rng = createRng(seed, `device:${id}`);
   const sampledQuality = qualityPolicy.sampleQuality01(rng);
   const quality01 = clamp01(sampledQuality);
+  const { effects, effectConfigs } = toDeviceInstanceEffectConfigs(blueprint);
+  const frozenEffects = freezeEffects(effects);
+  const frozenConfigs = freezeEffectConfigs(effectConfigs);
 
-  return Object.freeze({ quality01 }) as DeviceInstanceSeededAttributes;
+  return Object.freeze({
+    quality01,
+    effects: frozenEffects,
+    effectConfigs: frozenConfigs
+  }) as DeviceInstanceSeededAttributes;
 }
 
 function clamp01(value: number): number {
@@ -39,4 +61,36 @@ function clamp01(value: number): number {
   }
 
   return value;
+}
+
+function freezeEffects(effects?: readonly DeviceEffectType[]): readonly DeviceEffectType[] | undefined {
+  if (!effects || effects.length === 0) {
+    return undefined;
+  }
+
+  return Object.freeze([...effects]) as readonly DeviceEffectType[];
+}
+
+function freezeEffectConfigs(
+  configs?: DeviceEffectConfigs
+): DeviceEffectConfigs | undefined {
+  if (!configs) {
+    return undefined;
+  }
+
+  const next: DeviceEffectConfigs = {};
+
+  if (configs.thermal) {
+    next.thermal = Object.freeze({ ...configs.thermal });
+  }
+
+  if (configs.humidity) {
+    next.humidity = Object.freeze({ ...configs.humidity });
+  }
+
+  if (configs.lighting) {
+    next.lighting = Object.freeze({ ...configs.lighting });
+  }
+
+  return Object.freeze(next);
 }

--- a/packages/engine/src/backend/src/domain/entities.ts
+++ b/packages/engine/src/backend/src/domain/entities.ts
@@ -105,6 +105,31 @@ export interface CompanyLocation {
   readonly countryName: string;
 }
 
+export type DeviceEffectType = 'thermal' | 'humidity' | 'lighting' | 'airflow' | 'filtration';
+
+export interface ThermalEffectConfig {
+  readonly mode: 'heat' | 'cool' | 'auto';
+  readonly max_heat_W?: number;
+  readonly max_cool_W?: number;
+  readonly setpoint_C?: number;
+}
+
+export interface HumidityEffectConfig {
+  readonly mode: 'humidify' | 'dehumidify';
+  readonly capacity_g_per_h: number;
+}
+
+export interface LightingEffectConfig {
+  readonly ppfd_center_umol_m2s: number;
+  readonly photonEfficacy_umol_per_J?: number;
+}
+
+export interface DeviceEffectConfigs {
+  readonly thermal?: ThermalEffectConfig;
+  readonly humidity?: HumidityEffectConfig;
+  readonly lighting?: LightingEffectConfig;
+}
+
 /**
  * Canonical device instance model shared across placement scopes.
  */
@@ -129,6 +154,10 @@ export interface DeviceInstance extends DomainEntity, SluggedEntity {
   readonly airflow_m3_per_h: number;
   /** Maximum sensible heat removal capacity expressed in watts. */
   readonly sensibleHeatRemovalCapacity_W: number;
+  /** Explicit enumeration of effects copied from the originating blueprint, when available. */
+  readonly effects?: readonly DeviceEffectType[];
+  /** Effect-specific configuration payloads copied from the originating blueprint, when available. */
+  readonly effectConfigs?: DeviceEffectConfigs;
 }
 
 /**

--- a/packages/engine/tests/unit/device/createDeviceInstance.test.ts
+++ b/packages/engine/tests/unit/device/createDeviceInstance.test.ts
@@ -5,6 +5,7 @@ import {
   type DeviceQualityPolicy,
   type Uuid
 } from '@/backend/src/domain/world.js';
+import type { DeviceBlueprint } from '@/backend/src/domain/blueprints/deviceBlueprint.js';
 
 const QUALITY_POLICY: DeviceQualityPolicy = {
   sampleQuality01: (rng) => rng()
@@ -16,12 +17,152 @@ function uuid(value: string): Uuid {
   return value as Uuid;
 }
 
+const BASE_BLUEPRINT: DeviceBlueprint = {
+  id: '60000000-0000-0000-0000-000000000000',
+  slug: 'unit-test-device',
+  class: 'device.test.mock',
+  name: 'Unit Test Device',
+  placementScope: 'zone',
+  allowedRoomPurposes: ['growroom'],
+  power_W: 500,
+  efficiency01: 0.75,
+  coverage_m2: 10,
+  airflow_m3_per_h: 0
+};
+
+function buildBlueprint(overrides: Partial<DeviceBlueprint>): DeviceBlueprint {
+  return {
+    ...BASE_BLUEPRINT,
+    ...overrides,
+    allowedRoomPurposes: overrides.allowedRoomPurposes ?? [...BASE_BLUEPRINT.allowedRoomPurposes]
+  };
+}
+
 describe('createDeviceInstance', () => {
+  it('copies effects array from blueprint to device instance', () => {
+    const blueprint = buildBlueprint({
+      id: '60000000-0000-0000-0000-000000000010',
+      slug: 'effect-test-device',
+      effects: ['thermal', 'humidity'],
+      thermal: { mode: 'heat' },
+      humidity: { mode: 'dehumidify', capacity_g_per_h: 400 }
+    });
+
+    const device = createDeviceInstance(
+      QUALITY_POLICY,
+      WORLD_SEED,
+      uuid('60000000-0000-0000-0000-000000000001'),
+      blueprint
+    );
+
+    expect(device.effects).toEqual(['thermal', 'humidity']);
+  });
+
+  it('copies thermal config from blueprint to device instance', () => {
+    const blueprint = buildBlueprint({
+      id: '60000000-0000-0000-0000-000000000011',
+      slug: 'thermal-test-device',
+      effects: ['thermal'],
+      thermal: { mode: 'cool', max_cool_W: 3_000, setpoint_C: 22 }
+    });
+
+    const device = createDeviceInstance(
+      QUALITY_POLICY,
+      WORLD_SEED,
+      uuid('60000000-0000-0000-0000-000000000002'),
+      blueprint
+    );
+
+    expect(device.effectConfigs?.thermal).toEqual({
+      mode: 'cool',
+      max_cool_W: 3_000,
+      setpoint_C: 22
+    });
+  });
+
+  it('copies humidity config from blueprint to device instance', () => {
+    const blueprint = buildBlueprint({
+      id: '60000000-0000-0000-0000-000000000012',
+      slug: 'humidity-test-device',
+      effects: ['humidity'],
+      humidity: { mode: 'dehumidify', capacity_g_per_h: 750 }
+    });
+
+    const device = createDeviceInstance(
+      QUALITY_POLICY,
+      WORLD_SEED,
+      uuid('60000000-0000-0000-0000-000000000003'),
+      blueprint
+    );
+
+    expect(device.effectConfigs?.humidity).toEqual({
+      mode: 'dehumidify',
+      capacity_g_per_h: 750
+    });
+  });
+
+  it('copies lighting config from blueprint to device instance', () => {
+    const blueprint = buildBlueprint({
+      id: '60000000-0000-0000-0000-000000000013',
+      slug: 'lighting-test-device',
+      effects: ['lighting'],
+      lighting: { ppfd_center_umol_m2s: 800, photonEfficacy_umol_per_J: 2.4 }
+    });
+
+    const device = createDeviceInstance(
+      QUALITY_POLICY,
+      WORLD_SEED,
+      uuid('60000000-0000-0000-0000-000000000004'),
+      blueprint
+    );
+
+    expect(device.effectConfigs?.lighting).toEqual({
+      ppfd_center_umol_m2s: 800,
+      photonEfficacy_umol_per_J: 2.4
+    });
+  });
+
+  it('handles blueprint without effects (backward compatibility)', () => {
+    const device = createDeviceInstance(
+      QUALITY_POLICY,
+      WORLD_SEED,
+      uuid('60000000-0000-0000-0000-000000000005'),
+      BASE_BLUEPRINT
+    );
+
+    expect(device.effects).toBeUndefined();
+    expect(device.effectConfigs).toBeUndefined();
+  });
+
+  it('deep freezes effect configs to prevent mutation', () => {
+    const blueprint = buildBlueprint({
+      id: '60000000-0000-0000-0000-000000000014',
+      slug: 'freeze-test-device',
+      effects: ['thermal'],
+      thermal: { mode: 'heat' }
+    });
+
+    const device = createDeviceInstance(
+      QUALITY_POLICY,
+      WORLD_SEED,
+      uuid('60000000-0000-0000-0000-000000000006'),
+      blueprint
+    );
+
+    expect(Object.isFrozen(device)).toBe(true);
+    expect(Object.isFrozen(device.effectConfigs)).toBe(true);
+    expect(Object.isFrozen(device.effectConfigs?.thermal)).toBe(true);
+    expect(Object.isFrozen(device.effects)).toBe(true);
+    expect(() => {
+      (device.effectConfigs!.thermal as { mode: string }).mode = 'cool';
+    }).toThrow(TypeError);
+  });
+
   it('returns identical quality for repeated {seed, id} pairs', () => {
     const deviceId = uuid('50000000-0000-0000-0000-000000000001');
 
-    const first = createDeviceInstance(QUALITY_POLICY, WORLD_SEED, deviceId);
-    const second = createDeviceInstance(QUALITY_POLICY, WORLD_SEED, deviceId);
+    const first = createDeviceInstance(QUALITY_POLICY, WORLD_SEED, deviceId, BASE_BLUEPRINT);
+    const second = createDeviceInstance(QUALITY_POLICY, WORLD_SEED, deviceId, BASE_BLUEPRINT);
 
     expect(first.quality01).toBe(second.quality01);
     expect(Object.isFrozen(first)).toBe(true);
@@ -37,11 +178,21 @@ describe('createDeviceInstance', () => {
     };
 
     expect(
-      createDeviceInstance(highPolicy, WORLD_SEED, uuid('50000000-0000-0000-0000-000000000002')).quality01
+      createDeviceInstance(
+        highPolicy,
+        WORLD_SEED,
+        uuid('50000000-0000-0000-0000-000000000002'),
+        BASE_BLUEPRINT
+      ).quality01
     ).toBe(1);
 
     expect(
-      createDeviceInstance(lowPolicy, WORLD_SEED, uuid('50000000-0000-0000-0000-000000000003')).quality01
+      createDeviceInstance(
+        lowPolicy,
+        WORLD_SEED,
+        uuid('50000000-0000-0000-0000-000000000003'),
+        BASE_BLUEPRINT
+      ).quality01
     ).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- extend the device blueprint contract with explicit effect metadata/config projections for runtime use
- copy effect declarations into device instances and update the pipeline to consume them while preserving heuristic fallbacks
- migrate representative blueprints, document ADR-0011, and expand integration/unit coverage around multi-effect devices

## Testing
- pnpm --filter engine test *(fails: `vitest` binary missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df5effded88325a0386227daab0e48