### PR TITLE
Add airflow configs to exhaust and cooling blueprints

### DIFF
--- a/data/blueprints/device/airflow/exhaust/exhaust-fan-4-inch.json
+++ b/data/blueprints/device/airflow/exhaust/exhaust-fan-4-inch.json
@@ -14,6 +14,10 @@
   "effects": [
     "airflow"
   ],
+  "airflow": {
+    "mode": "exhaust",
+    "airflow_m3_per_h": 170
+  },
   "quality": 0.7,
   "complexity": 0.1,
   "lifetime_h": 17520,

--- a/data/blueprints/device/climate/cooling/cool-air-split-3000.json
+++ b/data/blueprints/device/climate/cooling/cool-air-split-3000.json
@@ -24,6 +24,10 @@
     "mode": "dehumidify",
     "capacity_g_per_h": 500
   },
+  "airflow": {
+    "mode": "recirculation",
+    "airflow_m3_per_h": 350
+  },
   "quality": 0.9,
   "complexity": 0.4,
   "lifetime_h": 35040,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### #49 WB-042 airflow config parity for exhaust and cooling devices
+- Added explicit airflow effect blocks to the Exhaust Fan 4-inch and CoolAir Split 3000
+  blueprints so `parseDeviceBlueprint` enforces the SEC airflow schema for existing
+  airflow effects.
+- Documented the airflow contract alignment here to keep blueprint data changes
+  traceable for contributors.
+
 ### #48 WB-041 interface stacking vectors and integration coverage
 - Documented stub reference vectors, stacking patterns, and acceptance criteria
   across SEC §6.3, DD §8a, and TDD §9a to align documentation with the


### PR DESCRIPTION
## Summary
- add explicit airflow effect configs to the exhaust fan and CoolAir Split 3000 device blueprints with SEC-compliant airflow modes and rates
- document the airflow blueprint contract alignment in the changelog for contributor visibility

## Testing
- pnpm test --filter "device blueprint" *(fails: spawn ENOENT – workspace dependencies not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df8c2924dc832586d6986da4ab6d6e