### PR TITLE
Add storage room blueprint

### DIFF
--- a/data/blueprints/room-purpose/core/storage/storage.json
+++ b/data/blueprints/room-purpose/core/storage/storage.json
@@ -1,0 +1,10 @@
+{
+  "id": "84a1f9ff-83ee-4cde-8700-2a9ed933aac0",
+  "slug": "storage",
+  "class": "room-purpose.core.storage",
+  "name": "Storage Room",
+  "description": "A room for storing materials, tools, and harvests.",
+  "economy": {
+    "areaCost": 2.6
+  }
+}


### PR DESCRIPTION
## Summary
- add a storage room blueprint matching the existing room-purpose schema
- define economy area cost for storage rooms

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1534922348325bd3dc5d0630c6adb