### PR TITLE
Reorder sensor sampling before environment update

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### #54 WB-047 sensor sampling before environment integration
+- Reordered the Engine tick pipeline so `applySensors` executes immediately after
+  `applyDeviceEffects`, capturing zone conditions before `updateEnvironment`
+  integrates actuator deltas as required by SEC §4.2.
+- Updated Pattern D integration coverage and the pipeline order trace assertion
+  to reflect the new sequencing while keeping runtime cleanup semantics intact.
+- Revised SEC, DD, and TDD documentation to call out the dedicated sensor stage
+  and its placement ahead of environmental integration.
+
 ### #53 WB-046 idle tick immutability guard
 - Updated `commitAndTelemetry` to return the existing world snapshot untouched
   (including `simTimeHours`) when no pipeline stage mutated state, matching the

--- a/docs/DD.md
+++ b/docs/DD.md
@@ -247,7 +247,7 @@ Fixed order per tick:
 - **Pattern D — Sensor + Actuator in One Housing:**
   - A device implements `ISensor` + actuator interface (e.g., `IThermalActuator`)
   - Example: Temperature controller with integrated sensor
-  - Note: Sensor readings must not be "polluted" by actuator output in the same tick
+  - Note: Sensor readings must not be "polluted" by actuator output in the same tick — pipeline order runs `applySensors` immediately after `applyDeviceEffects`, before `updateEnvironment` integrates actuator deltas.
 - **Pattern E — Substrate Buffer + Irrigation (Service + Domain):**
   - Service (`IIrrigationService`) + Domain stub (`INutrientBuffer`) jointly deliver nutrient outcome
   - Example: Irrigation service calculates flow, substrate buffer manages uptake/leaching

--- a/docs/SEC.md
+++ b/docs/SEC.md
@@ -329,18 +329,20 @@ Validation occurs at load time; on failure, the engine must not start. Validatio
 ### 4.2 Phase Order
 
 1. **Device Effects** — compute device outputs (light, heat, airflow, CO₂, dehumidification) subject to capacity & efficiency.
-    
-2. **Environment Update** — integrate device outputs into zone state (well-mixed model baseline).
-    
-3. **Irrigation & Nutrients** — fulfill zone method (manual enqueues tasks; automated fulfills on schedule).
-    
-4. **Plant Physiology** — update age/phase, biomass, stress, disease risk using strain curves and environment.
-    
-5. **Harvest & Inventory** — create lots when criteria met; move yield to inventory.
-    
-6. **Economy & Cost Accrual** — aggregate consumption/costs; maintenance curves progress.
-    
-7. **Commit & Telemetry** — snapshot state and publish read-only events.
+
+2. **Sensor Sampling** — record zone state before environmental integration so co-housed actuators observe pre-actuation values.
+
+3. **Environment Update** — integrate device outputs into zone state (well-mixed model baseline).
+
+4. **Irrigation & Nutrients** — fulfill zone method (manual enqueues tasks; automated fulfills on schedule).
+
+5. **Plant Physiology** — update age/phase, biomass, stress, disease risk using strain curves and environment.
+
+6. **Harvest & Inventory** — create lots when criteria met; move yield to inventory.
+
+7. **Economy & Cost Accrual** — aggregate consumption/costs; maintenance curves progress.
+
+8. **Commit & Telemetry** — snapshot state and publish read-only events.
     
 
 ---

--- a/docs/TDD.md
+++ b/docs/TDD.md
@@ -166,7 +166,7 @@ it('rejects zone device in non-grow room', () => {
 
 ## 7) Tick trace instrumentation & perf harness (Engine)
 
-- Canonical order: `applyDeviceEffects → updateEnvironment → applyIrrigationAndNutrients → advancePhysiology → applyHarvestAndInventory → applyEconomyAccrual → commitAndTelemetry` (mirrors SEC §4.2).
+- Canonical order: `applyDeviceEffects → applySensors → updateEnvironment → applyIrrigationAndNutrients → advancePhysiology → applyHarvestAndInventory → applyEconomyAccrual → commitAndTelemetry` (mirrors SEC §4.2).
 - `runTick(world, ctx, { trace: true })` returns `{ world, trace }` where `world` is the immutable post-tick snapshot and `trace` is an optional {@link TickTrace} with monotonic `startedAtNs`, `durationNs`, `endedAtNs`, and heap metrics for every stage without feeding wall-clock time into simulation logic.
 - `runOneTickWithTrace()` (engine test harness) clones the deterministic demo world and returns `{ world, context, trace }` for integration/unit assertions.
 - `withPerfHarness({ ticks })` executes repeated traced ticks and reports `{ traces, totalDurationNs, averageDurationNs, maxHeapUsedBytes }` so perf tests can guard throughput (< 5 ms avg/tick) and heap (< 64 MiB).

--- a/packages/engine/src/backend/src/engine/Engine.ts
+++ b/packages/engine/src/backend/src/engine/Engine.ts
@@ -80,8 +80,8 @@ export type PipelineStage = (
 
 const PIPELINE_DEFINITION: ReadonlyArray<readonly [StepName, PipelineStage]> = [
   ['applyDeviceEffects', applyDeviceEffects],
-  ['updateEnvironment', updateEnvironment],
   ['applySensors', applySensors],
+  ['updateEnvironment', updateEnvironment],
   ['applyIrrigationAndNutrients', applyIrrigationAndNutrients],
   ['advancePhysiology', advancePhysiology],
   ['applyHarvestAndInventory', applyHarvestAndInventory],


### PR DESCRIPTION
## Summary
- move the Engine sensor stage ahead of environment integration so sensor readings reflect the pre-actuation state while keeping downstream runtimes intact
- update the sensor integration suite and documentation (SEC, DD, TDD) to describe the new pipeline sequence and Pattern D behaviour
- record the sequencing change in the changelog for traceability

## Testing
- pnpm --filter @wb/engine exec vitest run tests/integration/pipeline/sensorActuatorPattern.integration.test.ts
- pnpm --filter @wb/engine exec vitest run tests/integration/pipeline/sensorReadings.integration.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dfa4a4ec548325bdd10d8a8a509481