### PR TITLE
Fix strain blueprint fixture path resolution in unit tests

### DIFF
--- a/packages/engine/tests/unit/domain/strainBlueprintSchema.test.ts
+++ b/packages/engine/tests/unit/domain/strainBlueprintSchema.test.ts
@@ -1,13 +1,14 @@
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
 import { parseStrainBlueprint } from '../../../src/backend/src/domain/blueprints/strainBlueprint.js';
 import { BlueprintClassMismatchError } from '../../../src/backend/src/domain/blueprints/taxonomy.js';
 
-const fixturePath = path.resolve(
-  'data/blueprints/strain/hybrid/balanced/white_widow.json'
+const fixturePath = fileURLToPath(
+  new URL('../../../../../data/blueprints/strain/hybrid/balanced/white_widow.json', import.meta.url)
 );
 const fixturePayload = JSON.parse(readFileSync(fixturePath, 'utf8'));
 


### PR DESCRIPTION
## Summary
- update the strain blueprint schema unit test to resolve the fixture JSON relative to the test file
- load the strain fixture using `fileURLToPath` so the test works regardless of the working directory

## Testing
- pnpm --filter @wb/engine test *(fails: existing assertions against strain blueprint fixture and diagnostics expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68e0b4468a80832580fd6d4c6ae6ad8f