### PR TITLE
refactor: centralize helper utilities

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### #60 Utility consolidation for helper functions
+- Added shared numeric helpers (`clamp`, `clamp01`, `resolveTickHoursValue`) and
+  validation/environment utilities to eliminate divergent inline
+  implementations across stubs, pipeline stages, and domain services.
+- Updated device creation, physiology, and actuator stubs to consume the new
+  helpers while standardising tick duration, airflow, and fraction handling.
+- Introduced a reusable `deviceQuality` test helper and documented the helper
+  catalogue under `/docs/helper-functions.md` to prevent future duplication.
+
 ### #59 Tooling - Node version manager hints
 - Added `.nvmrc` and `.node-version` pointing to Node.js 22 so local environment managers auto-select the target runtime during the LTS migration dry run.
 - Captured the decision in ADR-0012 to document the transitional alignment between local tooling and CI-enforced Node.js 23.

--- a/docs/helper-functions.md
+++ b/docs/helper-functions.md
@@ -1,0 +1,29 @@
+# Helper Function Registry
+
+This catalogue lists the shared helper modules that replace previously duplicated
+implementations. Use these utilities instead of introducing local variants to
+keep behaviour consistent across the engine and tests.
+
+## Backend utilities
+
+- `packages/engine/src/backend/src/util/math.ts`
+  - `clamp(value, min, max)` — bounds values while handling infinities safely.
+  - `clamp01(value)` — clamps to the `[0,1]` interval.
+- `packages/engine/src/backend/src/util/validation.ts`
+  - `assertPositiveFinite(value, name)` — asserts a value is finite and `> 0`.
+  - `assertNonNegativeFinite(value, name)` — asserts a value is finite and `>= 0`.
+  - `ensureFraction01(value, fallback, name)` — validates optional fractions in `[0,1]`.
+- `packages/engine/src/backend/src/util/environment.ts`
+  - `resolveAirflow(value)` — normalises airflow inputs to a non-negative flow.
+  - `resolveAirMassKg(value)` — normalises air mass values to a non-negative mass.
+- `packages/engine/src/backend/src/engine/resolveTickHours.ts`
+  - `resolveTickHoursValue(value)` — resolves tick durations with canonical fallbacks.
+
+## Test utilities
+
+- `packages/engine/tests/testUtils/deviceHelpers.ts`
+  - `deviceQuality(qualityPolicy, seed, id, blueprint)` — samples deterministic
+    device quality via `createDeviceInstance`.
+
+> ⚠️ If you need a new helper, add it to one of these modules (or extend this
+> list) rather than re-implementing ad-hoc versions.

--- a/packages/engine/src/backend/src/device/condition.ts
+++ b/packages/engine/src/backend/src/device/condition.ts
@@ -8,6 +8,8 @@
  * without rewriting call sites.
  */
 
+import { clamp01 } from '../util/math.js';
+
 const BASE_WEAR_RATE01 = 0.01;
 const QUALITY_WEAR_SLOPE = 0.5;
 
@@ -101,18 +103,6 @@ function determineRepairSuccess(
   }
 
   return successChance01 >= 0.5;
