### PR TITLE
fix: update JSON imports for Node 22 compatibility

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,5 +1,5 @@
-import difficultyConfig from '../../../data/configs/difficulty.json' assert { type: 'json' };
-import utilityPrices from '../../../data/prices/utilityPrices.json' assert { type: 'json' };
+import difficultyConfig from '../../../data/configs/difficulty.json' with { type: 'json' };
+import utilityPrices from '../../../data/prices/utilityPrices.json' with { type: 'json' };
 
 import {
   resolveTariffs,

--- a/packages/engine/tests/unit/domain/cultivationIrrigationCompatibility.test.ts
+++ b/packages/engine/tests/unit/domain/cultivationIrrigationCompatibility.test.ts
@@ -3,16 +3,16 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-import dripInline from '../../../../../data/blueprints/irrigation/drip/inline-fertigation/drip-inline-fertigation-basic.json' assert { type: 'json' };
-import ebbFlow from '../../../../../data/blueprints/irrigation/ebb-flow/table/ebb-flow-table-small.json' assert { type: 'json' };
-import manualCan from '../../../../../data/blueprints/irrigation/manual/can/manual-watering-can.json' assert { type: 'json' };
-import topFeed from '../../../../../data/blueprints/irrigation/top-feed/timer/top-feed-pump-timer.json' assert { type: 'json' };
-import cocoCoir from '../../../../../data/blueprints/substrate/coco/coir/coco-coir.json' assert { type: 'json' };
-import soilMulti from '../../../../../data/blueprints/substrate/soil/multi-cycle/soil-multi-cycle.json' assert { type: 'json' };
-import soilSingle from '../../../../../data/blueprints/substrate/soil/single-cycle/soil-single-cycle.json' assert { type: 'json' };
-import basicSoilPot from '../../../../../data/blueprints/cultivation-method/soil/basic-pot/basic-soil-pot.json' assert { type: 'json' };
-import scrog from '../../../../../data/blueprints/cultivation-method/training/scrog/screen-of-green.json' assert { type: 'json' };
-import sog from '../../../../../data/blueprints/cultivation-method/training/sog/sea-of-green.json' assert { type: 'json' };
+import dripInline from '../../../../../data/blueprints/irrigation/drip/inline-fertigation/drip-inline-fertigation-basic.json' with { type: 'json' };
+import ebbFlow from '../../../../../data/blueprints/irrigation/ebb-flow/table/ebb-flow-table-small.json' with { type: 'json' };
+import manualCan from '../../../../../data/blueprints/irrigation/manual/can/manual-watering-can.json' with { type: 'json' };
+import topFeed from '../../../../../data/blueprints/irrigation/top-feed/timer/top-feed-pump-timer.json' with { type: 'json' };
+import cocoCoir from '../../../../../data/blueprints/substrate/coco/coir/coco-coir.json' with { type: 'json' };
+import soilMulti from '../../../../../data/blueprints/substrate/soil/multi-cycle/soil-multi-cycle.json' with { type: 'json' };
+import soilSingle from '../../../../../data/blueprints/substrate/soil/single-cycle/soil-single-cycle.json' with { type: 'json' };
+import basicSoilPot from '../../../../../data/blueprints/cultivation-method/soil/basic-pot/basic-soil-pot.json' with { type: 'json' };
+import scrog from '../../../../../data/blueprints/cultivation-method/training/scrog/screen-of-green.json' with { type: 'json' };
+import sog from '../../../../../data/blueprints/cultivation-method/training/sog/sea-of-green.json' with { type: 'json' };
 
 import { parseIrrigationBlueprint, type IrrigationBlueprint } from '@/backend/src/domain/world.js';
 

--- a/packages/engine/tests/unit/domain/deviceBlueprintSchema.test.ts
+++ b/packages/engine/tests/unit/domain/deviceBlueprintSchema.test.ts
@@ -9,12 +9,12 @@ import {
   toDeviceInstanceCapacity
 } from '@/backend/src/domain/world.js';
 
-import climateUnit from '../../../../../data/blueprints/device/climate/cooling/cool-air-split-3000.json' assert { type: 'json' };
-import co2Injector from '../../../../../data/blueprints/device/climate/co2/co2-pulse.json' assert { type: 'json' };
-import dehumidifier from '../../../../../data/blueprints/device/climate/dehumidifier/drybox-200.json' assert { type: 'json' };
-import exhaustFan from '../../../../../data/blueprints/device/airflow/exhaust/exhaust-fan-4-inch.json' assert { type: 'json' };
-import humidityControl from '../../../../../data/blueprints/device/climate/humidity-controller/humidity-control-unit-l1.json' assert { type: 'json' };
-import vegLight from '../../../../../data/blueprints/device/lighting/vegetative/led-veg-light-600.json' assert { type: 'json' };
+import climateUnit from '../../../../../data/blueprints/device/climate/cooling/cool-air-split-3000.json' with { type: 'json' };
+import co2Injector from '../../../../../data/blueprints/device/climate/co2/co2-pulse.json' with { type: 'json' };
+import dehumidifier from '../../../../../data/blueprints/device/climate/dehumidifier/drybox-200.json' with { type: 'json' };
+import exhaustFan from '../../../../../data/blueprints/device/airflow/exhaust/exhaust-fan-4-inch.json' with { type: 'json' };
+import humidityControl from '../../../../../data/blueprints/device/climate/humidity-controller/humidity-control-unit-l1.json' with { type: 'json' };
+import vegLight from '../../../../../data/blueprints/device/lighting/vegetative/led-veg-light-600.json' with { type: 'json' };
 
 const climateUnitPath = fileURLToPath(
   new URL('../../../../../data/blueprints/device/climate/cooling/cool-air-split-3000.json', import.meta.url)

--- a/packages/engine/tests/unit/domain/devicePriceMapSchema.test.ts
+++ b/packages/engine/tests/unit/domain/devicePriceMapSchema.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { devicePriceMapSchema, parseDevicePriceMap } from '@/backend/src/domain/world.js';
 
-import devicePriceMap from '../../../../../data/prices/devicePrices.json' assert { type: 'json' };
+import devicePriceMap from '../../../../../data/prices/devicePrices.json' with { type: 'json' };
 
 describe('devicePriceMapSchema', () => {
   it('parses repository device price map', () => {

--- a/packages/engine/tests/unit/domain/irrigationBlueprintSchema.test.ts
+++ b/packages/engine/tests/unit/domain/irrigationBlueprintSchema.test.ts
@@ -3,13 +3,13 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-import dripInline from '../../../../../data/blueprints/irrigation/drip/inline-fertigation/drip-inline-fertigation-basic.json' assert { type: 'json' };
-import ebbFlow from '../../../../../data/blueprints/irrigation/ebb-flow/table/ebb-flow-table-small.json' assert { type: 'json' };
-import manualCan from '../../../../../data/blueprints/irrigation/manual/can/manual-watering-can.json' assert { type: 'json' };
-import topFeed from '../../../../../data/blueprints/irrigation/top-feed/timer/top-feed-pump-timer.json' assert { type: 'json' };
-import cocoCoir from '../../../../../data/blueprints/substrate/coco/coir/coco-coir.json' assert { type: 'json' };
-import soilMulti from '../../../../../data/blueprints/substrate/soil/multi-cycle/soil-multi-cycle.json' assert { type: 'json' };
-import soilSingle from '../../../../../data/blueprints/substrate/soil/single-cycle/soil-single-cycle.json' assert { type: 'json' };
+import dripInline from '../../../../../data/blueprints/irrigation/drip/inline-fertigation/drip-inline-fertigation-basic.json' with { type: 'json' };
+import ebbFlow from '../../../../../data/blueprints/irrigation/ebb-flow/table/ebb-flow-table-small.json' with { type: 'json' };
+import manualCan from '../../../../../data/blueprints/irrigation/manual/can/manual-watering-can.json' with { type: 'json' };
+import topFeed from '../../../../../data/blueprints/irrigation/top-feed/timer/top-feed-pump-timer.json' with { type: 'json' };
+import cocoCoir from '../../../../../data/blueprints/substrate/coco/coir/coco-coir.json' with { type: 'json' };
+import soilMulti from '../../../../../data/blueprints/substrate/soil/multi-cycle/soil-multi-cycle.json' with { type: 'json' };
+import soilSingle from '../../../../../data/blueprints/substrate/soil/single-cycle/soil-single-cycle.json' with { type: 'json' };
 
 import { parseIrrigationBlueprint } from '@/backend/src/domain/world.js';
 

--- a/packages/engine/tests/unit/domain/substrateBlueprintSchema.test.ts
+++ b/packages/engine/tests/unit/domain/substrateBlueprintSchema.test.ts
@@ -10,9 +10,9 @@ import {
   substrateBlueprintSchema
 } from '@/backend/src/domain/world.js';
 
-import cocoCoir from '../../../../../data/blueprints/substrate/coco/coir/coco-coir.json' assert { type: 'json' };
-import soilMulti from '../../../../../data/blueprints/substrate/soil/multi-cycle/soil-multi-cycle.json' assert { type: 'json' };
-import soilSingle from '../../../../../data/blueprints/substrate/soil/single-cycle/soil-single-cycle.json' assert { type: 'json' };
+import cocoCoir from '../../../../../data/blueprints/substrate/coco/coir/coco-coir.json' with { type: 'json' };
+import soilMulti from '../../../../../data/blueprints/substrate/soil/multi-cycle/soil-multi-cycle.json' with { type: 'json' };
+import soilSingle from '../../../../../data/blueprints/substrate/soil/single-cycle/soil-single-cycle.json' with { type: 'json' };
 
 const cocoCoirPath = fileURLToPath(
   new URL('../../../../../data/blueprints/substrate/coco/coir/coco-coir.json', import.meta.url)


### PR DESCRIPTION
## Summary
- replace deprecated `assert { type: 'json' }` syntax with `with { type: 'json' }` for engine configuration imports
- update engine domain unit tests to use the Node.js 22 JSON import assertion syntax

## Testing
- pnpm test *(fails: `vitest run` spawn ENOENT because workspace dependencies are not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0d1d2166883259c1813889c0a58f4