### PR TITLE
feat(engine): integrate sensor readings pipeline

### DIFF
--- a/packages/engine/src/backend/src/device/createDeviceInstance.ts
+++ b/packages/engine/src/backend/src/device/createDeviceInstance.ts
@@ -92,5 +92,9 @@ function freezeEffectConfigs(
     next.lighting = Object.freeze({ ...configs.lighting });
   }
 
+  if (configs.sensor) {
+    next.sensor = Object.freeze({ ...configs.sensor });
+  }
+
   return Object.freeze(next);
 }

--- a/packages/engine/src/backend/src/domain/entities.ts
+++ b/packages/engine/src/backend/src/domain/entities.ts
@@ -105,7 +105,7 @@ export interface CompanyLocation {
   readonly countryName: string;
 }
 
-export type DeviceEffectType = 'thermal' | 'humidity' | 'lighting' | 'airflow' | 'filtration';
+export type DeviceEffectType = 'thermal' | 'humidity' | 'lighting' | 'airflow' | 'filtration' | 'sensor';
 
 export interface ThermalEffectConfig {
   readonly mode: 'heat' | 'cool' | 'auto';
@@ -124,10 +124,18 @@ export interface LightingEffectConfig {
   readonly photonEfficacy_umol_per_J?: number;
 }
 
+export type SensorMeasurementType = 'temperature' | 'humidity' | 'ppfd';
+
+export interface SensorEffectConfig {
+  readonly measurementType: SensorMeasurementType;
+  readonly noise01: number;
+}
+
 export interface DeviceEffectConfigs {
   readonly thermal?: ThermalEffectConfig;
   readonly humidity?: HumidityEffectConfig;
   readonly lighting?: LightingEffectConfig;
+  readonly sensor?: SensorEffectConfig;
 }
 
 /**

--- a/packages/engine/src/backend/src/engine/Engine.ts
+++ b/packages/engine/src/backend/src/engine/Engine.ts
@@ -2,6 +2,7 @@ import type { SimulationWorld, Uuid } from '../domain/world.js';
 import type { IrrigationEvent } from '../domain/interfaces/IIrrigationService.js';
 import { applyDeviceEffects } from './pipeline/applyDeviceEffects.js';
 import { updateEnvironment } from './pipeline/updateEnvironment.js';
+import { applySensors, clearSensorReadingsRuntime } from './pipeline/applySensors.js';
 import { applyIrrigationAndNutrients } from './pipeline/applyIrrigationAndNutrients.js';
 import { advancePhysiology } from './pipeline/advancePhysiology.js';
 import { applyHarvestAndInventory } from './pipeline/applyHarvestAndInventory.js';
@@ -49,6 +50,7 @@ export type PipelineStage = (
 const PIPELINE_DEFINITION: ReadonlyArray<readonly [StepName, PipelineStage]> = [
   ['applyDeviceEffects', applyDeviceEffects],
   ['updateEnvironment', updateEnvironment],
+  ['applySensors', applySensors],
   ['applyIrrigationAndNutrients', applyIrrigationAndNutrients],
   ['advancePhysiology', advancePhysiology],
   ['applyHarvestAndInventory', applyHarvestAndInventory],
@@ -74,6 +76,10 @@ export function runTick(
     }
 
     ctx.instrumentation?.onStageComplete?.(stepName, nextWorld);
+
+    if (stepName === 'applySensors') {
+      clearSensorReadingsRuntime(ctx);
+    }
   }
 
   const trace = collector?.finalize();

--- a/packages/engine/src/backend/src/engine/pipeline/applySensors.ts
+++ b/packages/engine/src/backend/src/engine/pipeline/applySensors.ts
@@ -1,0 +1,143 @@
+import type { SensorOutputs } from '../../domain/interfaces/ISensor.js';
+import type { SensorMeasurementType, ZoneDeviceInstance } from '../../domain/entities.js';
+import type { SimulationWorld, Zone } from '../../domain/world.js';
+import { createSensorStub } from '../../stubs/index.js';
+import type { EngineDiagnostic, EngineRunContext } from '../Engine.js';
+import { createRng } from '../../util/rng.js';
+
+export interface SensorReadingsRuntime {
+  readonly deviceSensorReadings: Map<ZoneDeviceInstance['id'], SensorOutputs<number>[]>;
+}
+
+const SENSOR_READINGS_CONTEXT_KEY = '__wb_sensorReadings' as const;
+
+type Mutable<T> = { -readonly [K in keyof T]: T[K] };
+
+type SensorRuntimeCarrier = Mutable<EngineRunContext> & {
+  [SENSOR_READINGS_CONTEXT_KEY]?: SensorReadingsRuntime;
+};
+
+function setSensorRuntime(ctx: EngineRunContext, runtime: SensorReadingsRuntime): SensorReadingsRuntime {
+  (ctx as SensorRuntimeCarrier)[SENSOR_READINGS_CONTEXT_KEY] = runtime;
+  return runtime;
+}
+
+export function ensureSensorReadingsRuntime(ctx: EngineRunContext): SensorReadingsRuntime {
+  return setSensorRuntime(ctx, {
+    deviceSensorReadings: new Map()
+  });
+}
+
+export function getSensorReadingsRuntime(ctx: EngineRunContext): SensorReadingsRuntime | undefined {
+  return (ctx as SensorRuntimeCarrier)[SENSOR_READINGS_CONTEXT_KEY];
+}
+
+export function clearSensorReadingsRuntime(ctx: EngineRunContext): void {
+  delete (ctx as SensorRuntimeCarrier)[SENSOR_READINGS_CONTEXT_KEY];
+}
+
+function emitDiagnostic(ctx: EngineRunContext, diagnostic: EngineDiagnostic): void {
+  ctx.diagnostics?.emit(diagnostic);
+}
+
+function resolveMeasurement(measurementType: SensorMeasurementType, zone: Zone): number | null {
+  switch (measurementType) {
+    case 'temperature':
+      return Number.isFinite(zone.environment.airTemperatureC)
+        ? zone.environment.airTemperatureC
+        : 0;
+    case 'humidity':
+      return Number.isFinite(zone.environment.relativeHumidity_pct)
+        ? zone.environment.relativeHumidity_pct
+        : 0;
+    case 'ppfd':
+      return Number.isFinite(zone.ppfd_umol_m2s) ? zone.ppfd_umol_m2s : 0;
+    default:
+      return null;
+  }
+}
+
+function isSensorDevice(device: ZoneDeviceInstance): boolean {
+  return Array.isArray(device.effects) && device.effects.includes('sensor');
+}
+
+function recordSensorReading(
+  runtime: SensorReadingsRuntime,
+  deviceId: ZoneDeviceInstance['id'],
+  reading: SensorOutputs<number>
+): void {
+  const existing = runtime.deviceSensorReadings.get(deviceId);
+
+  if (existing) {
+    existing.push(reading);
+    return;
+  }
+
+  runtime.deviceSensorReadings.set(deviceId, [reading]);
+}
+
+export function applySensors(world: SimulationWorld, ctx: EngineRunContext): SimulationWorld {
+  const runtime = ensureSensorReadingsRuntime(ctx);
+
+  for (const structure of world.company.structures) {
+    for (const room of structure.rooms) {
+      for (const zone of room.zones) {
+        for (const device of zone.devices) {
+          if (!isSensorDevice(device)) {
+            continue;
+          }
+
+          const sensorConfig = device.effectConfigs?.sensor;
+
+          if (!sensorConfig) {
+            emitDiagnostic(ctx, {
+              scope: 'zone',
+              code: 'sensor.config.missing',
+              zoneId: zone.id,
+              message: `Sensor device "${device.name}" is missing sensor configuration payload.`,
+              metadata: {
+                deviceId: device.id,
+                deviceSlug: device.slug
+              }
+            });
+            continue;
+          }
+
+          const { measurementType, noise01 } = sensorConfig;
+          const trueValue = resolveMeasurement(measurementType, zone);
+
+          if (trueValue === null) {
+            emitDiagnostic(ctx, {
+              scope: 'zone',
+              code: 'sensor.config.invalid',
+              zoneId: zone.id,
+              message: `Sensor device "${device.name}" has unsupported measurement type "${measurementType}".`,
+              metadata: {
+                deviceId: device.id,
+                deviceSlug: device.slug,
+                measurementType
+              }
+            });
+            continue;
+          }
+
+          const stub = createSensorStub(measurementType);
+          const rng = createRng(world.seed, `sensor:${device.id}`);
+          const reading = stub.computeEffect(
+            {
+              trueValue,
+              noise01,
+              condition01: device.condition01
+            },
+            rng
+          );
+
+          recordSensorReading(runtime, device.id, reading);
+        }
+      }
+    }
+  }
+
+  return world;
+}
+

--- a/packages/engine/src/backend/src/engine/trace.ts
+++ b/packages/engine/src/backend/src/engine/trace.ts
@@ -3,6 +3,7 @@ import { withPerfStage } from '../util/perf.js';
 export type StepName =
   | 'applyDeviceEffects'
   | 'updateEnvironment'
+  | 'applySensors'
   | 'applyIrrigationAndNutrients'
   | 'advancePhysiology'
   | 'applyHarvestAndInventory'

--- a/packages/engine/src/backend/src/stubs/SensorStub.ts
+++ b/packages/engine/src/backend/src/stubs/SensorStub.ts
@@ -1,0 +1,89 @@
+import type { ISensor, SensorInputs, SensorOutputs } from '../domain/interfaces/ISensor.js';
+import type { SensorMeasurementType } from '../domain/entities.js';
+import type { RandomNumberGenerator } from '../util/rng.js';
+
+function clamp(value: number, min: number, max: number): number {
+  if (value < min) {
+    return min;
+  }
+
+  if (value > max) {
+    return max;
+  }
+
+  return value;
+}
+
+function boxMullerTransform(rng: RandomNumberGenerator): number {
+  let u1 = 0;
+  let u2 = 0;
+
+  // Guard against zero values which would break the logarithm.
+  while (u1 === 0) {
+    u1 = rng();
+  }
+
+  while (u2 === 0) {
+    u2 = rng();
+  }
+
+  const radius = Math.sqrt(-2.0 * Math.log(u1));
+  const theta = 2.0 * Math.PI * u2;
+  return radius * Math.cos(theta);
+}
+
+function clampMeasuredValue(measurementType: SensorMeasurementType, value: number): number {
+  switch (measurementType) {
+    case 'temperature':
+      return clamp(value, -50, 150);
+    case 'humidity':
+      return clamp(value, 0, 100);
+    case 'ppfd':
+    default:
+      return Math.max(0, value);
+  }
+}
+
+function ensureRng(rng: RandomNumberGenerator | null | undefined): asserts rng is RandomNumberGenerator {
+  if (typeof rng !== 'function') {
+    throw new Error('SensorStub requires a deterministic RNG instance');
+  }
+}
+
+function ensureNumeric(value: unknown, fallback: number): number {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return fallback;
+  }
+
+  return value;
+}
+
+export function createSensorStub(measurementType: SensorMeasurementType): ISensor<number> {
+  return {
+    computeEffect(inputs: SensorInputs<number>, rng: RandomNumberGenerator | null | undefined): SensorOutputs<number> {
+      ensureRng(rng);
+
+      const trueValue = ensureNumeric(inputs.trueValue, 0);
+      const noise01 = clamp(ensureNumeric(inputs.noise01, 0), 0, 1);
+      const condition01 = clamp(ensureNumeric(inputs.condition01, 1), 0, 1);
+
+      if (noise01 === 0 || condition01 === 1) {
+        return {
+          measuredValue: clampMeasuredValue(measurementType, trueValue),
+          error: 0
+        } satisfies SensorOutputs<number>;
+      }
+
+      const gaussian = boxMullerTransform(rng);
+      const deviation = noise01 * (1 - condition01);
+      const measuredValue = clampMeasuredValue(measurementType, trueValue + gaussian * deviation);
+
+      return {
+        measuredValue,
+        error: Math.abs(measuredValue - trueValue)
+      } satisfies SensorOutputs<number>;
+    }
+  } satisfies ISensor<number>;
+}
+
+export default createSensorStub;

--- a/packages/engine/src/backend/src/stubs/index.ts
+++ b/packages/engine/src/backend/src/stubs/index.ts
@@ -11,7 +11,9 @@ export * from './HumidityActuatorStub.js';
 export * from './LightEmitterStub.js';
 export * from './NutrientBufferStub.js';
 export * from './IrrigationServiceStub.js';
+export * from './SensorStub.js';
 
 export { createThermalActuatorStub } from './ThermalActuatorStub.js';
 export { createHumidityActuatorStub } from './HumidityActuatorStub.js';
 export { createLightEmitterStub } from './LightEmitterStub.js';
+export { createSensorStub } from './SensorStub.js';

--- a/packages/engine/tests/integration/pipeline/sensorReadings.integration.test.ts
+++ b/packages/engine/tests/integration/pipeline/sensorReadings.integration.test.ts
@@ -1,0 +1,435 @@
+import { describe, expect, it } from 'vitest';
+
+import { runTick, type EngineRunContext } from '@/backend/src/engine/Engine.js';
+import { getSensorReadingsRuntime } from '@/backend/src/engine/pipeline/applySensors.js';
+import { createDemoWorld } from '@/backend/src/engine/testHarness.js';
+import type { SensorOutputs } from '@/backend/src/domain/interfaces/ISensor.js';
+import type { DeviceBlueprint } from '@/backend/src/domain/blueprints/deviceBlueprint.js';
+import {
+  createDeviceInstance,
+  type DeviceQualityPolicy,
+  type Uuid,
+  type ZoneDeviceInstance
+} from '@/backend/src/domain/world.js';
+
+function uuid(value: string): Uuid {
+  return value as Uuid;
+}
+
+const QUALITY_POLICY: DeviceQualityPolicy = {
+  sampleQuality01: (rng) => rng()
+};
+
+const SENSOR_BLUEPRINT: DeviceBlueprint = {
+  id: '40000000-0000-0000-0000-000000000000',
+  slug: 'temperature-sensor',
+  class: 'device.test.sensor',
+  name: 'Temperature Sensor',
+  placementScope: 'zone',
+  allowedRoomPurposes: ['growroom'],
+  power_W: 0,
+  efficiency01: 1,
+  coverage_m2: 0,
+  airflow_m3_per_h: 0,
+  effects: ['sensor'],
+  sensor: {
+    measurementType: 'temperature',
+    noise01: 0
+  }
+};
+
+const HEATER_BLUEPRINT: DeviceBlueprint = {
+  id: '40000000-0000-0000-0000-000000000001',
+  slug: 'integration-heater',
+  class: 'device.test.heater',
+  name: 'Integration Heater',
+  placementScope: 'zone',
+  allowedRoomPurposes: ['growroom'],
+  power_W: 1_000,
+  efficiency01: 0.2,
+  coverage_m2: 20,
+  airflow_m3_per_h: 0,
+  effects: ['thermal'],
+  thermal: {
+    mode: 'heat'
+  }
+};
+
+function deviceQuality(id: Uuid, blueprint: DeviceBlueprint): number {
+  return createDeviceInstance(QUALITY_POLICY, 'sensor-seed', id, blueprint).quality01;
+}
+
+describe('Tick pipeline — sensor readings', () => {
+  it('registers applySensors in the pipeline trace after updateEnvironment', () => {
+    const world = createDemoWorld();
+    const ctx: EngineRunContext = {};
+
+    const { trace } = runTick(world, ctx, { trace: true });
+
+    expect(trace).toBeDefined();
+    const stepNames = trace?.steps.map((step) => step.name) ?? [];
+    const updateIndex = stepNames.indexOf('updateEnvironment');
+    const sensorIndex = stepNames.indexOf('applySensors');
+    const advanceIndex = stepNames.indexOf('advancePhysiology');
+
+    expect(updateIndex).toBeGreaterThanOrEqual(0);
+    expect(sensorIndex).toBeGreaterThan(updateIndex);
+    expect(sensorIndex).toBeLessThan(advanceIndex);
+    expect(getSensorReadingsRuntime(ctx)).toBeUndefined();
+  });
+
+  it('sensors capture the environment state after actuators run', () => {
+    const world = createDemoWorld();
+    const structure = world.company.structures[0];
+    const room = structure.rooms[0];
+    const zone = room.zones[0];
+
+    zone.environment = {
+      ...zone.environment,
+      airTemperatureC: 20
+    };
+
+    const heaterId = uuid('40000000-0000-0000-0000-000000000010');
+    const heater: ZoneDeviceInstance = {
+      id: heaterId,
+      slug: HEATER_BLUEPRINT.slug,
+      name: HEATER_BLUEPRINT.name,
+      blueprintId: HEATER_BLUEPRINT.id,
+      placementScope: 'zone',
+      quality01: deviceQuality(heaterId, HEATER_BLUEPRINT),
+      condition01: 1,
+      powerDraw_W: HEATER_BLUEPRINT.power_W,
+      dutyCycle01: 1,
+      efficiency01: HEATER_BLUEPRINT.efficiency01,
+      coverage_m2: HEATER_BLUEPRINT.coverage_m2 ?? 0,
+      airflow_m3_per_h: HEATER_BLUEPRINT.airflow_m3_per_h ?? 0,
+      sensibleHeatRemovalCapacity_W: 0,
+      effects: ['thermal'],
+      effectConfigs: { thermal: { mode: 'heat' } }
+    } satisfies ZoneDeviceInstance;
+
+    const sensorId = uuid('40000000-0000-0000-0000-000000000011');
+    const sensor: ZoneDeviceInstance = {
+      id: sensorId,
+      slug: SENSOR_BLUEPRINT.slug,
+      name: SENSOR_BLUEPRINT.name,
+      blueprintId: SENSOR_BLUEPRINT.id,
+      placementScope: 'zone',
+      quality01: deviceQuality(sensorId, SENSOR_BLUEPRINT),
+      condition01: 1,
+      powerDraw_W: 0,
+      dutyCycle01: 1,
+      efficiency01: 1,
+      coverage_m2: 0,
+      airflow_m3_per_h: 0,
+      sensibleHeatRemovalCapacity_W: 0,
+      effects: ['sensor'],
+      effectConfigs: {
+        sensor: {
+          measurementType: 'temperature',
+          noise01: 0
+        }
+      }
+    } satisfies ZoneDeviceInstance;
+
+    zone.devices = [heater, sensor];
+
+    const captured: SensorOutputs<number>[] = [];
+    const ctx: EngineRunContext = {
+      instrumentation: {
+        onStageComplete(stage) {
+          if (stage !== 'applySensors') {
+            return;
+          }
+
+          const runtime = getSensorReadingsRuntime(ctx);
+          const readings = runtime?.deviceSensorReadings.get(sensorId) ?? [];
+          captured.push(...readings);
+        }
+      }
+    };
+
+    const { world: nextWorld } = runTick(world, ctx);
+    const nextZone = nextWorld.company.structures[0].rooms[0].zones[0];
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.measuredValue).toBeCloseTo(nextZone.environment.airTemperatureC, 5);
+    expect(captured[0]?.error).toBe(0);
+  });
+
+  it('records readings from multiple sensors', () => {
+    const world = createDemoWorld();
+    const zone = world.company.structures[0].rooms[0].zones[0];
+
+    const temperatureSensorId = uuid('40000000-0000-0000-0000-000000000012');
+    const humiditySensorId = uuid('40000000-0000-0000-0000-000000000013');
+
+    const temperatureSensor: ZoneDeviceInstance = {
+      id: temperatureSensorId,
+      slug: 'temp-sensor',
+      name: 'Temp Sensor',
+      blueprintId: SENSOR_BLUEPRINT.id,
+      placementScope: 'zone',
+      quality01: deviceQuality(temperatureSensorId, SENSOR_BLUEPRINT),
+      condition01: 0.9,
+      powerDraw_W: 0,
+      dutyCycle01: 1,
+      efficiency01: 1,
+      coverage_m2: 0,
+      airflow_m3_per_h: 0,
+      sensibleHeatRemovalCapacity_W: 0,
+      effects: ['sensor'],
+      effectConfigs: {
+        sensor: { measurementType: 'temperature', noise01: 0.05 }
+      }
+    } satisfies ZoneDeviceInstance;
+
+    const humiditySensor: ZoneDeviceInstance = {
+      id: humiditySensorId,
+      slug: 'humidity-probe',
+      name: 'Humidity Probe',
+      blueprintId: SENSOR_BLUEPRINT.id,
+      placementScope: 'zone',
+      quality01: deviceQuality(humiditySensorId, SENSOR_BLUEPRINT),
+      condition01: 0.8,
+      powerDraw_W: 0,
+      dutyCycle01: 1,
+      efficiency01: 1,
+      coverage_m2: 0,
+      airflow_m3_per_h: 0,
+      sensibleHeatRemovalCapacity_W: 0,
+      effects: ['sensor'],
+      effectConfigs: {
+        sensor: { measurementType: 'humidity', noise01: 0.1 }
+      }
+    } satisfies ZoneDeviceInstance;
+
+    zone.devices = [temperatureSensor, humiditySensor];
+
+    const readingsByDevice = new Map<Uuid, SensorOutputs<number>[]>();
+    const ctx: EngineRunContext = {
+      instrumentation: {
+        onStageComplete(stage) {
+          if (stage !== 'applySensors') {
+            return;
+          }
+
+          const runtime = getSensorReadingsRuntime(ctx);
+
+          if (!runtime) {
+            return;
+          }
+
+          for (const [deviceId, readings] of runtime.deviceSensorReadings.entries()) {
+            readingsByDevice.set(deviceId, readings.slice());
+          }
+        }
+      }
+    };
+
+    runTick(world, ctx);
+
+    expect(readingsByDevice.size).toBe(2);
+    expect(readingsByDevice.get(temperatureSensorId)?.[0]?.measuredValue).toBeDefined();
+    expect(readingsByDevice.get(humiditySensorId)?.[0]?.measuredValue).toBeDefined();
+  });
+
+  it('produces error telemetry when noise is applied', () => {
+    const world = createDemoWorld();
+    const zone = world.company.structures[0].rooms[0].zones[0];
+
+    const sensorId = uuid('40000000-0000-0000-0000-000000000017');
+    zone.devices = [
+      {
+        id: sensorId,
+        slug: 'noisy-temp-sensor',
+        name: 'Noisy Temp Sensor',
+        blueprintId: SENSOR_BLUEPRINT.id,
+        placementScope: 'zone',
+        quality01: deviceQuality(sensorId, SENSOR_BLUEPRINT),
+        condition01: 0.5,
+        powerDraw_W: 0,
+        dutyCycle01: 1,
+        efficiency01: 1,
+        coverage_m2: 0,
+        airflow_m3_per_h: 0,
+        sensibleHeatRemovalCapacity_W: 0,
+        effects: ['sensor'],
+        effectConfigs: {
+          sensor: {
+            measurementType: 'temperature',
+            noise01: 0.4
+          }
+        }
+      } satisfies ZoneDeviceInstance
+    ];
+
+    const errors: number[] = [];
+    const ctx: EngineRunContext = {
+      instrumentation: {
+        onStageComplete(stage) {
+          if (stage !== 'applySensors') {
+            return;
+          }
+
+          const runtime = getSensorReadingsRuntime(ctx);
+          const readings = runtime?.deviceSensorReadings.get(sensorId) ?? [];
+
+          if (readings[0]) {
+            errors.push(readings[0].error);
+          }
+        }
+      }
+    };
+
+    runTick(world, ctx);
+
+    expect(errors[0]).toBeGreaterThan(0);
+  });
+
+  it('yields exact readings when noise is zero regardless of condition', () => {
+    const world = createDemoWorld();
+    const zone = world.company.structures[0].rooms[0].zones[0];
+
+    zone.devices = [
+      {
+        id: uuid('40000000-0000-0000-0000-000000000014'),
+        slug: 'ppfd-sensor',
+        name: 'PPFD Sensor',
+        blueprintId: SENSOR_BLUEPRINT.id,
+        placementScope: 'zone',
+        quality01: 1,
+        condition01: 0.2,
+        powerDraw_W: 0,
+        dutyCycle01: 1,
+        efficiency01: 1,
+        coverage_m2: 0,
+        airflow_m3_per_h: 0,
+        sensibleHeatRemovalCapacity_W: 0,
+        effects: ['sensor'],
+        effectConfigs: {
+          sensor: {
+            measurementType: 'ppfd',
+            noise01: 0
+          }
+        }
+      } satisfies ZoneDeviceInstance
+    ];
+
+    const ctx: EngineRunContext = {
+      instrumentation: {
+        onStageComplete(stage) {
+          if (stage !== 'applySensors') {
+            return;
+          }
+
+          const runtime = getSensorReadingsRuntime(ctx);
+          const readings = runtime?.deviceSensorReadings.values().next().value as
+            | SensorOutputs<number>[]
+            | undefined;
+
+          if (readings?.[0]) {
+            expect(readings[0].measuredValue).toBe(zone.ppfd_umol_m2s);
+            expect(readings[0].error).toBe(0);
+          }
+        }
+      }
+    };
+
+    runTick(world, ctx);
+  });
+
+  it('produces deterministic readings for the same seed', () => {
+    const firstWorld = createDemoWorld();
+    const secondWorld = createDemoWorld();
+
+    const sensorBlueprint: DeviceBlueprint = {
+      ...SENSOR_BLUEPRINT,
+      slug: 'deterministic-sensor'
+    };
+
+    const firstZone = firstWorld.company.structures[0].rooms[0].zones[0];
+    const secondZone = secondWorld.company.structures[0].rooms[0].zones[0];
+
+    const sensorId = uuid('40000000-0000-0000-0000-000000000015');
+    const sensorDevice: ZoneDeviceInstance = {
+      id: sensorId,
+      slug: sensorBlueprint.slug,
+      name: sensorBlueprint.name,
+      blueprintId: sensorBlueprint.id,
+      placementScope: 'zone',
+      quality01: deviceQuality(sensorId, sensorBlueprint),
+      condition01: 0.7,
+      powerDraw_W: 0,
+      dutyCycle01: 1,
+      efficiency01: 1,
+      coverage_m2: 0,
+      airflow_m3_per_h: 0,
+      sensibleHeatRemovalCapacity_W: 0,
+      effects: ['sensor'],
+      effectConfigs: {
+        sensor: {
+          measurementType: 'temperature',
+          noise01: 0.2
+        }
+      }
+    } satisfies ZoneDeviceInstance;
+
+    firstZone.devices = [sensorDevice];
+    secondZone.devices = [
+      {
+        ...sensorDevice,
+        id: uuid('40000000-0000-0000-0000-000000000016')
+      }
+    ];
+
+    const readingsA: SensorOutputs<number>[] = [];
+    const readingsB: SensorOutputs<number>[] = [];
+
+    const ctxA: EngineRunContext = {
+      instrumentation: {
+        onStageComplete(stage) {
+          if (stage !== 'applySensors') {
+            return;
+          }
+
+          const runtime = getSensorReadingsRuntime(ctxA);
+          const values = runtime?.deviceSensorReadings.values().next().value as
+            | SensorOutputs<number>[]
+            | undefined;
+
+          if (values?.[0]) {
+            readingsA.push(values[0]);
+          }
+        }
+      }
+    };
+
+    const ctxB: EngineRunContext = {
+      instrumentation: {
+        onStageComplete(stage) {
+          if (stage !== 'applySensors') {
+            return;
+          }
+
+          const runtime = getSensorReadingsRuntime(ctxB);
+          const values = runtime?.deviceSensorReadings.values().next().value as
+            | SensorOutputs<number>[]
+            | undefined;
+
+          if (values?.[0]) {
+            readingsB.push(values[0]);
+          }
+        }
+      }
+    };
+
+    runTick(firstWorld, ctxA);
+    runTick(secondWorld, ctxB);
+
+    expect(readingsA).toHaveLength(1);
+    expect(readingsB).toHaveLength(1);
+    expect(readingsA[0]?.measuredValue).toBe(readingsB[0]?.measuredValue);
+    expect(readingsA[0]?.error).toBe(readingsB[0]?.error);
+  });
+});

--- a/packages/engine/tests/unit/stubs/SensorStub.test.ts
+++ b/packages/engine/tests/unit/stubs/SensorStub.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+
+import { createSensorStub } from '@/backend/src/stubs/SensorStub.js';
+import { createRng } from '@/backend/src/util/rng.js';
+
+const TEMPERATURE_STUB = createSensorStub('temperature');
+const HUMIDITY_STUB = createSensorStub('humidity');
+const PPFD_STUB = createSensorStub('ppfd');
+
+describe('SensorStub', () => {
+  it('returns true value when noise01 is zero', () => {
+    const rng = createRng('test-seed', 'sensor:zero-noise');
+    const reading = TEMPERATURE_STUB.computeEffect(
+      {
+        trueValue: 22.5,
+        noise01: 0,
+        condition01: 0.9
+      },
+      rng
+    );
+
+    expect(reading.measuredValue).toBe(22.5);
+    expect(reading.error).toBe(0);
+  });
+
+  it('returns true value when condition01 is 1.0', () => {
+    const rng = createRng('test-seed', 'sensor:perfect-condition');
+    const reading = HUMIDITY_STUB.computeEffect(
+      {
+        trueValue: 60,
+        noise01: 0.5,
+        condition01: 1
+      },
+      rng
+    );
+
+    expect(reading.measuredValue).toBe(60);
+    expect(reading.error).toBe(0);
+  });
+
+  it('applies Gaussian noise for degraded sensor', () => {
+    const rng = createRng('test-seed', 'sensor:noisy');
+    const reading = TEMPERATURE_STUB.computeEffect(
+      {
+        trueValue: 25,
+        noise01: 0.2,
+        condition01: 0.5
+      },
+      rng
+    );
+
+    expect(reading.measuredValue).not.toBe(25);
+    expect(reading.error).toBeGreaterThan(0);
+    expect(reading.error).toBeLessThan(5);
+  });
+
+  it('produces deterministic results for same seed', () => {
+    const rngA = createRng('test-seed', 'sensor:deterministic');
+    const rngB = createRng('test-seed', 'sensor:deterministic');
+
+    const readingA = HUMIDITY_STUB.computeEffect(
+      {
+        trueValue: 45,
+        noise01: 0.3,
+        condition01: 0.4
+      },
+      rngA
+    );
+    const readingB = HUMIDITY_STUB.computeEffect(
+      {
+        trueValue: 45,
+        noise01: 0.3,
+        condition01: 0.4
+      },
+      rngB
+    );
+
+    expect(readingA.measuredValue).toBe(readingB.measuredValue);
+    expect(readingA.error).toBe(readingB.error);
+  });
+
+  it('produces different results for different seeds', () => {
+    const rngA = createRng('test-seed', 'sensor:seed-a');
+    const rngB = createRng('test-seed', 'sensor:seed-b');
+
+    const readingA = PPFD_STUB.computeEffect(
+      {
+        trueValue: 200,
+        noise01: 0.4,
+        condition01: 0.6
+      },
+      rngA
+    );
+    const readingB = PPFD_STUB.computeEffect(
+      {
+        trueValue: 200,
+        noise01: 0.4,
+        condition01: 0.6
+      },
+      rngB
+    );
+
+    expect(readingA.measuredValue).not.toBe(readingB.measuredValue);
+  });
+
+  it('clamps temperature readings to realistic bounds', () => {
+    const rng = createRng('test-seed', 'sensor:temp-clamp');
+    const reading = TEMPERATURE_STUB.computeEffect(
+      {
+        trueValue: 100,
+        noise01: 1,
+        condition01: 0.1
+      },
+      rng
+    );
+
+    expect(reading.measuredValue).toBeGreaterThanOrEqual(-50);
+    expect(reading.measuredValue).toBeLessThanOrEqual(150);
+  });
+
+  it('clamps humidity readings to [0, 100]', () => {
+    const rng = createRng('test-seed', 'sensor:humidity-clamp');
+    const reading = HUMIDITY_STUB.computeEffect(
+      {
+        trueValue: 95,
+        noise01: 1,
+        condition01: 0.1
+      },
+      rng
+    );
+
+    expect(reading.measuredValue).toBeGreaterThanOrEqual(0);
+    expect(reading.measuredValue).toBeLessThanOrEqual(100);
+  });
+
+  it('calculates absolute error correctly', () => {
+    const rng = createRng('test-seed', 'sensor:error');
+    const reading = TEMPERATURE_STUB.computeEffect(
+      {
+        trueValue: 50,
+        noise01: 0.1,
+        condition01: 0.8
+      },
+      rng
+    );
+
+    expect(reading.error).toBeCloseTo(Math.abs(reading.measuredValue - 50));
+  });
+
+  it('throws when RNG is not provided', () => {
+    expect(() =>
+      TEMPERATURE_STUB.computeEffect({ trueValue: 20, noise01: 0.2, condition01: 0.5 }, undefined as never)
+    ).toThrowError('SensorStub requires a deterministic RNG instance');
+  });
+});


### PR DESCRIPTION
## Summary
- extend device effect contracts and blueprint parsing to include sensor configurations
- add deterministic sensor stub plus applySensors pipeline stage with runtime context and trace wiring
- cover the new sensor flow with dedicated unit tests and pipeline integration scenarios

## Testing
- pnpm --filter @wb/engine test *(fails: vitest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df633f20f083258f09c3d0bbe335ba