### PR TITLE
Add airflow and filtration device effects

### DIFF
--- a/data/blueprints/device/filtration/carbon/carbon-filter-6-inch.json
+++ b/data/blueprints/device/filtration/carbon/carbon-filter-6-inch.json
@@ -1,0 +1,39 @@
+{
+  "id": "a846e7f6-60f0-4594-a6ae-68c99ba5e5c9",
+  "slug": "carbon-filter-6-inch",
+  "class": "device.filtration.carbon",
+  "name": "Carbon Filter 6-inch",
+  "placementScope": "zone",
+  "allowedRoomPurposes": ["growroom"],
+  "power_W": 0,
+  "efficiency01": 0.85,
+  "coverage_m2": 0,
+  "effects": ["filtration"],
+  "filtration": {
+    "filterType": "carbon",
+    "efficiency01": 0.85,
+    "basePressureDrop_pa": 120
+  },
+  "quality": 0.75,
+  "complexity": 0.2,
+  "lifetime_h": 8760,
+  "efficiencyDegeneration": 0.3,
+  "maintenance": {
+    "intervalDays": 90,
+    "hoursPerService": 0.5
+  },
+  "meta": {
+    "description": "Activated carbon filter for odor control, designed to be chained with exhaust fans. Removes volatile organic compounds and odors from grow room air.",
+    "advantages": [
+      "Effective odor removal",
+      "Low maintenance",
+      "Compatible with 6-inch ducting"
+    ],
+    "disadvantages": [
+      "Adds pressure drop to airflow system",
+      "Efficiency degrades over time",
+      "Requires periodic replacement"
+    ],
+    "notes": "Must be paired with an exhaust fan. Pressure drop increases as filter clogs; monitor ACH warnings."
+  }
+}

--- a/packages/engine/src/backend/src/device/createDeviceInstance.ts
+++ b/packages/engine/src/backend/src/device/createDeviceInstance.ts
@@ -92,6 +92,14 @@ function freezeEffectConfigs(
     next.lighting = Object.freeze({ ...configs.lighting });
   }
 
+  if (configs.airflow) {
+    next.airflow = Object.freeze({ ...configs.airflow });
+  }
+
+  if (configs.filtration) {
+    next.filtration = Object.freeze({ ...configs.filtration });
+  }
+
   if (configs.sensor) {
     next.sensor = Object.freeze({ ...configs.sensor });
   }

--- a/packages/engine/src/backend/src/domain/entities.ts
+++ b/packages/engine/src/backend/src/domain/entities.ts
@@ -131,10 +131,23 @@ export interface SensorEffectConfig {
   readonly noise01: number;
 }
 
+export interface AirflowEffectConfig {
+  readonly mode: 'recirculation' | 'exhaust' | 'intake';
+  readonly airflow_m3_per_h: number;
+}
+
+export interface FiltrationEffectConfig {
+  readonly filterType: 'carbon' | 'hepa' | 'pre-filter';
+  readonly efficiency01: number;
+  readonly basePressureDrop_pa: number;
+}
+
 export interface DeviceEffectConfigs {
   readonly thermal?: ThermalEffectConfig;
   readonly humidity?: HumidityEffectConfig;
   readonly lighting?: LightingEffectConfig;
+  readonly airflow?: AirflowEffectConfig;
+  readonly filtration?: FiltrationEffectConfig;
   readonly sensor?: SensorEffectConfig;
 }
 

