### PR TITLE
chore: align Node.js engines with v22

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "packageManager": "pnpm@10.18.0+sha512.e804f889f1cecc40d572db084eec3e4881739f8dec69c0ff10d2d1beff9a4e309383ba27b5b750059d7f4c149535b6cd0d2cb1ed3aeb739239a4284a68f40cfa",
   "engines": {
-    "node": ">=23.0.0",
+    "node": ">=22.0.0",
     "pnpm": ">=10.17.1"
   },
   "scripts": {

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -15,7 +15,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "engines": {
-    "node": ">=23.0.0"
+    "node": ">=22.0.0"
   },
   "dependencies": {
     "zod": "3.24.0"

--- a/packages/facade/package.json
+++ b/packages/facade/package.json
@@ -15,6 +15,6 @@
     "dev": "tsx watch src/index.ts"
   },
   "engines": {
-    "node": ">=23.0.0"
+    "node": ">=22.0.0"
   }
 }

--- a/packages/tools-monitor/package.json
+++ b/packages/tools-monitor/package.json
@@ -13,6 +13,6 @@
     "dev": "tsx watch src/index.ts"
   },
   "engines": {
-    "node": ">=23.0.0"
+    "node": ">=22.0.0"
   }
 }

--- a/packages/transport-sio/package.json
+++ b/packages/transport-sio/package.json
@@ -13,6 +13,6 @@
     "dev": "tsx watch src/index.ts"
   },
   "engines": {
-    "node": ">=23.0.0"
+    "node": ">=22.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- update all package manifests to require Node.js >=22.0.0 while leaving pnpm constraints unchanged

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0d28756c48325bb050e1df476941a