### PR TITLE
Align multi-effect airflow fixtures with schema requirements

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### #55 WB-048 airflow schema coverage parity
+- Extended the device blueprint schema regression fixture to include the
+  explicit airflow effect block required by the SEC, keeping the multi-effect
+  validation aligned with runtime expectations.
+- Updated the multi-effect pipeline integration fixtures to supply matching
+  airflow configurations so ACH aggregation and logging continue to exercise
+  the enforced schema nuance.
+
 ### #54 WB-047 sensor sampling before environment integration
 - Reordered the Engine tick pipeline so `applySensors` executes immediately after
   `applyDeviceEffects`, capturing zone conditions before `updateEnvironment`

--- a/packages/engine/tests/integration/pipeline/multiEffectDevice.integration.test.ts
+++ b/packages/engine/tests/integration/pipeline/multiEffectDevice.integration.test.ts
@@ -42,7 +42,7 @@ const COOL_AIR_DEHUMIDIFIER_BLUEPRINT: DeviceBlueprint = {
   effects: ['thermal', 'humidity', 'airflow'],
   thermal: { mode: 'cool', max_cool_W: 3_000 },
   humidity: { mode: 'dehumidify', capacity_g_per_h: 500 },
-  airflow: { mode: 'circulate' }
+  airflow: { mode: 'circulate', airflow_m3_per_h: 350 }
 };
 
 const RESISTIVE_HEATER_BLUEPRINT: DeviceBlueprint = {
@@ -104,7 +104,7 @@ const PATTERN_A_SPLIT_AC_BLUEPRINT: DeviceBlueprint = {
   effects: ['thermal', 'humidity', 'airflow'],
   thermal: { mode: 'cool', max_cool_W: 3_000 },
   humidity: { mode: 'dehumidify', capacity_g_per_h: 500 },
-  airflow: { mode: 'circulate' }
+  airflow: { mode: 'circulate', airflow_m3_per_h: 350 }
 };
 
 const PATTERN_B_REHEAT_BLUEPRINT: DeviceBlueprint = {
@@ -179,7 +179,8 @@ describe('Tick pipeline — multi-effect devices', () => {
       effects: ['thermal', 'humidity', 'airflow'],
       effectConfigs: {
         thermal: { mode: 'cool', max_cool_W: 3_000 },
-        humidity: { mode: 'dehumidify', capacity_g_per_h: 500 }
+        humidity: { mode: 'dehumidify', capacity_g_per_h: 500 },
+        airflow: { mode: 'circulate', airflow_m3_per_h: 350 }
       }
     } satisfies ZoneDeviceInstance;
 
@@ -382,7 +383,8 @@ describe('Tick pipeline — multi-effect devices', () => {
       effects: ['thermal', 'humidity', 'airflow'],
       effectConfigs: {
         thermal: { mode: 'cool', max_cool_W: 3_000 },
-        humidity: { mode: 'dehumidify', capacity_g_per_h: 500 }
+        humidity: { mode: 'dehumidify', capacity_g_per_h: 500 },
+        airflow: { mode: 'circulate', airflow_m3_per_h: 350 }
       }
     } satisfies ZoneDeviceInstance;
 

--- a/packages/engine/tests/unit/domain/deviceBlueprintSchema.test.ts
+++ b/packages/engine/tests/unit/domain/deviceBlueprintSchema.test.ts
@@ -161,6 +161,7 @@ describe('deviceBlueprintSchema', () => {
       effects: ['thermal', 'humidity', 'airflow'],
       thermal: { mode: 'cool', max_cool_W: 3_000 },
       humidity: { mode: 'dehumidify', capacity_g_per_h: 600 },
+      airflow: { mode: 'recirculation', airflow_m3_per_h: 300 },
       coverage: { maxArea_m2: 25 },
       limits: { coolingCapacity_kW: 3 },
       settings: {


### PR DESCRIPTION
## Summary
- add the required airflow effect block to the multi-effect device blueprint schema fixture
- mirror the airflow configuration on multi-effect integration fixtures so runtime coverage exercises ACH expectations
- document the enforced airflow schema nuance in the changelog

## Testing
- pnpm --filter @wb/engine test -- deviceBlueprintSchema multiEffectDevice *(fails: vitest not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfa5fedb00832587521ca47946b897