--- a/packages/engine/src/backend/src/domain/interfaces/IFiltrationUnit.ts
+++ b/packages/engine/src/backend/src/domain/interfaces/IFiltrationUnit.ts
@@ -10,6 +10,8 @@ export interface FiltrationUnitInputs {
   readonly efficiency01: number;
   /** Filter condition on the canonical [0,1] scale representing clogging or ageing. */
   readonly condition01: number;
+  /** Baseline pressure drop characteristic for the clean filter media, expressed in pascal. */
+  readonly basePressureDrop_pa: number;
 }
 
 /**

--- a/packages/engine/src/backend/src/stubs/AirflowActuatorStub.ts
+++ b/packages/engine/src/backend/src/stubs/AirflowActuatorStub.ts
@@ -1,0 +1,83 @@
+import { HOURS_PER_TICK } from '../constants/simConstants.js';
+import type {
+  AirflowActuatorInputs,
+  AirflowActuatorOutputs,
+  IAirflowActuator
+} from '../domain/interfaces/IAirflowActuator.js';
+
+const ZERO_OUTPUT: AirflowActuatorOutputs = {
+  effective_airflow_m3_per_h: 0,
+  ach: 0,
+  pressure_loss_pa: 0,
+  energy_Wh: undefined
+};
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  if (value <= 0) {
+    return 0;
+  }
+
+  if (value >= 1) {
+    return 1;
+  }
+
+  return value;
+}
+
+function resolveAirflow(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+
+  return value;
+}
+
+function resolveVolume(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+
+  return value;
+}
+
+/**
+ * Factory producing a deterministic stub implementation of {@link IAirflowActuator}.
+ *
+ * Mirrors the consolidated SEC spec (Section 4, Pattern C) by modelling fans as
+ * pure producers whose output may be reduced by downstream filtration units.
+ * The stub intentionally omits intrinsic pressure losses, delegating those to
+ * {@link createFiltrationStub} to support chained Fan→Filter pipelines.
+ */
+export function createAirflowActuatorStub(): IAirflowActuator {
+  return {
+    computeEffect(
+      inputs: AirflowActuatorInputs,
+      zoneVolume_m3: number,
+      dt_h: number,
+    ): AirflowActuatorOutputs {
+      const dutyCycle01 = clamp01(inputs.dutyCycle01);
+      const airflow_m3_per_h = resolveAirflow(inputs.airflow_m3_per_h);
+      const resolvedVolume_m3 = resolveVolume(zoneVolume_m3);
+      const resolvedDt_h =
+        typeof dt_h === 'number' && Number.isFinite(dt_h) ? dt_h : HOURS_PER_TICK;
+
+      if (resolvedVolume_m3 <= 0 || resolvedDt_h <= 0 || airflow_m3_per_h === 0 || dutyCycle01 === 0) {
+        return ZERO_OUTPUT;
+      }
+
+      const effective_airflow_m3_per_h = airflow_m3_per_h * dutyCycle01;
+      const ach = effective_airflow_m3_per_h / resolvedVolume_m3;
+
+      return {
+        effective_airflow_m3_per_h,
+        ach,
+        pressure_loss_pa: 0,
+        energy_Wh: undefined
+      } satisfies AirflowActuatorOutputs;
+    },
+  } satisfies IAirflowActuator;
+}

--- a/packages/engine/src/backend/src/stubs/FiltrationStub.ts
+++ b/packages/engine/src/backend/src/stubs/FiltrationStub.ts
@@ -1,0 +1,97 @@
+import type {
+  FiltrationUnitInputs,
+  FiltrationUnitOutputs,
+  IFiltrationUnit
+} from '../domain/interfaces/IFiltrationUnit.js';
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  if (value <= 0) {
+    return 0;
+  }
+
+  if (value >= 1) {
+    return 1;
+  }
+
+  return value;
+}
+
+function resolveAirflow(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+
+  return value;
+}
+
+function resolveBasePressureDrop(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+
+  return value;
+}
+
+function resolveDtHours(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+
+  return value;
+}
+
+/**
+ * Factory producing a deterministic stub implementation of {@link IFiltrationUnit}.
+ *
+ * Implements the consolidated SEC spec (Section 4, Pattern C) where filters
+ * introduce pressure drops that reduce upstream airflow, emit odour telemetry
+ * and track particulate removal. Designed for chaining with
+ * {@link createAirflowActuatorStub}.
+ */
+export function createFiltrationStub(): IFiltrationUnit {
+  return {
+    computeEffect(inputs: FiltrationUnitInputs, dt_h: number): FiltrationUnitOutputs {
+      const airflow_m3_per_h = resolveAirflow(inputs.airflow_m3_per_h);
+      const efficiency01 = clamp01(inputs.efficiency01);
+      const condition01 = clamp01(inputs.condition01);
+      const basePressureDrop_pa = resolveBasePressureDrop(inputs.basePressureDrop_pa);
+      const resolvedDt_h = resolveDtHours(dt_h);
+
+      if (airflow_m3_per_h === 0 || resolvedDt_h === 0 || basePressureDrop_pa === 0) {
+        return {
+          odor_concentration_delta: 0,
+          particulate_removal_pct: 0,
+          pressure_drop_pa: 0,
+          airflow_reduction_m3_per_h: 0
+        } satisfies FiltrationUnitOutputs;
+      }
+
+      const conditionFactor = 1 + (1 - condition01) * 2;
+      const airflowRatio = Math.max(airflow_m3_per_h / 200, 0);
+      const pressure_drop_pa = basePressureDrop_pa * conditionFactor * Math.pow(airflowRatio, 1.5);
+      const unclampedReduction = pressure_drop_pa * 0.005 * airflow_m3_per_h;
+      const maxReduction = airflow_m3_per_h * 0.3;
+      const airflow_reduction_m3_per_h = Math.min(Math.max(unclampedReduction, 0), maxReduction);
+      const odor_concentration_delta = -efficiency01 * condition01 * (airflow_m3_per_h / 100) * resolvedDt_h;
+
+      let particulate_removal_pct = 0;
+
+      if (inputs.filterType === 'hepa') {
+        particulate_removal_pct = efficiency01 * 99;
+      } else if (inputs.filterType === 'pre-filter') {
+        particulate_removal_pct = efficiency01 * 60;
+      }
+
+      return {
+        odor_concentration_delta,
+        particulate_removal_pct,
+        pressure_drop_pa,
+        airflow_reduction_m3_per_h
+      } satisfies FiltrationUnitOutputs;
+    }
+  } satisfies IFiltrationUnit;
+}

