### PR TITLE
Align idle tick immutability

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### #53 WB-046 idle tick immutability guard
+- Updated `commitAndTelemetry` to return the existing world snapshot untouched
+  (including `simTimeHours`) when no pipeline stage mutated state, matching the
+  SEC §1 ordered-tick guarantee that idle ticks do not fabricate temporal
+  advancement.
+- Extended the irrigation/nutrient integration suite to assert both reference
+  equality and time stability when the tick processes zero irrigation events,
+  ensuring regressions surface immediately.
+- Normalised placeholder physiology/harvest/economy pipeline stages to return
+  their input world when no work occurs so mutation tracking and the new commit
+  semantics remain faithful.
+
 ### #52 WB-045 irrigation runtime lifecycle instrumentation
 - Deferred `clearIrrigationNutrientsRuntime` to the Engine tick runner so the
   instrumentation hook can inspect irrigation/nutrient outputs before the

--- a/packages/engine/src/backend/src/engine/pipeline/advancePhysiology.ts
+++ b/packages/engine/src/backend/src/engine/pipeline/advancePhysiology.ts
@@ -4,7 +4,5 @@ import type { EngineRunContext } from '../Engine.js';
 export function advancePhysiology(world: SimulationWorld, ctx: EngineRunContext): SimulationWorld {
   void ctx;
 
-  const nextWorld = { ...world } satisfies SimulationWorld;
-
-  return nextWorld;
+  return world;
 }

--- a/packages/engine/src/backend/src/engine/pipeline/applyEconomyAccrual.ts
+++ b/packages/engine/src/backend/src/engine/pipeline/applyEconomyAccrual.ts
@@ -4,7 +4,5 @@ import type { EngineRunContext } from '../Engine.js';
 export function applyEconomyAccrual(world: SimulationWorld, ctx: EngineRunContext): SimulationWorld {
   void ctx;
 
-  const nextWorld = { ...world } satisfies SimulationWorld;
-
-  return nextWorld;
+  return world;
 }

--- a/packages/engine/src/backend/src/engine/pipeline/applyHarvestAndInventory.ts
+++ b/packages/engine/src/backend/src/engine/pipeline/applyHarvestAndInventory.ts
@@ -4,7 +4,5 @@ import type { EngineRunContext } from '../Engine.js';
 export function applyHarvestAndInventory(world: SimulationWorld, ctx: EngineRunContext): SimulationWorld {
   void ctx;
 
-  const nextWorld = { ...world } satisfies SimulationWorld;
-
-  return nextWorld;
+  return world;
 }

--- a/packages/engine/src/backend/src/engine/pipeline/commitAndTelemetry.ts
+++ b/packages/engine/src/backend/src/engine/pipeline/commitAndTelemetry.ts
@@ -2,12 +2,8 @@ import { HOURS_PER_TICK } from '../../constants/simConstants.js';
 import type { SimulationWorld } from '../../domain/world.js';
 import { hasWorldBeenMutated, type EngineRunContext } from '../Engine.js';
 
-type Mutable<T> = { -readonly [K in keyof T]: T[K] };
-
 export function commitAndTelemetry(world: SimulationWorld, ctx: EngineRunContext): SimulationWorld {
   if (!hasWorldBeenMutated(ctx)) {
-    const mutableWorld = world as Mutable<SimulationWorld>;
-    mutableWorld.simTimeHours += HOURS_PER_TICK;
     return world;
   }
 

--- a/packages/engine/tests/integration/pipeline/irrigationNutrients.integration.test.ts
+++ b/packages/engine/tests/integration/pipeline/irrigationNutrients.integration.test.ts
@@ -140,9 +140,24 @@ describe('Tick pipeline — irrigation and nutrients', () => {
     const world = createDemoWorld();
     setWorldSeed(world, WORLD_SEED);
 
-    const { world: nextWorld } = runTick(world, { irrigationEvents: [] });
+    const initialSimTime = world.simTimeHours;
+    const stageMutations: Record<string, boolean> = {};
+    let lastWorld: SimulationWorld = world;
+
+    const { world: nextWorld } = runTick(world, {
+      irrigationEvents: [],
+      instrumentation: {
+        onStageComplete(stage, stageWorld) {
+          stageMutations[stage] = stageWorld !== lastWorld;
+          lastWorld = stageWorld;
+        }
+      }
+    });
 
     expect(nextWorld).toBe(world);
+    expect(nextWorld.simTimeHours).toBe(initialSimTime);
+    expect(stageMutations.commitAndTelemetry).toBe(false);
+    expect(Object.values(stageMutations)).not.toContain(true);
   });
 
   it('updates multiple zones independently based on targeted events', () => {


### PR DESCRIPTION
## Summary
- keep commitAndTelemetry from advancing simTimeHours when no stage mutated the world
- stop placeholder physiology, harvest, and economy stages from cloning worlds when they do no work
- extend the irrigation and time progression integration tests and changelog to cover idle tick immutability

## Testing
- `pnpm --filter @wb/engine test -- tests/integration/pipeline/irrigationNutrients.integration.test.ts` *(fails: known issues in `deviceBlueprintSchema` multi-effect config and sensor/actuator pattern integration)*

------
https://chatgpt.com/codex/tasks/task_e_68dfa245c8248325b946912c7c4596a5