-}
-
-function clamp01(value: number): number {
-  if (value <= 0) {
-    return 0;
-  }
-
-  if (value >= 1) {
-    return 1;
-  }
-
-  return value;
 }
 
 function assertFinite(label: string, value: number): void {

--- a/packages/engine/src/backend/src/domain/cultivation/substrateUsage.ts
+++ b/packages/engine/src/backend/src/domain/cultivation/substrateUsage.ts
@@ -1,31 +1,6 @@
 import { convertSubstrateVolumeLToMassKg } from '../blueprints/substrateBlueprint.js';
 import type { SubstratePhysicalProfile } from '../blueprints/substrateBlueprint.js';
-
-function assertPositiveFinite(value: number, name: string): void {
-  if (!Number.isFinite(value)) {
-    throw new Error(`${name} must be a finite number.`);
-  }
-
-  if (value <= 0) {
-    throw new Error(`${name} must be greater than zero.`);
-  }
-}
-
-function clamp01(value: number | undefined, fallback: number, name: string): number {
-  if (value === undefined) {
-    return fallback;
-  }
-
-  if (!Number.isFinite(value)) {
-    throw new Error(`${name} must be a finite number.`);
-  }
-
-  if (value < 0 || value > 1) {
-    throw new Error(`${name} must lie within [0,1].`);
-  }
-
-  return value;
-}
+import { assertPositiveFinite, ensureFraction01 } from '../../util/validation.js';
 
 export interface ContainerFillProfile {
   readonly substrate: SubstratePhysicalProfile;
@@ -39,7 +14,7 @@ export interface PlantingBatchProfile extends ContainerFillProfile {
 
 export function estimateSubstrateMassPerContainer(profile: ContainerFillProfile): number {
   assertPositiveFinite(profile.containerVolume_L, 'containerVolume_L');
-  const fillFraction = clamp01(profile.fillFraction01, 1, 'fillFraction01');
+  const fillFraction = ensureFraction01(profile.fillFraction01, 1, 'fillFraction01');
   const filledVolume_L = profile.containerVolume_L * fillFraction;
 
   return convertSubstrateVolumeLToMassKg(profile.substrate, filledVolume_L);

--- a/packages/engine/src/backend/src/domain/irrigation/waterUsage.ts
+++ b/packages/engine/src/backend/src/domain/irrigation/waterUsage.ts
@@ -1,41 +1,10 @@
 import { convertSubstrateVolumeLToMassKg } from '../blueprints/substrateBlueprint.js';
 import type { SubstratePhysicalProfile } from '../blueprints/substrateBlueprint.js';
-
-function assertPositiveFinite(value: number, name: string): void {
-  if (!Number.isFinite(value)) {
-    throw new Error(`${name} must be a finite number.`);
-  }
-
-  if (value <= 0) {
-    throw new Error(`${name} must be greater than zero.`);
-  }
-}
-
-function assertNonNegativeFinite(value: number, name: string): void {
-  if (!Number.isFinite(value)) {
-    throw new Error(`${name} must be a finite number.`);
-  }
-
-  if (value < 0) {
-    throw new Error(`${name} must be greater than or equal to zero.`);
-  }
-}
-
-function clamp01(value: number | undefined, fallback: number, name: string): number {
-  if (value === undefined) {
-    return fallback;
-  }
-
-  if (!Number.isFinite(value)) {
-    throw new Error(`${name} must be a finite number.`);
-  }
-
-  if (value < 0 || value > 1) {
-    throw new Error(`${name} must lie within [0,1].`);
-  }
-
-  return value;
-}
+import {
+  assertPositiveFinite,
+  assertNonNegativeFinite,
+  ensureFraction01
+} from '../../util/validation.js';
 
 export interface IrrigationChargeInput {
   readonly substrate: SubstratePhysicalProfile;
@@ -58,13 +27,13 @@ export function estimateIrrigationCharge(input: IrrigationChargeInput): Irrigati
   assertPositiveFinite(input.containerVolume_L, 'containerVolume_L');
   assertNonNegativeFinite(input.plantCount, 'plantCount');
 
-  const moistureFraction = clamp01(
+  const moistureFraction = ensureFraction01(
     input.targetMoistureFraction01,
     input.targetMoistureFraction01,
     'targetMoistureFraction01'
   );
-  const fillFraction = clamp01(input.fillFraction01, 1, 'fillFraction01');
-  const runoffFraction = clamp01(input.runoffFraction01, 0, 'runoffFraction01');
+  const fillFraction = ensureFraction01(input.fillFraction01, 1, 'fillFraction01');
+  const runoffFraction = ensureFraction01(input.runoffFraction01, 0, 'runoffFraction01');
 
   if (runoffFraction >= 1) {
     throw new Error('runoffFraction01 must be less than 1.');

--- a/packages/engine/src/backend/src/engine/pipeline/advancePhysiology.ts
+++ b/packages/engine/src/backend/src/engine/pipeline/advancePhysiology.ts
@@ -21,6 +21,7 @@ import {
   shouldTransitionToVegetative
 } from '../../util/photoperiod.js';
 import { resolveTickHours } from '../resolveTickHours.js';
+import { clamp01 } from '../../util/math.js';
 
 interface PhysiologyRuntime {
   readonly strainBlueprints: Map<Uuid, StrainBlueprint>;
@@ -38,22 +39,6 @@ function getOrLoadStrainBlueprint(
 
   // TODO: Load strain blueprint definitions from the filesystem (separate task).
   return null;
-}
-
-function clamp01(value: number): number {
-  if (!Number.isFinite(value)) {
-    return 0;
-  }
-
-  if (value <= 0) {
-    return 0;
-  }
-
-  if (value >= 1) {
-    return 1;
-  }
-
-  return value;
 }
 
 function hasNumericChange(previous: number, next: number): boolean {

--- a/packages/engine/src/backend/src/engine/pipeline/applyDeviceEffects.ts
+++ b/packages/engine/src/backend/src/engine/pipeline/applyDeviceEffects.ts
@@ -22,6 +22,7 @@ import {
 } from '../../stubs/index.js';
 import type { EngineDiagnostic, EngineRunContext } from '../Engine.js';
 import { resolveTickHours } from '../resolveTickHours.js';
+import { clamp01 } from '../../util/math.js';
 
 export interface DeviceEffectsRuntime {
   readonly zoneTemperatureDeltaC: Map<Zone['id'], number>;
@@ -79,22 +80,6 @@ export function getDeviceEffectsRuntime(
 
 export function clearDeviceEffectsRuntime(ctx: EngineRunContext): void {
   delete (ctx as DeviceEffectsCarrier)[DEVICE_EFFECTS_CONTEXT_KEY];
-}
-
-function clamp01(value: number): number {
-  if (!Number.isFinite(value)) {
-    return 0;
-  }
-
-  if (value <= 0) {
-    return 0;
-  }
-
-  if (value >= 1) {
-    return 1;
-  }
-
-  return value;
 }
 
 function accumulateTemperatureDelta(

--- a/packages/engine/src/backend/src/engine/resolveTickHours.ts
+++ b/packages/engine/src/backend/src/engine/resolveTickHours.ts
@@ -5,14 +5,18 @@ function isPositiveFinite(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value) && value > 0;
 }
 
+export function resolveTickHoursValue(value: unknown): number {
+  if (isPositiveFinite(value)) {
+    return value;
+  }
+
+  return HOURS_PER_TICK;
+}
+
 export function resolveTickHours(ctx: EngineRunContext): number {
   const candidate =
     (ctx as { tickDurationHours?: unknown }).tickDurationHours ??
     (ctx as { tickHours?: unknown }).tickHours;
 
-  if (isPositiveFinite(candidate)) {
-    return candidate;
-  }
-
-  return HOURS_PER_TICK;
+  return resolveTickHoursValue(candidate);
 }

--- a/packages/engine/src/backend/src/engine/thermo/heat.ts
+++ b/packages/engine/src/backend/src/engine/thermo/heat.ts
@@ -4,42 +4,9 @@ import {
   SECONDS_PER_HOUR
 } from '../../constants/simConstants.js';
 import type { Zone, ZoneDeviceInstance } from '../../domain/world.js';
-
-function clamp01(value: number): number {
-  if (!Number.isFinite(value)) {
-    return 0;
-  }
-
-  if (value <= 0) {
-    return 0;
-  }
-
-  if (value >= 1) {
-    return 1;
-  }
-
-  return value;
-}
-
-function resolveTickHours(tickHours: number | undefined): number {
-  if (typeof tickHours !== 'number') {
-    return HOURS_PER_TICK;
-  }
-
-  if (!Number.isFinite(tickHours) || tickHours <= 0) {
-    return HOURS_PER_TICK;
-  }
-
-  return tickHours;
-}
-
-function resolveAirMassKg(zone: Pick<Zone, 'airMass_kg'>): number {
-  if (!Number.isFinite(zone.airMass_kg) || zone.airMass_kg <= 0) {
-    return 0;
-  }
-
-  return zone.airMass_kg;
-}
+import { clamp01 } from '../../util/math.js';
+import { resolveAirMassKg } from '../../util/environment.js';
+import { resolveTickHoursValue } from '../resolveTickHours.js';
 
 /**
  * @deprecated Heating-only implementation (waste heat).
@@ -73,13 +40,13 @@ export function applyDeviceHeat(
 
   const duty = clamp01(device.dutyCycle01);
   const powerDraw_W = Math.max(0, device.powerDraw_W);
-  const resolvedTickHours = resolveTickHours(tickHours);
+  const resolvedTickHours = resolveTickHoursValue(tickHours);
 
   if (duty === 0 || powerDraw_W === 0 || resolvedTickHours === 0) {
     return 0;
   }
 
-  const airMassKg = resolveAirMassKg(zone);
+  const airMassKg = resolveAirMassKg(zone.airMass_kg);
 
   if (airMassKg === 0) {
     return 0;

--- a/packages/engine/src/backend/src/stubs/AirflowActuatorStub.ts
+++ b/packages/engine/src/backend/src/stubs/AirflowActuatorStub.ts
@@ -1,9 +1,11 @@
-import { HOURS_PER_TICK } from '../constants/simConstants.js';
 import type {
   AirflowActuatorInputs,
   AirflowActuatorOutputs,
   IAirflowActuator
 } from '../domain/interfaces/IAirflowActuator.js';
+import { clamp01 } from '../util/math.js';
+import { resolveAirflow } from '../util/environment.js';
+import { resolveTickHoursValue } from '../engine/resolveTickHours.js';
 
 const ZERO_OUTPUT: AirflowActuatorOutputs = {
   effective_airflow_m3_per_h: 0,
@@ -11,30 +13,6 @@ const ZERO_OUTPUT: AirflowActuatorOutputs = {
   pressure_loss_pa: 0,
   energy_Wh: undefined
 };
-
-function clamp01(value: number): number {
-  if (!Number.isFinite(value)) {
-    return 0;
-  }
-
-  if (value <= 0) {
-    return 0;
-  }
-
-  if (value >= 1) {
-    return 1;
-  }
-
-  return value;
-}
-
-function resolveAirflow(value: number): number {
-  if (!Number.isFinite(value) || value <= 0) {
-    return 0;
-  }
-
-  return value;
-}
 
 function resolveVolume(value: number): number {
   if (!Number.isFinite(value) || value <= 0) {
@@ -62,8 +40,7 @@ export function createAirflowActuatorStub(): IAirflowActuator {
       const dutyCycle01 = clamp01(inputs.dutyCycle01);
       const airflow_m3_per_h = resolveAirflow(inputs.airflow_m3_per_h);
       const resolvedVolume_m3 = resolveVolume(zoneVolume_m3);
-      const resolvedDt_h =
-        typeof dt_h === 'number' && Number.isFinite(dt_h) ? dt_h : HOURS_PER_TICK;
+      const resolvedDt_h = resolveTickHoursValue(dt_h);
 
       if (resolvedVolume_m3 <= 0 || resolvedDt_h <= 0 || airflow_m3_per_h === 0 || dutyCycle01 === 0) {
         return ZERO_OUTPUT;

--- a/packages/engine/src/backend/src/stubs/FiltrationStub.ts
+++ b/packages/engine/src/backend/src/stubs/FiltrationStub.ts
@@ -3,30 +3,8 @@ import type {
   FiltrationUnitOutputs,
   IFiltrationUnit
 } from '../domain/interfaces/IFiltrationUnit.js';
-
-function clamp01(value: number): number {
-  if (!Number.isFinite(value)) {
-    return 0;
-  }
-
-  if (value <= 0) {
-    return 0;
-  }
-
-  if (value >= 1) {
-    return 1;
-  }
-
-  return value;
-}
-
-function resolveAirflow(value: number): number {
-  if (!Number.isFinite(value) || value <= 0) {
-    return 0;
-  }
-
-  return value;
-}
+import { clamp01 } from '../util/math.js';
+import { resolveAirflow } from '../util/environment.js';
 
 function resolveBasePressureDrop(value: number): number {
   if (!Number.isFinite(value) || value <= 0) {

--- a/packages/engine/src/backend/src/stubs/HumidityActuatorStub.ts
+++ b/packages/engine/src/backend/src/stubs/HumidityActuatorStub.ts
@@ -1,46 +1,12 @@
-import { HOURS_PER_TICK } from '../constants/simConstants.js';
 import type {
   HumidityActuatorInputs,
   HumidityActuatorOutputs,
   IHumidityActuator
 } from '../domain/interfaces/IHumidityActuator.js';
 import type { ZoneEnvironment } from '../domain/entities.js';
-
-function clamp(value: number, min: number, max: number): number {
-  if (!Number.isFinite(value)) {
-    return min;
-  }
-
-  if (value < min) {
-    return min;
-  }
-
-  if (value > max) {
-    return max;
-  }
-
-  return value;
-}
-
-function resolveTickHours(tickHours: number | undefined): number {
-  if (typeof tickHours !== 'number') {
-    return HOURS_PER_TICK;
-  }
-
-  if (!Number.isFinite(tickHours) || tickHours <= 0) {
-    return HOURS_PER_TICK;
-  }
-
-  return tickHours;
-}
-
-function resolveAirMassKg(airMass_kg: number): number {
-  if (!Number.isFinite(airMass_kg) || airMass_kg <= 0) {
-    return 0;
-  }
-
-  return airMass_kg;
-}
+import { clamp } from '../util/math.js';
+import { resolveAirMassKg } from '../util/environment.js';
+import { resolveTickHoursValue } from '../engine/resolveTickHours.js';
 
 function ensureFiniteOutputs(
   outputs: HumidityActuatorOutputs
@@ -143,7 +109,7 @@ export function createHumidityActuatorStub(): IHumidityActuator {
         return { deltaRH_pct: 0, water_g: 0, energy_Wh: 0 };
       }
 
-      const resolvedDt_h = resolveTickHours(dt_h);
+      const resolvedDt_h = resolveTickHoursValue(dt_h);
       const resolvedAirMass = resolveAirMassKg(airMass_kg);
 
       if (resolvedDt_h === 0 || resolvedAirMass === 0) {

--- a/packages/engine/src/backend/src/stubs/IrrigationServiceStub.ts
+++ b/packages/engine/src/backend/src/stubs/IrrigationServiceStub.ts
@@ -1,4 +1,3 @@
-import { HOURS_PER_TICK } from '../constants/simConstants.js';
 import type {
   IIrrigationService,
   IrrigationEvent,
@@ -9,34 +8,8 @@ import type {
   INutrientBuffer,
   NutrientBufferInputs,
 } from '../domain/interfaces/INutrientBuffer.js';
-
-function clamp(value: number, min: number, max: number): number {
-  if (!Number.isFinite(value)) {
-    return min;
-  }
-
-  if (value < min) {
-    return min;
-  }
-
-  if (value > max) {
-    return max;
-  }
-
-  return value;
-}
-
-function resolveTickHours(tickHours: number | undefined): number {
-  if (typeof tickHours !== 'number') {
-    return HOURS_PER_TICK;
-  }
-
-  if (!Number.isFinite(tickHours) || tickHours <= 0) {
-    return HOURS_PER_TICK;
-  }
-
-  return tickHours;
-}
+import { clamp } from '../util/math.js';
+import { resolveTickHoursValue } from '../engine/resolveTickHours.js';
 
 function multiplyNutrientRecord(
   record: Record<string, number>,
@@ -160,7 +133,7 @@ export function createIrrigationServiceStub(
         return zeroOutputs();
       }
 
-      const resolvedDt_h = resolveTickHours(dt_h);
+      const resolvedDt_h = resolveTickHoursValue(dt_h);
 
       if (!Number.isFinite(resolvedDt_h) || resolvedDt_h <= 0) {
         return zeroOutputs();

--- a/packages/engine/src/backend/src/stubs/LightEmitterStub.ts
+++ b/packages/engine/src/backend/src/stubs/LightEmitterStub.ts
@@ -1,41 +1,11 @@
-import { HOURS_PER_TICK, SECONDS_PER_HOUR } from '../constants/simConstants.js';
+import { SECONDS_PER_HOUR } from '../constants/simConstants.js';
 import type {
   ILightEmitter,
   LightEmitterInputs,
   LightEmitterOutputs
 } from '../domain/interfaces/ILightEmitter.js';
-
-function clamp(value: number, min: number, max: number): number {
-  if (!Number.isFinite(value)) {
-    return min;
-  }
-
-  if (value < min) {
-    return min;
-  }
-
-  if (value > max) {
-    return max;
-  }
-
-  return value;
-}
-
-function clamp01(value: number): number {
-  return clamp(value, 0, 1);
-}
-
-function resolveTickHours(tickHours: number | undefined): number {
-  if (typeof tickHours !== 'number') {
-    return HOURS_PER_TICK;
-  }
-
-  if (!Number.isFinite(tickHours) || tickHours <= 0) {
-    return HOURS_PER_TICK;
-  }
-
-  return tickHours;
-}
+import { clamp, clamp01 } from '../util/math.js';
+import { resolveTickHoursValue } from '../engine/resolveTickHours.js';
 
 function ensureFiniteOutputs(outputs: LightEmitterOutputs): LightEmitterOutputs {
   const { ppfd_effective_umol_m2s, dli_mol_m2d_inc, energy_Wh } = outputs;
@@ -108,7 +78,7 @@ export function createLightEmitterStub(): ILightEmitter {
         return zeroEffect();
       }
 
-      const resolvedDt_h = resolveTickHours(dt_h);
+      const resolvedDt_h = resolveTickHoursValue(dt_h);
 
       if (resolvedDt_h === 0 || coverage_m2 === 0 || ppfd_center_umol_m2s === 0) {
         return zeroEffect();

--- a/packages/engine/src/backend/src/stubs/NutrientBufferStub.ts
+++ b/packages/engine/src/backend/src/stubs/NutrientBufferStub.ts
@@ -1,37 +1,10 @@
-import { HOURS_PER_TICK } from '../constants/simConstants.js';
 import type {
   INutrientBuffer,
   NutrientBufferInputs,
   NutrientBufferOutputs,
 } from '../domain/interfaces/INutrientBuffer.js';
-
-function clamp(value: number, min: number, max: number): number {
-  if (!Number.isFinite(value)) {
-    return min;
-  }
-
-  if (value < min) {
-    return min;
-  }
-
-  if (value > max) {
-    return max;
-  }
-
-  return value;
-}
-
-function resolveTickHours(tickHours: number | undefined): number {
-  if (typeof tickHours !== 'number') {
-    return HOURS_PER_TICK;
-  }
-
-  if (!Number.isFinite(tickHours) || tickHours <= 0) {
-    return HOURS_PER_TICK;
-  }
-
-  return tickHours;
-}
+import { clamp } from '../util/math.js';
+import { resolveTickHoursValue } from '../engine/resolveTickHours.js';
 
 function clampNutrientRecord(
   record: Record<string, number>,
@@ -105,7 +78,7 @@ export function createNutrientBufferStub(): INutrientBuffer {
         return zeroOutputs();
       }
 
-      const resolvedDt_h = resolveTickHours(dt_h);
+      const resolvedDt_h = resolveTickHoursValue(dt_h);
 
       if (!Number.isFinite(resolvedDt_h) || resolvedDt_h <= 0) {
         return zeroOutputs();

--- a/packages/engine/src/backend/src/stubs/SensorStub.ts
+++ b/packages/engine/src/backend/src/stubs/SensorStub.ts
@@ -1,18 +1,7 @@
 import type { ISensor, SensorInputs, SensorOutputs } from '../domain/interfaces/ISensor.js';
 import type { SensorMeasurementType } from '../domain/entities.js';
 import type { RandomNumberGenerator } from '../util/rng.js';
-
-function clamp(value: number, min: number, max: number): number {
-  if (value < min) {
-    return min;
-  }
-
-  if (value > max) {
-    return max;
-  }
-
-  return value;
-}
+import { clamp } from '../util/math.js';
 
 function boxMullerTransform(rng: RandomNumberGenerator): number {
   let u1 = 0;

--- a/packages/engine/src/backend/src/stubs/ThermalActuatorStub.ts
+++ b/packages/engine/src/backend/src/stubs/ThermalActuatorStub.ts
@@ -9,58 +9,9 @@ import type {
   ThermalActuatorOutputs
 } from '../domain/interfaces/IThermalActuator.js';
 import type { ZoneEnvironment } from '../domain/entities.js';
-
-function clamp01(value: number): number {
-  if (!Number.isFinite(value)) {
-    return 0;
-  }
-
-  if (value <= 0) {
-    return 0;
-  }
-
-  if (value >= 1) {
-    return 1;
-  }
-
-  return value;
-}
-
-function clamp(value: number, min: number, max: number): number {
-  if (!Number.isFinite(value)) {
-    return min;
-  }
-
-  if (value < min) {
-    return min;
-  }
-
-  if (value > max) {
-    return max;
-  }
-
-  return value;
-}
-
-function resolveTickHours(tickHours: number | undefined): number {
-  if (typeof tickHours !== 'number') {
-    return HOURS_PER_TICK;
-  }
-
-  if (!Number.isFinite(tickHours) || tickHours <= 0) {
-    return HOURS_PER_TICK;
-  }
-
-  return tickHours;
-}
-
-function resolveAirMassKg(airMass_kg: number): number {
-  if (!Number.isFinite(airMass_kg) || airMass_kg <= 0) {
-    return 0;
-  }
-
-  return airMass_kg;
-}
+import { clamp, clamp01 } from '../util/math.js';
+import { resolveAirMassKg } from '../util/environment.js';
+import { resolveTickHoursValue } from '../engine/resolveTickHours.js';
 
 function ensureFiniteOutputs(outputs: ThermalActuatorOutputs): ThermalActuatorOutputs {
   const { deltaT_K, energy_Wh, used_W } = outputs;
@@ -110,7 +61,7 @@ export function createThermalActuatorStub(): IThermalActuator {
         return { deltaT_K: 0, energy_Wh: 0, used_W: 0 };
       }
 
-      const resolvedDt_h = resolveTickHours(dt_h);
+      const resolvedDt_h = resolveTickHoursValue(dt_h);
       const resolvedAirMass = resolveAirMassKg(airMass_kg);
       const powerDraw_W = Math.max(0, inputs.power_W);
 

--- a/packages/engine/src/backend/src/util/environment.ts
+++ b/packages/engine/src/backend/src/util/environment.ts
@@ -1,0 +1,18 @@
+/**
+ * Environment-related numeric helpers.
+ */
+export function resolveAirflow(value: number | undefined): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+
+  return value;
+}
+
+export function resolveAirMassKg(value: number | undefined): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+
+  return value;
+}

--- a/packages/engine/src/backend/src/util/growth.ts
+++ b/packages/engine/src/backend/src/util/growth.ts
@@ -7,26 +7,7 @@ import type {
   StrainBlueprint
 } from '../domain/blueprints/strainBlueprint.js';
 import type { RandomNumberGenerator } from './rng.js';
-
-function clamp(value: number, min: number, max: number): number {
-  if (!Number.isFinite(value)) {
-    return min;
-  }
-
-  if (value <= min) {
-    return min;
-  }
-
-  if (value >= max) {
-    return max;
-  }
-
-  return value;
-}
-
-function clamp01(value: number): number {
-  return clamp(value, 0, 1);
-}
+import { clamp, clamp01 } from './math.js';
 
 const DEFAULT_DRY_MATTER_FRACTION = 0.2;
 const DEFAULT_HARVEST_INDEX = 0.7;

--- a/packages/engine/src/backend/src/util/math.ts
+++ b/packages/engine/src/backend/src/util/math.ts
@@ -1,0 +1,33 @@
+/**
+ * Numeric helper utilities shared across the simulation engine.
+ */
+export function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) {
+    if (value === Number.POSITIVE_INFINITY) {
+      return max === Number.POSITIVE_INFINITY ? value : max;
+    }
+
+    if (value === Number.NEGATIVE_INFINITY) {
+      return min === Number.NEGATIVE_INFINITY ? value : min;
+    }
+
+    return min;
+  }
+
+  if (value < min) {
+    return min;
+  }
+
+  if (value > max) {
+    return max;
+  }
+
+  return value;
+}
+
+/**
+ * Clamps a numeric value to the inclusive [0,1] interval.
+ */
+export function clamp01(value: number): number {
+  return clamp(value, 0, 1);
+}

--- a/packages/engine/src/backend/src/util/stress.ts
+++ b/packages/engine/src/backend/src/util/stress.ts
@@ -1,21 +1,6 @@
 import type { PlantLifecycleStage, ZoneEnvironment } from '../domain/entities.js';
 import type { EnvBand, StrainBlueprint } from '../domain/blueprints/strainBlueprint.js';
-
-function clamp01(value: number): number {
-  if (!Number.isFinite(value)) {
-    return 0;
-  }
-
-  if (value <= 0) {
-    return 0;
-  }
-
-  if (value >= 1) {
-    return 1;
-  }
-
-  return value;
-}
+import { clamp01 } from './math.js';
 
 function toStageEnvBand(
   strain: StrainBlueprint,

--- a/packages/engine/src/backend/src/util/validation.ts
+++ b/packages/engine/src/backend/src/util/validation.ts
@@ -1,0 +1,42 @@
+/**
+ * Runtime validation helpers for deterministic engine code.
+ */
+export function assertPositiveFinite(value: number, name: string): void {
+  if (!Number.isFinite(value)) {
+    throw new Error(`${name} must be a finite number.`);
+  }
+
+  if (value <= 0) {
+    throw new Error(`${name} must be greater than zero.`);
+  }
+}
+
+export function assertNonNegativeFinite(value: number, name: string): void {
+  if (!Number.isFinite(value)) {
+    throw new Error(`${name} must be a finite number.`);
+  }
+
+  if (value < 0) {
+    throw new Error(`${name} must be greater than or equal to zero.`);
+  }
+}
+
+export function ensureFraction01(
+  value: number | undefined,
+  fallback: number,
+  name: string
+): number {
+  if (value === undefined) {
+    return fallback;
+  }
+
+  if (!Number.isFinite(value)) {
+    throw new Error(`${name} must be a finite number.`);
+  }
+
+  if (value < 0 || value > 1) {
+    throw new Error(`${name} must lie within [0,1].`);
+  }
+
+  return value;
+}

--- a/packages/engine/tests/integration/pipeline/deviceThermals.integration.test.ts
+++ b/packages/engine/tests/integration/pipeline/deviceThermals.integration.test.ts
@@ -8,13 +8,9 @@ import {
 import type { EngineRunContext } from '@/backend/src/engine/Engine.js';
 import { runTick } from '@/backend/src/engine/Engine.js';
 import { createDemoWorld } from '@/backend/src/engine/testHarness.js';
-import {
-  createDeviceInstance,
-  type DeviceQualityPolicy,
-  type Uuid,
-  type ZoneDeviceInstance
-} from '@/backend/src/domain/world.js';
+import { type DeviceQualityPolicy, type Uuid, type ZoneDeviceInstance } from '@/backend/src/domain/world.js';
 import type { DeviceBlueprint } from '@/backend/src/domain/blueprints/deviceBlueprint.js';
+import { deviceQuality } from '../../testUtils/deviceHelpers.js';
 
 function uuid(value: string): Uuid {
   return value as Uuid;
@@ -52,10 +48,6 @@ const HVAC_BLUEPRINT: DeviceBlueprint = {
   airflow_m3_per_h: 0
 };
 
-function deviceQuality(id: Uuid, blueprint: DeviceBlueprint): number {
-  return createDeviceInstance(QUALITY_POLICY, WORLD_SEED, id, blueprint).quality01;
-}
-
 describe('Tick pipeline — device thermal effects', () => {
   it('integrates heat additions and HVAC removals across the first two stages', () => {
     const world = createDemoWorld();
@@ -71,7 +63,7 @@ describe('Tick pipeline — device thermal effects', () => {
       name: LIGHTING_BLUEPRINT.name,
       blueprintId: uuid(LIGHTING_BLUEPRINT.id),
       placementScope: 'zone',
-      quality01: deviceQuality(lightingDeviceId, LIGHTING_BLUEPRINT),
+      quality01: deviceQuality(QUALITY_POLICY, WORLD_SEED, lightingDeviceId, LIGHTING_BLUEPRINT),
       condition01: 0.94,
       powerDraw_W: 600,
       dutyCycle01: 1,
@@ -88,7 +80,7 @@ describe('Tick pipeline — device thermal effects', () => {
       name: HVAC_BLUEPRINT.name,
       blueprintId: uuid(HVAC_BLUEPRINT.id),
       placementScope: 'zone',
-      quality01: deviceQuality(hvacDeviceId, HVAC_BLUEPRINT),
+      quality01: deviceQuality(QUALITY_POLICY, WORLD_SEED, hvacDeviceId, HVAC_BLUEPRINT),
       condition01: 0.9,
       powerDraw_W: 800,
       dutyCycle01: 1,

--- a/packages/engine/tests/integration/pipeline/lightingEffects.integration.test.ts
+++ b/packages/engine/tests/integration/pipeline/lightingEffects.integration.test.ts
@@ -6,13 +6,9 @@ import {
 } from '@/backend/src/constants/simConstants.js';
 import { runTick } from '@/backend/src/engine/Engine.js';
 import { createDemoWorld } from '@/backend/src/engine/testHarness.js';
-import {
-  createDeviceInstance,
-  type DeviceQualityPolicy,
-  type Uuid,
-  type ZoneDeviceInstance
-} from '@/backend/src/domain/world.js';
+import { type DeviceQualityPolicy, type Uuid, type ZoneDeviceInstance } from '@/backend/src/domain/world.js';
 import type { DeviceBlueprint } from '@/backend/src/domain/blueprints/deviceBlueprint.js';
+import { deviceQuality } from '../../testUtils/deviceHelpers.js';
 
 function uuid(value: string): Uuid {
   return value as Uuid;
@@ -89,10 +85,6 @@ const INVALID_LIGHT_BLUEPRINT: DeviceBlueprint = {
   airflow_m3_per_h: 0
 };
 
-function deviceQuality(id: Uuid, blueprint: DeviceBlueprint): number {
-  return createDeviceInstance(QUALITY_POLICY, WORLD_SEED, id, blueprint).quality01;
-}
-
 describe('Tick pipeline — lighting effects', () => {
   it('accumulates PPFD and DLI from lighting devices', () => {
     const world = createDemoWorld();
@@ -107,7 +99,7 @@ describe('Tick pipeline — lighting effects', () => {
       name: LED_VEG_BLUEPRINT.name,
       blueprintId: uuid(LED_VEG_BLUEPRINT.id),
       placementScope: 'zone',
-      quality01: deviceQuality(deviceId, LED_VEG_BLUEPRINT),
+      quality01: deviceQuality(QUALITY_POLICY, WORLD_SEED, deviceId, LED_VEG_BLUEPRINT),
       condition01: 0.96,
       powerDraw_W: 600,
       dutyCycle01: 1,
@@ -145,7 +137,7 @@ describe('Tick pipeline — lighting effects', () => {
       name: VEG_LIGHT_A_BLUEPRINT.name,
       blueprintId: uuid(VEG_LIGHT_A_BLUEPRINT.id),
       placementScope: 'zone',
-      quality01: deviceQuality(deviceAId, VEG_LIGHT_A_BLUEPRINT),
+      quality01: deviceQuality(QUALITY_POLICY, WORLD_SEED, deviceAId, VEG_LIGHT_A_BLUEPRINT),
       condition01: 0.94,
       powerDraw_W: 500,
       dutyCycle01: 1,
@@ -161,7 +153,7 @@ describe('Tick pipeline — lighting effects', () => {
       name: VEG_LIGHT_B_BLUEPRINT.name,
       blueprintId: uuid(VEG_LIGHT_B_BLUEPRINT.id),
       placementScope: 'zone',
-      quality01: deviceQuality(deviceBId, VEG_LIGHT_B_BLUEPRINT),
+      quality01: deviceQuality(QUALITY_POLICY, WORLD_SEED, deviceBId, VEG_LIGHT_B_BLUEPRINT),
       condition01: 0.93,
       powerDraw_W: 450,
       dutyCycle01: 1,
@@ -198,7 +190,7 @@ describe('Tick pipeline — lighting effects', () => {
       name: DIMMED_LIGHT_BLUEPRINT.name,
       blueprintId: uuid(DIMMED_LIGHT_BLUEPRINT.id),
       placementScope: 'zone',
-      quality01: deviceQuality(deviceId, DIMMED_LIGHT_BLUEPRINT),
+      quality01: deviceQuality(QUALITY_POLICY, WORLD_SEED, deviceId, DIMMED_LIGHT_BLUEPRINT),
       condition01: 0.91,
       powerDraw_W: 400,
       dutyCycle01: 0.5,
@@ -234,7 +226,7 @@ describe('Tick pipeline — lighting effects', () => {
       name: INVALID_LIGHT_BLUEPRINT.name,
       blueprintId: uuid(INVALID_LIGHT_BLUEPRINT.id),
       placementScope: 'zone',
-      quality01: deviceQuality(deviceId, INVALID_LIGHT_BLUEPRINT),
+      quality01: deviceQuality(QUALITY_POLICY, WORLD_SEED, deviceId, INVALID_LIGHT_BLUEPRINT),
       condition01: 0.9,
       powerDraw_W: 500,
       dutyCycle01: 1,

--- a/packages/engine/tests/integration/pipeline/multiEffectDevice.integration.test.ts
+++ b/packages/engine/tests/integration/pipeline/multiEffectDevice.integration.test.ts
@@ -9,14 +9,10 @@ import {
 import type { EngineRunContext } from '@/backend/src/engine/Engine.js';
 import { runTick } from '@/backend/src/engine/Engine.js';
 import { createDemoWorld } from '@/backend/src/engine/testHarness.js';
-import {
-  createDeviceInstance,
-  type DeviceQualityPolicy,
-  type Uuid,
-  type ZoneDeviceInstance
-} from '@/backend/src/domain/world.js';
+import { type DeviceQualityPolicy, type Uuid, type ZoneDeviceInstance } from '@/backend/src/domain/world.js';
 import type { DeviceBlueprint } from '@/backend/src/domain/blueprints/deviceBlueprint.js';
 import { getDeviceEffectsRuntime } from '@/backend/src/engine/pipeline/applyDeviceEffects.js';
+import { deviceQuality } from '../../testUtils/deviceHelpers.js';
 
 function uuid(value: string): Uuid {
   return value as Uuid;
@@ -136,10 +132,6 @@ const LEGACY_DEHUMIDIFIER_BLUEPRINT: DeviceBlueprint = {
   airflow_m3_per_h: 0
 };
 
-function deviceQuality(id: Uuid, blueprint: DeviceBlueprint): number {
-  return createDeviceInstance(QUALITY_POLICY, WORLD_SEED, id, blueprint).quality01;
-}
-
 describe('Tick pipeline — multi-effect devices', () => {
   it('integrates thermal cooling and humidity removal in a single tick', () => {
     const world = createDemoWorld();
@@ -168,7 +160,7 @@ describe('Tick pipeline — multi-effect devices', () => {
       name: COOL_AIR_DEHUMIDIFIER_BLUEPRINT.name,
       blueprintId: uuid(COOL_AIR_DEHUMIDIFIER_BLUEPRINT.id),
       placementScope: 'zone',
-      quality01: deviceQuality(deviceId, COOL_AIR_DEHUMIDIFIER_BLUEPRINT),
+      quality01: deviceQuality(QUALITY_POLICY, WORLD_SEED, deviceId, COOL_AIR_DEHUMIDIFIER_BLUEPRINT),
       condition01: 0.95,
       powerDraw_W: 1_200,
       dutyCycle01: 1,
@@ -238,7 +230,7 @@ describe('Tick pipeline — multi-effect devices', () => {
       name: RESISTIVE_HEATER_BLUEPRINT.name,
       blueprintId: uuid(RESISTIVE_HEATER_BLUEPRINT.id),
       placementScope: 'zone',
-      quality01: deviceQuality(heaterId, RESISTIVE_HEATER_BLUEPRINT),
+      quality01: deviceQuality(QUALITY_POLICY, WORLD_SEED, heaterId, RESISTIVE_HEATER_BLUEPRINT),
       condition01: 0.9,
       powerDraw_W: 900,
       dutyCycle01: 1,
@@ -257,7 +249,7 @@ describe('Tick pipeline — multi-effect devices', () => {
       name: SMART_DEHUMIDIFIER_BLUEPRINT.name,
       blueprintId: uuid(SMART_DEHUMIDIFIER_BLUEPRINT.id),
       placementScope: 'zone',
-      quality01: deviceQuality(dehumidifierId, SMART_DEHUMIDIFIER_BLUEPRINT),
+      quality01: deviceQuality(QUALITY_POLICY, WORLD_SEED, dehumidifierId, SMART_DEHUMIDIFIER_BLUEPRINT),
       condition01: 0.92,
       powerDraw_W: 450,
       dutyCycle01: 1,
@@ -325,7 +317,7 @@ describe('Tick pipeline — multi-effect devices', () => {
       name: PARTIAL_HEATER_BLUEPRINT.name,
       blueprintId: uuid(PARTIAL_HEATER_BLUEPRINT.id),
       placementScope: 'zone',
-      quality01: deviceQuality(heaterId, PARTIAL_HEATER_BLUEPRINT),
+      quality01: deviceQuality(QUALITY_POLICY, WORLD_SEED, heaterId, PARTIAL_HEATER_BLUEPRINT),
       condition01: 0.88,
       powerDraw_W: 1_000,
       dutyCycle01: 1,
@@ -372,7 +364,7 @@ describe('Tick pipeline — multi-effect devices', () => {
       name: PATTERN_A_SPLIT_AC_BLUEPRINT.name,
       blueprintId: uuid(PATTERN_A_SPLIT_AC_BLUEPRINT.id),
       placementScope: 'zone',
-      quality01: deviceQuality(deviceId, PATTERN_A_SPLIT_AC_BLUEPRINT),
+      quality01: deviceQuality(QUALITY_POLICY, WORLD_SEED, deviceId, PATTERN_A_SPLIT_AC_BLUEPRINT),
       condition01: 0.96,
       powerDraw_W: 1_200,
       dutyCycle01: 1,
@@ -457,7 +449,7 @@ describe('Tick pipeline — multi-effect devices', () => {
       name: PATTERN_B_REHEAT_BLUEPRINT.name,
       blueprintId: uuid(PATTERN_B_REHEAT_BLUEPRINT.id),
       placementScope: 'zone',
-      quality01: deviceQuality(deviceId, PATTERN_B_REHEAT_BLUEPRINT),
+      quality01: deviceQuality(QUALITY_POLICY, WORLD_SEED, deviceId, PATTERN_B_REHEAT_BLUEPRINT),
       condition01: 0.9,
       powerDraw_W: 300,
       dutyCycle01: 1,
@@ -541,7 +533,7 @@ describe('Tick pipeline — multi-effect devices', () => {
       name: LEGACY_DEHUMIDIFIER_BLUEPRINT.name,
       blueprintId: uuid(LEGACY_DEHUMIDIFIER_BLUEPRINT.id),
       placementScope: 'zone',
-      quality01: deviceQuality(legacyId, LEGACY_DEHUMIDIFIER_BLUEPRINT),
+      quality01: deviceQuality(QUALITY_POLICY, WORLD_SEED, legacyId, LEGACY_DEHUMIDIFIER_BLUEPRINT),
       condition01: 0.85,
       powerDraw_W: 400,
       dutyCycle01: 1,

--- a/packages/engine/tests/integration/pipeline/sensorReadings.integration.test.ts
+++ b/packages/engine/tests/integration/pipeline/sensorReadings.integration.test.ts
@@ -5,12 +5,8 @@ import { getSensorReadingsRuntime } from '@/backend/src/engine/pipeline/applySen
 import { createDemoWorld } from '@/backend/src/engine/testHarness.js';
 import type { SensorOutputs } from '@/backend/src/domain/interfaces/ISensor.js';
 import type { DeviceBlueprint } from '@/backend/src/domain/blueprints/deviceBlueprint.js';
-import {
-  createDeviceInstance,
-  type DeviceQualityPolicy,
-  type Uuid,
-  type ZoneDeviceInstance
-} from '@/backend/src/domain/world.js';
+import { type DeviceQualityPolicy, type Uuid, type ZoneDeviceInstance } from '@/backend/src/domain/world.js';
+import { deviceQuality } from '../../testUtils/deviceHelpers.js';
 
 function uuid(value: string): Uuid {
   return value as Uuid;
@@ -19,6 +15,8 @@ function uuid(value: string): Uuid {
 const QUALITY_POLICY: DeviceQualityPolicy = {
   sampleQuality01: (rng) => rng()
 };
+
+const WORLD_SEED = 'sensor-seed';
 
 const SENSOR_BLUEPRINT: DeviceBlueprint = {
   id: '40000000-0000-0000-0000-000000000000',
@@ -54,10 +52,6 @@ const HEATER_BLUEPRINT: DeviceBlueprint = {
     mode: 'heat'
   }
 };
-
-function deviceQuality(id: Uuid, blueprint: DeviceBlueprint): number {
-  return createDeviceInstance(QUALITY_POLICY, 'sensor-seed', id, blueprint).quality01;
-}
 
 function runSensorTick(
   world: ReturnType<typeof createDemoWorld>,
@@ -127,7 +121,7 @@ describe('Tick pipeline — sensor readings', () => {
       name: HEATER_BLUEPRINT.name,
       blueprintId: HEATER_BLUEPRINT.id,
       placementScope: 'zone',
-      quality01: deviceQuality(heaterId, HEATER_BLUEPRINT),
+      quality01: deviceQuality(QUALITY_POLICY, WORLD_SEED, heaterId, HEATER_BLUEPRINT),
       condition01: 1,
       powerDraw_W: HEATER_BLUEPRINT.power_W,
       dutyCycle01: 1,
@@ -146,7 +140,7 @@ describe('Tick pipeline — sensor readings', () => {
       name: SENSOR_BLUEPRINT.name,
       blueprintId: SENSOR_BLUEPRINT.id,
       placementScope: 'zone',
-      quality01: deviceQuality(sensorId, SENSOR_BLUEPRINT),
+      quality01: deviceQuality(QUALITY_POLICY, WORLD_SEED, sensorId, SENSOR_BLUEPRINT),
       condition01: 1,
       powerDraw_W: 0,
       dutyCycle01: 1,
@@ -202,7 +196,7 @@ describe('Tick pipeline — sensor readings', () => {
       name: 'Temp Sensor',
       blueprintId: SENSOR_BLUEPRINT.id,
       placementScope: 'zone',
-      quality01: deviceQuality(temperatureSensorId, SENSOR_BLUEPRINT),
+      quality01: deviceQuality(QUALITY_POLICY, WORLD_SEED, temperatureSensorId, SENSOR_BLUEPRINT),
       condition01: 0.9,
       powerDraw_W: 0,
       dutyCycle01: 1,
@@ -222,7 +216,7 @@ describe('Tick pipeline — sensor readings', () => {
       name: 'Humidity Probe',
       blueprintId: SENSOR_BLUEPRINT.id,
       placementScope: 'zone',
-      quality01: deviceQuality(humiditySensorId, SENSOR_BLUEPRINT),
+      quality01: deviceQuality(QUALITY_POLICY, WORLD_SEED, humiditySensorId, SENSOR_BLUEPRINT),
       condition01: 0.8,
       powerDraw_W: 0,
       dutyCycle01: 1,
@@ -278,7 +272,7 @@ describe('Tick pipeline — sensor readings', () => {
         name: 'Noisy Temp Sensor',
         blueprintId: SENSOR_BLUEPRINT.id,
         placementScope: 'zone',
-        quality01: deviceQuality(sensorId, SENSOR_BLUEPRINT),
+        quality01: deviceQuality(QUALITY_POLICY, WORLD_SEED, sensorId, SENSOR_BLUEPRINT),
         condition01: 0.5,
         powerDraw_W: 0,
         dutyCycle01: 1,
@@ -390,7 +384,7 @@ describe('Tick pipeline — sensor readings', () => {
       name: sensorBlueprint.name,
       blueprintId: sensorBlueprint.id,
       placementScope: 'zone',
-      quality01: deviceQuality(id, sensorBlueprint),
+      quality01: deviceQuality(QUALITY_POLICY, WORLD_SEED, id, sensorBlueprint),
       condition01: 0.7,
       powerDraw_W: 0,
       dutyCycle01: 1,
@@ -440,7 +434,7 @@ describe('Tick pipeline — sensor readings', () => {
       name: sensorBlueprint.name,
       blueprintId: sensorBlueprint.id,
       placementScope: 'zone',
-      quality01: deviceQuality(id, sensorBlueprint),
+      quality01: deviceQuality(QUALITY_POLICY, WORLD_SEED, id, sensorBlueprint),
       condition01: 0.7,
       powerDraw_W: 0,
       dutyCycle01: 1,

--- a/packages/engine/tests/integration/pipeline/zoneCapacity.integration.test.ts
+++ b/packages/engine/tests/integration/pipeline/zoneCapacity.integration.test.ts
@@ -14,12 +14,12 @@ import { updateEnvironment } from '@/backend/src/engine/pipeline/updateEnvironme
 import { createDemoWorld } from '@/backend/src/engine/testHarness.js';
 import { applyDeviceHeat } from '@/backend/src/engine/thermo/heat.js';
 import {
-  createDeviceInstance,
   type DeviceQualityPolicy,
   type ZoneDeviceInstance,
   type Uuid
 } from '@/backend/src/domain/world.js';
 import type { DeviceBlueprint } from '@/backend/src/domain/blueprints/deviceBlueprint.js';
+import { deviceQuality } from '../../testUtils/deviceHelpers.js';
 
 function uuid(value: string): Uuid {
   return value as Uuid;
@@ -61,10 +61,6 @@ const AIRFLOW_FAN_BLUEPRINT: DeviceBlueprint = {
   airflow: { mode: 'circulate' }
 };
 
-function deviceQuality(id: Uuid, blueprint: DeviceBlueprint): number {
-  return createDeviceInstance(QUALITY_POLICY, WORLD_SEED, id, blueprint).quality01;
-}
-
 describe('Phase 1 zone capacity diagnostics', () => {
   it('clamps device effectiveness and emits coverage warnings when undersized', () => {
     const world = createDemoWorld();
@@ -80,7 +76,7 @@ describe('Phase 1 zone capacity diagnostics', () => {
       name: COVERAGE_HEATER_BLUEPRINT.name,
       blueprintId: uuid(COVERAGE_HEATER_BLUEPRINT.id),
       placementScope: 'zone',
-      quality01: deviceQuality(heaterId, COVERAGE_HEATER_BLUEPRINT),
+      quality01: deviceQuality(QUALITY_POLICY, WORLD_SEED, heaterId, COVERAGE_HEATER_BLUEPRINT),
       condition01: 1,
       powerDraw_W: 1_000,
       dutyCycle01: 1,
@@ -142,7 +138,7 @@ describe('Phase 1 zone capacity diagnostics', () => {
       name: AIRFLOW_FAN_BLUEPRINT.name,
       blueprintId: uuid(AIRFLOW_FAN_BLUEPRINT.id),
       placementScope: 'zone',
-      quality01: deviceQuality(fanId, AIRFLOW_FAN_BLUEPRINT),
+      quality01: deviceQuality(QUALITY_POLICY, WORLD_SEED, fanId, AIRFLOW_FAN_BLUEPRINT),
       condition01: 1,
       powerDraw_W: 200,
       dutyCycle01: 1,

--- a/packages/engine/tests/testUtils/deviceHelpers.ts
+++ b/packages/engine/tests/testUtils/deviceHelpers.ts
@@ -1,0 +1,15 @@
+import type { DeviceBlueprint } from '@/backend/src/domain/blueprints/deviceBlueprint.js';
+import {
+  createDeviceInstance,
+  type DeviceQualityPolicy,
+  type Uuid
+} from '@/backend/src/domain/world.js';
+
+export function deviceQuality(
+  qualityPolicy: DeviceQualityPolicy,
+  seed: string,
+  id: Uuid,
+  blueprint: DeviceBlueprint
+): number {
+  return createDeviceInstance(qualityPolicy, seed, id, blueprint).quality01;
+}

--- a/packages/engine/tests/unit/domain/schemas.test.ts
+++ b/packages/engine/tests/unit/domain/schemas.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 import { AIR_DENSITY_KG_PER_M3, ROOM_DEFAULT_HEIGHT_M } from '@/backend/src/constants/simConstants.js';
 import {
   companySchema,
-  createDeviceInstance,
   parseCompanyWorld,
   type DevicePlacementScope,
   type DeviceQualityPolicy,
@@ -10,6 +9,7 @@ import {
   type Uuid
 } from '@wb/engine';
 import type { DeviceBlueprint } from '@/backend/src/domain/blueprints/deviceBlueprint.js';
+import { deviceQuality } from '../../testUtils/deviceHelpers.js';
 
 type DeepMutable<T> = T extends (...args: unknown[]) => unknown
   ? T
@@ -71,10 +71,6 @@ const SCHEMA_STRUCTURE_DEVICE_BLUEPRINT: DeviceBlueprint = {
   coverage_m2: 0,
   airflow_m3_per_h: 0
 };
-
-function deviceQuality(id: Uuid, blueprint: DeviceBlueprint): number {
-  return createDeviceInstance(QUALITY_POLICY, WORLD_SEED, id, blueprint).quality01;
-}
 
 const BASE_WORLD = {
   id: '00000000-0000-0000-0000-000000000001',
@@ -146,6 +142,8 @@ const BASE_WORLD = {
                   blueprintId: SCHEMA_ZONE_DEVICE_BLUEPRINT.id,
                   placementScope: 'zone',
                   quality01: deviceQuality(
+                    QUALITY_POLICY,
+                    WORLD_SEED,
                     '00000000-0000-0000-0000-000000000060' as Uuid,
                     SCHEMA_ZONE_DEVICE_BLUEPRINT
                   ),
@@ -168,6 +166,8 @@ const BASE_WORLD = {
               blueprintId: SCHEMA_ROOM_DEVICE_BLUEPRINT.id,
               placementScope: 'room',
               quality01: deviceQuality(
+                QUALITY_POLICY,
+                WORLD_SEED,
                 '00000000-0000-0000-0000-000000000070' as Uuid,
                 SCHEMA_ROOM_DEVICE_BLUEPRINT
               ),
@@ -190,6 +190,8 @@ const BASE_WORLD = {
             blueprintId: SCHEMA_STRUCTURE_DEVICE_BLUEPRINT.id,
             placementScope: 'structure',
             quality01: deviceQuality(
+              QUALITY_POLICY,
+              WORLD_SEED,
               '00000000-0000-0000-0000-000000000080' as Uuid,
               SCHEMA_STRUCTURE_DEVICE_BLUEPRINT
             ),

--- a/packages/engine/tests/unit/domain/validateCompanyWorld.test.ts
+++ b/packages/engine/tests/unit/domain/validateCompanyWorld.test.ts
@@ -10,7 +10,6 @@ import {
   DEFAULT_COMPANY_LOCATION_COUNTRY
 } from '@/backend/src/constants/simConstants.js';
 import {
-  createDeviceInstance,
   type Company,
   type Structure,
   type Room,
@@ -24,6 +23,7 @@ import {
   validateCompanyWorld
 } from '@/backend/src/domain/world.js';
 import type { DeviceBlueprint } from '@/backend/src/domain/blueprints/deviceBlueprint.js';
+import { deviceQuality } from '../../testUtils/deviceHelpers.js';
 
 const QUALITY_POLICY: DeviceQualityPolicy = {
   sampleQuality01: (rng) => rng()
@@ -69,10 +69,6 @@ const STRUCTURE_DEVICE_BLUEPRINT: DeviceBlueprint = {
   coverage_m2: 0,
   airflow_m3_per_h: 0
 };
-
-function deviceQuality(id: Uuid, blueprint: DeviceBlueprint): number {
-  return createDeviceInstance(QUALITY_POLICY, WORLD_SEED, id, blueprint).quality01;
-}
 
 function uuid(value: string): Uuid {
   return value as Uuid;
@@ -358,7 +354,7 @@ function createCompany(): Company {
     name: ZONE_DEVICE_BLUEPRINT.name,
     blueprintId: uuid(ZONE_DEVICE_BLUEPRINT.id),
     placementScope: 'zone',
-    quality01: deviceQuality(zoneDeviceId, ZONE_DEVICE_BLUEPRINT),
+    quality01: deviceQuality(QUALITY_POLICY, WORLD_SEED, zoneDeviceId, ZONE_DEVICE_BLUEPRINT),
     condition01: 0.75,
     powerDraw_W: 480,
     dutyCycle01: 1,
@@ -398,7 +394,7 @@ function createCompany(): Company {
     name: ROOM_DEVICE_BLUEPRINT.name,
     blueprintId: uuid(ROOM_DEVICE_BLUEPRINT.id),
     placementScope: 'room',
-    quality01: deviceQuality(roomDeviceId, ROOM_DEVICE_BLUEPRINT),
+    quality01: deviceQuality(QUALITY_POLICY, WORLD_SEED, roomDeviceId, ROOM_DEVICE_BLUEPRINT),
     condition01: 0.9,
     powerDraw_W: 250,
     dutyCycle01: 1,
@@ -426,7 +422,12 @@ function createCompany(): Company {
     name: STRUCTURE_DEVICE_BLUEPRINT.name,
     blueprintId: uuid(STRUCTURE_DEVICE_BLUEPRINT.id),
     placementScope: 'structure',
-    quality01: deviceQuality(structureDeviceId, STRUCTURE_DEVICE_BLUEPRINT),
+    quality01: deviceQuality(
+      QUALITY_POLICY,
+      WORLD_SEED,
+      structureDeviceId,
+      STRUCTURE_DEVICE_BLUEPRINT
+    ),
     condition01: 0.88,
     powerDraw_W: 3_500,
     dutyCycle01: 1,


### PR DESCRIPTION
## Summary
- create shared math, validation, and environment utilities for clamping, tick resolution, and airflow handling
- refactor stubs, device factories, and domain services to consume the shared helpers instead of reimplementing them
- add a reusable test `deviceQuality` helper and document the helper catalogue to guard against future duplication

## Testing
- pnpm --filter engine test -- --runInBand *(fails: vitest not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e14a0f22c48325974adbed5562ae81