### PR TITLE
Fix photoperiod accumulated light test expectation

### DIFF
--- a/packages/engine/tests/unit/util/photoperiod.test.ts
+++ b/packages/engine/tests/unit/util/photoperiod.test.ts
@@ -93,8 +93,8 @@ describe('photoperiod utilities', () => {
     });
 
     it('calculates light hours with partial day remainder', () => {
-      const light = schedule({ onHours: 12, startHour: 6 });
-      expect(calculateAccumulatedLightHours(30, light)).toBeCloseTo(18, 5);
+        const light = schedule({ onHours: 12, startHour: 6 });
+        expect(calculateAccumulatedLightHours(30, light)).toBeCloseTo(12, 5);
     });
 
     it('handles midnight overflow schedules', () => {


### PR DESCRIPTION
## Summary
- correct the photoperiod accumulated light unit test to expect 12 hours for a 30-hour plant age with a 6-18 light schedule

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0b2dcb3508325b240518d345679b5