--- a/packages/engine/src/backend/src/stubs/index.ts
+++ b/packages/engine/src/backend/src/stubs/index.ts
@@ -12,8 +12,12 @@ export * from './LightEmitterStub.js';
 export * from './NutrientBufferStub.js';
 export * from './IrrigationServiceStub.js';
 export * from './SensorStub.js';
+export * from './AirflowActuatorStub.js';
+export * from './FiltrationStub.js';
 
 export { createThermalActuatorStub } from './ThermalActuatorStub.js';
 export { createHumidityActuatorStub } from './HumidityActuatorStub.js';
 export { createLightEmitterStub } from './LightEmitterStub.js';
 export { createSensorStub } from './SensorStub.js';
+export { createAirflowActuatorStub } from './AirflowActuatorStub.js';
+export { createFiltrationStub } from './FiltrationStub.js';

--- a/packages/engine/tests/integration/pipeline/fanFilterChain.integration.test.ts
+++ b/packages/engine/tests/integration/pipeline/fanFilterChain.integration.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AIR_DENSITY_KG_PER_M3,
+  HOURS_PER_TICK,
+  ROOM_DEFAULT_HEIGHT_M
+} from '@/backend/src/constants/simConstants.js';
+import type { EngineDiagnostic, EngineRunContext } from '@/backend/src/engine/Engine.js';
+import { runTick } from '@/backend/src/engine/Engine.js';
+import { getDeviceEffectsRuntime } from '@/backend/src/engine/pipeline/applyDeviceEffects.js';
+import { createDemoWorld } from '@/backend/src/engine/testHarness.js';
+import type { ZoneDeviceInstance, Uuid } from '@/backend/src/domain/world.js';
+
+function uuid(value: string): Uuid {
+  return value as Uuid;
+}
+
+function createFanDevice(id: string, airflow_m3_per_h: number, dutyCycle01 = 1): ZoneDeviceInstance {
+  return {
+    id: uuid(id),
+    slug: `fan-${id}`,
+    name: `Test Fan ${id}`,
+    blueprintId: uuid(`${id}-blueprint`),
+    placementScope: 'zone',
+    quality01: 0.95,
+    condition01: 1,
+    powerDraw_W: 150,
+    dutyCycle01,
+    efficiency01: 0.8,
+    coverage_m2: 20,
+    airflow_m3_per_h,
+    sensibleHeatRemovalCapacity_W: 0,
+    effects: ['airflow'],
+    effectConfigs: {
+      airflow: {
+        mode: 'exhaust',
+        airflow_m3_per_h
+      }
+    }
+  } satisfies ZoneDeviceInstance;
+}
+
+function createFilterDevice(
+  id: string,
+  filterType: 'carbon' | 'hepa' | 'pre-filter',
+  efficiency01: number,
+  condition01: number,
+  basePressureDrop_pa: number
+): ZoneDeviceInstance {
+  return {
+    id: uuid(id),
+    slug: `filter-${id}`,
+    name: `Test Filter ${id}`,
+    blueprintId: uuid(`${id}-blueprint`),
+    placementScope: 'zone',
+    quality01: 0.9,
+    condition01,
+    powerDraw_W: 0,
+    dutyCycle01: 1,
+    efficiency01,
+    coverage_m2: 0,
+    airflow_m3_per_h: 0,
+    sensibleHeatRemovalCapacity_W: 0,
+    effects: ['filtration'],
+    effectConfigs: {
+      filtration: {
+        filterType,
+        efficiency01,
+        basePressureDrop_pa
+      }
+    }
+  } satisfies ZoneDeviceInstance;
+}
+
+describe('Tick pipeline — fan and filter chains', () => {
+  it('reduces airflow after filter pressure drops', () => {
+    const world = createDemoWorld();
+    const zone = world.company.structures[0].rooms[0].zones[0];
+    zone.floorArea_m2 = 25;
+    zone.height_m = 2;
+    zone.airMass_kg = zone.floorArea_m2 * zone.height_m * AIR_DENSITY_KG_PER_M3;
+
+    const fan = createFanDevice('50000000-0000-0000-0000-000000000001', 200);
+    const filter = createFilterDevice(
+      '50000000-0000-0000-0000-000000000002',
+      'carbon',
+      0.9,
+      1,
+      100
+    );
+
+    zone.devices = [fan, filter];
+
+    let runtime = undefined as ReturnType<typeof getDeviceEffectsRuntime>;
+    const ctx: EngineRunContext = {
+      tickDurationHours: HOURS_PER_TICK,
+      instrumentation: {
+        onStageComplete: (stage) => {
+          if (stage === 'applyDeviceEffects') {
+            runtime = getDeviceEffectsRuntime(ctx);
+          }
+        }
+      }
+    } satisfies EngineRunContext;
+
+    runTick(world, ctx);
+
+    expect(runtime).toBeDefined();
+
+    const netAirflow = runtime!.zoneAirflowTotals_m3_per_h.get(zone.id) ?? 0;
+    const netAch = runtime!.zoneAirChangesPerHour.get(zone.id) ?? 0;
+    const reduction = runtime!.zoneAirflowReductions_m3_per_h.get(zone.id) ?? 0;
+
+    expect(netAirflow).toBeGreaterThan(0);
+    expect(netAirflow).toBeLessThan(200);
+    expect(netAch).toBeLessThan(4);
+    expect(reduction).toBeGreaterThan(0);
+  });
+
+  it('emits ACH warnings after severe filter reductions', () => {
+    const world = createDemoWorld();
+    const zone = world.company.structures[0].rooms[0].zones[0];
+    zone.floorArea_m2 = 20;
+    zone.height_m = ROOM_DEFAULT_HEIGHT_M;
+    zone.airMass_kg = zone.floorArea_m2 * zone.height_m * AIR_DENSITY_KG_PER_M3;
+
+    const fan = createFanDevice('50000000-0000-0000-0000-000000000003', 80);
+    const filter = createFilterDevice(
+      '50000000-0000-0000-0000-000000000004',
+      'carbon',
+      0.85,
+      0.3,
+      180
+    );
+
+    zone.devices = [fan, filter];
+
+    const diagnostics: EngineDiagnostic[] = [];
+    let runtime = undefined as ReturnType<typeof getDeviceEffectsRuntime>;
+
+    const ctx: EngineRunContext = {
+      tickDurationHours: HOURS_PER_TICK,
+      diagnostics: {
+        emit: (diagnostic) => diagnostics.push(diagnostic)
+      },
+      instrumentation: {
+        onStageComplete: (stage) => {
+          if (stage === 'applyDeviceEffects') {
+            runtime = getDeviceEffectsRuntime(ctx);
+          }
+        }
+      }
+    } satisfies EngineRunContext;
+
+    runTick(world, ctx);
+
+    expect(runtime).toBeDefined();
+
+    const netAch = runtime!.zoneAirChangesPerHour.get(zone.id) ?? 0;
+    expect(netAch).toBeLessThan(1);
+    expect(diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'zone.capacity.airflow.warn', zoneId: zone.id })
+      ])
+    );
+  });
+
+  it('accumulates airflow reductions across multiple fans and filters', () => {
+    const world = createDemoWorld();
+    const zone = world.company.structures[0].rooms[0].zones[0];
+    zone.floorArea_m2 = 30;
+    zone.height_m = ROOM_DEFAULT_HEIGHT_M;
+    zone.airMass_kg = zone.floorArea_m2 * zone.height_m * AIR_DENSITY_KG_PER_M3;
+
+    const fanA = createFanDevice('50000000-0000-0000-0000-000000000005', 150);
+    const fanB = createFanDevice('50000000-0000-0000-0000-000000000006', 150);
+    const filterA = createFilterDevice(
+      '50000000-0000-0000-0000-000000000007',
+      'carbon',
+      0.8,
+      0.8,
+      90
+    );
+    const filterB = createFilterDevice(
+      '50000000-0000-0000-0000-000000000008',
+      'hepa',
+      0.95,
+      0.7,
+      140
+    );
+
+    zone.devices = [fanA, fanB, filterA, filterB];
+
+    let runtime = undefined as ReturnType<typeof getDeviceEffectsRuntime>;
+    const ctx: EngineRunContext = {
+      tickDurationHours: HOURS_PER_TICK,
+      instrumentation: {
+        onStageComplete: (stage) => {
+          if (stage === 'applyDeviceEffects') {
+            runtime = getDeviceEffectsRuntime(ctx);
+          }
+        }
+      }
+    } satisfies EngineRunContext;
+
+    runTick(world, ctx);
+
+    expect(runtime).toBeDefined();
+
+    const netAirflow = runtime!.zoneAirflowTotals_m3_per_h.get(zone.id) ?? 0;
+    const reduction = runtime!.zoneAirflowReductions_m3_per_h.get(zone.id) ?? 0;
+    const grossAirflow = 300;
+
+    expect(netAirflow).toBeGreaterThan(0);
+    expect(netAirflow).toBeLessThan(grossAirflow);
+    expect(reduction).toBeGreaterThan(0);
+    expect(reduction).toBeCloseTo(grossAirflow - netAirflow, 5);
+  });
+
+  it('accumulates odor and particulate telemetry from filters', () => {
+    const world = createDemoWorld();
+    const zone = world.company.structures[0].rooms[0].zones[0];
+    zone.floorArea_m2 = 15;
+    zone.height_m = ROOM_DEFAULT_HEIGHT_M;
+    zone.airMass_kg = zone.floorArea_m2 * zone.height_m * AIR_DENSITY_KG_PER_M3;
+
+    const fan = createFanDevice('50000000-0000-0000-0000-000000000009', 180);
+    const filter = createFilterDevice(
+      '50000000-0000-0000-0000-000000000010',
+      'hepa',
+      0.92,
+      0.85,
+      130
+    );
+
+    zone.devices = [fan, filter];
+
+    let runtime = undefined as ReturnType<typeof getDeviceEffectsRuntime>;
+    const ctx: EngineRunContext = {
+      tickDurationHours: HOURS_PER_TICK,
+      instrumentation: {
+        onStageComplete: (stage) => {
+          if (stage === 'applyDeviceEffects') {
+            runtime = getDeviceEffectsRuntime(ctx);
+          }
+        }
+      }
+    } satisfies EngineRunContext;
+
+    runTick(world, ctx);
+
+    expect(runtime).toBeDefined();
+
+    const odorDelta = runtime!.zoneOdorDelta.get(zone.id) ?? 0;
+    const particulate = runtime!.zoneParticulateRemoval_pct.get(zone.id) ?? 0;
+
+    expect(odorDelta).toBeLessThan(0);
+    expect(particulate).toBeGreaterThan(0);
+  });
+
+  it('continues to support legacy airflow devices without effects metadata', () => {
+    const world = createDemoWorld();
+    const zone = world.company.structures[0].rooms[0].zones[0];
+    zone.floorArea_m2 = 12;
+    zone.height_m = ROOM_DEFAULT_HEIGHT_M;
+    zone.airMass_kg = zone.floorArea_m2 * zone.height_m * AIR_DENSITY_KG_PER_M3;
+
+    const legacyFan: ZoneDeviceInstance = {
+      id: uuid('50000000-0000-0000-0000-000000000011'),
+      slug: 'legacy-fan',
+      name: 'Legacy Fan',
+      blueprintId: uuid('50000000-0000-0000-0000-000000000012'),
+      placementScope: 'zone',
+      quality01: 0.9,
+      condition01: 1,
+      powerDraw_W: 100,
+      dutyCycle01: 1,
+      efficiency01: 0.75,
+      coverage_m2: 30,
+      airflow_m3_per_h: 200,
+      sensibleHeatRemovalCapacity_W: 0
+    } satisfies ZoneDeviceInstance;
+
+    zone.devices = [legacyFan];
+
+    let runtime = undefined as ReturnType<typeof getDeviceEffectsRuntime>;
+    const ctx: EngineRunContext = {
+      tickDurationHours: HOURS_PER_TICK,
+      instrumentation: {
+        onStageComplete: (stage) => {
+          if (stage === 'applyDeviceEffects') {
+            runtime = getDeviceEffectsRuntime(ctx);
+          }
+        }
+      }
+    } satisfies EngineRunContext;
+
+    runTick(world, ctx);
+
+    expect(runtime).toBeDefined();
+
+    const netAirflow = runtime!.zoneAirflowTotals_m3_per_h.get(zone.id) ?? 0;
+    expect(netAirflow).toBeCloseTo(legacyFan.airflow_m3_per_h, 5);
+  });
+});

