### PR TITLE
Model latent heat coupling in multi-effect device pipeline

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### #51 WB-044 latent heat coupling for stacked climate devices
+- Added the SEC-mandated `LATENT_HEAT_VAPORIZATION_WATER_J_PER_KG` constant to
+  the simulation canon and documentation so latent/sensible coupling shares a
+  single source of truth.
+- Extended `applyDeviceEffects` to translate humidity actuator water removal/
+  addition into sensible temperature deltas using the new constant while
+  respecting duty cycle, coverage effectiveness, and thermal mode to avoid
+  double counting on multi-effect devices.
+- Updated the multi-effect integration suite to log per-zone contributions via
+  pipeline instrumentation and to assert the combined sensible+latent
+  expectations for Patterns A/B and stacked heater+dehumidifier scenarios.
+
 ### #50 WB-043 world mutation tracking in Engine pipeline
 - Added a private `__wb_worldMutated` tracking helper on `EngineRunContext` so the
   tick runner can detect in-place stage stability without cloning worlds.

--- a/docs/constants/simConstants.md
+++ b/docs/constants/simConstants.md
@@ -15,6 +15,7 @@ normalisation mandated by the SEC.
 | `SECONDS_PER_HOUR` | `3 600` | s | Seconds per in-game hour for power ↔ energy conversions. |
 | `ROOM_DEFAULT_HEIGHT_M` | `3` | m | Default room interior height when blueprints omit overrides. |
 | `CP_AIR_J_PER_KG_K` | `1 005` | J/(kg·K) | Specific heat capacity of dry air at constant pressure. |
+| `LATENT_HEAT_VAPORIZATION_WATER_J_PER_KG` | `2 260 000` | J/kg | Latent heat of vaporisation for water at 1 atm (SEC §6.3.2). |
 | `AIR_DENSITY_KG_PER_M3` | `1.2041` | kg/m³ | Density of dry air at standard conditions (20 °C, 1 atm). |
 | `HOURS_PER_TICK` | `1` | h | Duration represented by one simulation tick (one in-game hour). |
 | `HOURS_PER_DAY` | `24` | h | Hours per in-game day (calendar invariant). |

--- a/packages/engine/src/backend/src/constants/simConstants.ts
+++ b/packages/engine/src/backend/src/constants/simConstants.ts
@@ -31,6 +31,11 @@ export interface SimulationConstants {
    */
   readonly CP_AIR_J_PER_KG_K: number;
   /**
+   * Latent heat of vaporisation for water at standard atmospheric pressure,
+   * expressed in joules per kilogram.
+   */
+  readonly LATENT_HEAT_VAPORIZATION_WATER_J_PER_KG: number;
+  /**
    * Density of dry air at standard conditions, expressed in kilograms per
    * cubic metre.
    */
@@ -133,6 +138,13 @@ export const ROOM_DEFAULT_HEIGHT_M = 3 as const;
 export const CP_AIR_J_PER_KG_K = 1_005 as const;
 
 /**
+ * Canonical constant describing the latent heat of vaporisation for water at
+ * standard atmospheric pressure (SEC §6.3.2), expressed in joules per
+ * kilogram.
+ */
+export const LATENT_HEAT_VAPORIZATION_WATER_J_PER_KG = 2_260_000 as const;
+
+/**
  * Canonical constant describing the density of dry air at standard conditions,
  * expressed in kilograms per cubic metre.
  */
@@ -231,6 +243,7 @@ export const SIM_CONSTANTS: Readonly<SimulationConstants> = Object.freeze({
   SECONDS_PER_HOUR,
   ROOM_DEFAULT_HEIGHT_M,
   CP_AIR_J_PER_KG_K,
+  LATENT_HEAT_VAPORIZATION_WATER_J_PER_KG,
   AIR_DENSITY_KG_PER_M3,
   HOURS_PER_TICK,
   HOURS_PER_DAY,


### PR DESCRIPTION
## Summary
- add the SEC latent heat of vaporisation constant to the simulation canon and documentation
- convert humidity actuator water removal/addition into latent temperature deltas inside `applyDeviceEffects`
- update multi-effect integration coverage to assert the new thermal expectations and log per-zone contributions for Patterns A/B

## Testing
- pnpm --filter @wb/engine test multiEffectDevice.integration.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68df9a89031883259c6bf7b5dbb38ca5