### PR TITLE
Optimize Engine commit stage cloning behavior

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### #50 WB-043 world mutation tracking in Engine pipeline
+- Added a private `__wb_worldMutated` tracking helper on `EngineRunContext` so the
+  tick runner can detect in-place stage stability without cloning worlds.
+- Updated `runTick` to raise the flag when a stage returns a new world instance
+  and to clear it once the pipeline finishes, keeping context reuse deterministic.
+- Optimised `commitAndTelemetry` to mutate `simTimeHours` in-place when no prior
+  stage touched the world, preserving the existing clone path when mutations do occur.
+
 ### #49 WB-042 airflow config parity for exhaust and cooling devices
 - Added explicit airflow effect blocks to the Exhaust Fan 4-inch and CoolAir Split 3000
   blueprints so `parseDeviceBlueprint` enforces the SEC airflow schema for existing

--- a/packages/engine/src/backend/src/engine/pipeline/commitAndTelemetry.ts
+++ b/packages/engine/src/backend/src/engine/pipeline/commitAndTelemetry.ts
@@ -1,9 +1,15 @@
 import { HOURS_PER_TICK } from '../../constants/simConstants.js';
 import type { SimulationWorld } from '../../domain/world.js';
-import type { EngineRunContext } from '../Engine.js';
+import { hasWorldBeenMutated, type EngineRunContext } from '../Engine.js';
+
+type Mutable<T> = { -readonly [K in keyof T]: T[K] };
 
 export function commitAndTelemetry(world: SimulationWorld, ctx: EngineRunContext): SimulationWorld {
-  void ctx;
+  if (!hasWorldBeenMutated(ctx)) {
+    const mutableWorld = world as Mutable<SimulationWorld>;
+    mutableWorld.simTimeHours += HOURS_PER_TICK;
+    return world;
+  }
 
   return {
     ...world,


### PR DESCRIPTION
## Summary
- add a private world mutation flag to EngineRunContext so runTick can detect when stages replace the world reference
- update runTick to maintain the mutation flag across stages and reset it between ticks
- optimize commitAndTelemetry to mutate simTimeHours in place when safe and document the behavior change in the changelog

## Testing
- pnpm --filter @wb/engine exec vitest run tests/integration/pipeline/timeProgression.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68df99128a588325a3e1e3ab84d7340b