--- a/packages/engine/tests/unit/stubs/AirflowActuatorStub.test.ts
+++ b/packages/engine/tests/unit/stubs/AirflowActuatorStub.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+
+import { HOURS_PER_TICK } from '@/backend/src/constants/simConstants.js';
+import { createAirflowActuatorStub } from '@/backend/src/stubs/AirflowActuatorStub.js';
+import type { AirflowActuatorInputs } from '@/backend/src/domain/interfaces/IAirflowActuator.js';
+
+const ZONE_VOLUME_M3 = 50;
+const BASE_INPUTS: AirflowActuatorInputs = {
+  airflow_m3_per_h: 200,
+  mode: 'exhaust',
+  dutyCycle01: 1
+};
+
+function createInputs(overrides: Partial<AirflowActuatorInputs> = {}): AirflowActuatorInputs {
+  return {
+    ...BASE_INPUTS,
+    ...overrides
+  };
+}
+
+describe('AirflowActuatorStub', () => {
+  const stub = createAirflowActuatorStub();
+
+  describe('basic calculations', () => {
+    it('computes effective airflow with dutyCycle01 = 1.0', () => {
+      const result = stub.computeEffect(BASE_INPUTS, ZONE_VOLUME_M3, HOURS_PER_TICK);
+
+      expect(result.effective_airflow_m3_per_h).toBeCloseTo(200, 5);
+      expect(result.ach).toBeCloseTo(4, 5);
+      expect(result.pressure_loss_pa).toBe(0);
+      expect(result.energy_Wh).toBeUndefined();
+    });
+
+    it('computes effective airflow with dutyCycle01 = 0.5', () => {
+      const inputs = createInputs({ dutyCycle01: 0.5 });
+      const result = stub.computeEffect(inputs, ZONE_VOLUME_M3, HOURS_PER_TICK);
+
+      expect(result.effective_airflow_m3_per_h).toBeCloseTo(100, 5);
+      expect(result.ach).toBeCloseTo(2, 5);
+    });
+
+    it('computes ACH correctly for varying zone volumes', () => {
+      const inputs = createInputs({ airflow_m3_per_h: 300 });
+      const result = stub.computeEffect(inputs, 75, HOURS_PER_TICK);
+
+      expect(result.ach).toBeCloseTo(4, 5);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns zeros when airflow_m3_per_h is zero', () => {
+      const inputs = createInputs({ airflow_m3_per_h: 0 });
+      const result = stub.computeEffect(inputs, ZONE_VOLUME_M3, HOURS_PER_TICK);
+
+      expect(result.effective_airflow_m3_per_h).toBe(0);
+      expect(result.ach).toBe(0);
+    });
+
+    it('returns zeros when dutyCycle01 is zero', () => {
+      const inputs = createInputs({ dutyCycle01: 0 });
+      const result = stub.computeEffect(inputs, ZONE_VOLUME_M3, HOURS_PER_TICK);
+
+      expect(result.effective_airflow_m3_per_h).toBe(0);
+      expect(result.ach).toBe(0);
+    });
+
+    it('returns zeros when zoneVolume_m3 is zero', () => {
+      const result = stub.computeEffect(BASE_INPUTS, 0, HOURS_PER_TICK);
+
+      expect(result.effective_airflow_m3_per_h).toBe(0);
+      expect(result.ach).toBe(0);
+    });
+
+    it('returns zeros when dt_h is zero', () => {
+      const result = stub.computeEffect(BASE_INPUTS, ZONE_VOLUME_M3, 0);
+
+      expect(result.effective_airflow_m3_per_h).toBe(0);
+      expect(result.ach).toBe(0);
+    });
+
+    it('clamps negative airflow to zero', () => {
+      const inputs = createInputs({ airflow_m3_per_h: -150 });
+      const result = stub.computeEffect(inputs, ZONE_VOLUME_M3, HOURS_PER_TICK);
+
+      expect(result.effective_airflow_m3_per_h).toBe(0);
+      expect(result.ach).toBe(0);
+    });
+
+    it('clamps dutyCycle01 above one to 1.0', () => {
+      const inputs = createInputs({ dutyCycle01: 1.5 });
+      const result = stub.computeEffect(inputs, ZONE_VOLUME_M3, HOURS_PER_TICK);
+
+      expect(result.effective_airflow_m3_per_h).toBeCloseTo(200, 5);
+      expect(result.ach).toBeCloseTo(4, 5);
+    });
+  });
+
+  describe('mode handling', () => {
+    it('accepts recirculation mode without changing calculations', () => {
+      const inputs = createInputs({ mode: 'recirculation' });
+      const result = stub.computeEffect(inputs, ZONE_VOLUME_M3, HOURS_PER_TICK);
+
+      expect(result.effective_airflow_m3_per_h).toBeCloseTo(200, 5);
+      expect(result.ach).toBeCloseTo(4, 5);
+    });
+
+    it('accepts intake mode without changing calculations', () => {
+      const inputs = createInputs({ mode: 'intake' });
+      const result = stub.computeEffect(inputs, ZONE_VOLUME_M3, HOURS_PER_TICK);
+
+      expect(result.effective_airflow_m3_per_h).toBeCloseTo(200, 5);
+      expect(result.ach).toBeCloseTo(4, 5);
+    });
+  });
+
+  describe('output structure', () => {
+    it('always returns finite numeric outputs', () => {
+      const inputs = createInputs({ airflow_m3_per_h: 180, dutyCycle01: 0.75 });
+      const result = stub.computeEffect(inputs, ZONE_VOLUME_M3, HOURS_PER_TICK);
+
+      expect(Number.isFinite(result.effective_airflow_m3_per_h)).toBe(true);
+      expect(Number.isFinite(result.ach)).toBe(true);
+      expect(result.pressure_loss_pa).toBe(0);
+      expect(result.energy_Wh).toBeUndefined();
+    });
+  });
+});

--- a/packages/engine/tests/unit/stubs/FiltrationStub.test.ts
+++ b/packages/engine/tests/unit/stubs/FiltrationStub.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+
+import { HOURS_PER_TICK } from '@/backend/src/constants/simConstants.js';
+import { createFiltrationStub } from '@/backend/src/stubs/FiltrationStub.js';
+import type { FiltrationUnitInputs } from '@/backend/src/domain/interfaces/IFiltrationUnit.js';
+
+const BASE_INPUTS: FiltrationUnitInputs = {
+  airflow_m3_per_h: 200,
+  filterType: 'carbon',
+  efficiency01: 0.9,
+  condition01: 1,
+  basePressureDrop_pa: 100
+};
+
+function createInputs(overrides: Partial<FiltrationUnitInputs> = {}): FiltrationUnitInputs {
+  return {
+    ...BASE_INPUTS,
+    ...overrides
+  };
+}
+
+describe('FiltrationStub', () => {
+  const stub = createFiltrationStub();
+
+  describe('pressure drop calculations', () => {
+    it('computes pressure drop at perfect condition', () => {
+      const result = stub.computeEffect(BASE_INPUTS, HOURS_PER_TICK);
+
+      expect(result.pressure_drop_pa).toBeCloseTo(100, 5);
+      expect(result.airflow_reduction_m3_per_h).toBeGreaterThan(0);
+    });
+
+    it('increases pressure drop when condition deteriorates', () => {
+      const inputs = createInputs({ condition01: 0.5 });
+      const result = stub.computeEffect(inputs, HOURS_PER_TICK);
+
+      expect(result.pressure_drop_pa).toBeGreaterThan(100);
+    });
+
+    it('scales pressure drop with airflow throughput', () => {
+      const lowFlow = stub.computeEffect(createInputs({ airflow_m3_per_h: 150 }), HOURS_PER_TICK);
+      const highFlow = stub.computeEffect(createInputs({ airflow_m3_per_h: 400 }), HOURS_PER_TICK);
+
+      expect(highFlow.pressure_drop_pa).toBeGreaterThan(lowFlow.pressure_drop_pa);
+    });
+  });
+
+  describe('airflow reduction', () => {
+    it('reduces airflow proportional to pressure drop', () => {
+      const result = stub.computeEffect(BASE_INPUTS, HOURS_PER_TICK);
+
+      expect(result.airflow_reduction_m3_per_h).toBeGreaterThan(0);
+      expect(result.airflow_reduction_m3_per_h).toBeLessThan(BASE_INPUTS.airflow_m3_per_h);
+    });
+
+    it('clamps reduction to 30% of input airflow', () => {
+      const inputs = createInputs({ airflow_m3_per_h: 500, basePressureDrop_pa: 300 });
+      const result = stub.computeEffect(inputs, HOURS_PER_TICK);
+      const maxReduction = inputs.airflow_m3_per_h * 0.3;
+
+      expect(result.airflow_reduction_m3_per_h).toBeCloseTo(maxReduction, 5);
+    });
+
+    it('returns zero reduction when airflow is zero', () => {
+      const result = stub.computeEffect(createInputs({ airflow_m3_per_h: 0 }), HOURS_PER_TICK);
+
+      expect(result.airflow_reduction_m3_per_h).toBe(0);
+      expect(result.pressure_drop_pa).toBe(0);
+    });
+  });
+
+  describe('odor concentration', () => {
+    it('reduces odor concentration proportionally to efficiency and condition', () => {
+      const result = stub.computeEffect(BASE_INPUTS, HOURS_PER_TICK);
+
+      expect(result.odor_concentration_delta).toBeLessThan(0);
+    });
+
+    it('scales odor reduction with volumetric flow and dt', () => {
+      const lowFlow = stub.computeEffect(BASE_INPUTS, HOURS_PER_TICK);
+      const highFlow = stub.computeEffect(createInputs({ airflow_m3_per_h: 400 }), HOURS_PER_TICK);
+
+      expect(highFlow.odor_concentration_delta).toBeLessThan(lowFlow.odor_concentration_delta);
+    });
+  });
+
+  describe('particulate removal', () => {
+    it('reports near 99% removal for HEPA filters at full efficiency', () => {
+      const result = stub.computeEffect(
+        createInputs({ filterType: 'hepa', efficiency01: 1, basePressureDrop_pa: 200 }),
+        HOURS_PER_TICK
+      );
+
+      expect(result.particulate_removal_pct).toBeCloseTo(99, 5);
+    });
+
+    it('reports 60% removal baseline for pre-filters at full efficiency', () => {
+      const result = stub.computeEffect(
+        createInputs({ filterType: 'pre-filter', efficiency01: 1, basePressureDrop_pa: 120 }),
+        HOURS_PER_TICK
+      );
+
+      expect(result.particulate_removal_pct).toBeCloseTo(60, 5);
+    });
+
+    it('reports zero particulate removal for carbon filters', () => {
+      const result = stub.computeEffect(BASE_INPUTS, HOURS_PER_TICK);
+
+      expect(result.particulate_removal_pct).toBe(0);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('clamps efficiency and condition to [0,1]', () => {
+      const result = stub.computeEffect(
+        createInputs({ efficiency01: 1.5, condition01: -0.5, basePressureDrop_pa: 150 }),
+        HOURS_PER_TICK
+      );
+
+      expect(result.odor_concentration_delta).toBeGreaterThanOrEqual(-BASE_INPUTS.airflow_m3_per_h);
+      expect(result.pressure_drop_pa).toBeGreaterThanOrEqual(0);
+    });
+
+    it('returns zeros when basePressureDrop_pa is zero', () => {
+      const result = stub.computeEffect(createInputs({ basePressureDrop_pa: 0 }), HOURS_PER_TICK);
+
+      expect(result.pressure_drop_pa).toBe(0);
+      expect(result.airflow_reduction_m3_per_h).toBe(0);
+      expect(result.odor_concentration_delta).toBe(0);
+    });
+  });
+
+  describe('output structure', () => {
+    it('always returns finite numeric outputs', () => {
+      const result = stub.computeEffect(
+        createInputs({ airflow_m3_per_h: 250, efficiency01: 0.8, condition01: 0.7 }),
+        HOURS_PER_TICK
+      );
+
+      expect(Number.isFinite(result.pressure_drop_pa)).toBe(true);
+      expect(Number.isFinite(result.airflow_reduction_m3_per_h)).toBe(true);
+      expect(Number.isFinite(result.particulate_removal_pct)).toBe(true);
+      expect(Number.isFinite(result.odor_concentration_delta)).toBe(true);
+      expect(result.odor_concentration_delta).toBeLessThanOrEqual(0);
+      expect(result.airflow_reduction_m3_per_h).toBeGreaterThanOrEqual(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extend device effect configs and blueprints with airflow and filtration support
- add deterministic airflow and filtration stubs and integrate them into the device-effects pipeline
- cover new behaviour with unit/integration tests and provide a sample carbon filter blueprint

## Testing
- pnpm --filter engine test *(fails: vitest executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df6a8a1afc8325b535cfa473ff50da