### PR TITLE
feat(engine): add strain blueprint loader

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### #XX WB-XXX Strain Blueprint Loader mit Filesystem-Integration
+
+- Implementiert `strainBlueprintLoader.ts` mit Lazy-Loading-Mechanismus: Scannt `/data/blueprints/strain/**` beim ersten Zugriff, baut In-Memory-Index (`Map<Uuid, StrainBlueprint>`), und cached Blueprints im Modul-Scope.
+- Integriert Loader in `advancePhysiology.ts`: Ersetzt TODO-Block (Zeile 40) mit `loadStrainBlueprint()`-Aufruf; Runtime-Cache verhindert redundante Lookups pro Tick.
+- Fügt Unit-Tests hinzu (`strainBlueprintLoader.test.ts`): Validiert Filesystem-Scan, Index-Build, Cache-Verhalten, und Fehlerbehandlung mit echten JSON-Fixtures.
+- Erweitert Integration-Tests (`plantPhysiology.integration.test.ts`): Testet vollständigen Plant-Lifecycle mit White Widow Blueprint, validiert Stage-Transitions und Biomasse-Wachstum.
+- Erstellt `strainFixtures.ts` Test-Utility: Zentralisiert Strain-IDs (`WHITE_WIDOW_STRAIN_ID`) und Factory-Funktionen für Test-Pflanzen/Zonen.
+- Fügt Blueprint-Barrel-Export (`blueprints/index.ts`) hinzu: Vereinfacht Imports und etabliert API-Grenze für Blueprint-Subsystem.
+- Etabliert Muster für zukünftige Blueprint-Loader (Device, Irrigation, Substrate): Filesystem-Scan + Validation + Caching.
+
 ### #60 Utility consolidation for helper functions
 - Added shared numeric helpers (`clamp`, `clamp01`, `resolveTickHoursValue`) and
   validation/environment utilities to eliminate divergent inline

--- a/packages/engine/src/backend/src/domain/blueprints/index.ts
+++ b/packages/engine/src/backend/src/domain/blueprints/index.ts
@@ -1,0 +1,6 @@
+export * from './strainBlueprint.js';
+export * from './strainBlueprintLoader.js';
+export * from './taxonomy.js';
+export * from './deviceBlueprint.js';
+export * from './irrigationBlueprint.js';
+export * from './substrateBlueprint.js';

--- a/packages/engine/src/backend/src/domain/blueprints/strainBlueprintLoader.ts
+++ b/packages/engine/src/backend/src/domain/blueprints/strainBlueprintLoader.ts
@@ -1,0 +1,112 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { parseStrainBlueprint, type StrainBlueprint } from './strainBlueprint.js';
+import type { Uuid } from '../entities.js';
+
+export interface LoadStrainBlueprintOptions {
+  readonly blueprintsRoot?: string;
+  readonly strict?: boolean;
+}
+
+const DEFAULT_BLUEPRINTS_ROOT = path.resolve('data/blueprints');
+
+let blueprintCache: Map<Uuid, StrainBlueprint> | null = null;
+
+function resolveBlueprintsRoot(root?: string): string {
+  if (!root) {
+    return DEFAULT_BLUEPRINTS_ROOT;
+  }
+
+  return path.isAbsolute(root) ? path.normalize(root) : path.resolve(root);
+}
+
+function collectStrainBlueprintFiles(blueprintsRoot: string): string[] {
+  const strainRoot = path.join(blueprintsRoot, 'strain');
+
+  if (!fs.existsSync(strainRoot)) {
+    throw new Error(`Strain blueprints root "${strainRoot}" does not exist.`);
+  }
+
+  const stack: string[] = [strainRoot];
+  const files: string[] = [];
+
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    const stat = fs.statSync(current);
+
+    if (stat.isDirectory()) {
+      const entries = fs.readdirSync(current);
+
+      for (const entry of entries) {
+        stack.push(path.join(current, entry));
+      }
+    } else if (stat.isFile() && current.endsWith('.json')) {
+      files.push(current);
+    }
+  }
+
+  return files.sort();
+}
+
+function buildStrainBlueprintIndex(options: LoadStrainBlueprintOptions = {}): Map<Uuid, StrainBlueprint> {
+  const blueprintsRoot = resolveBlueprintsRoot(options.blueprintsRoot);
+  const files = collectStrainBlueprintFiles(blueprintsRoot);
+  const slugRegistry = new Map<string, string>();
+  const index = new Map<Uuid, StrainBlueprint>();
+
+  for (const filePath of files) {
+    let blueprint: StrainBlueprint | null = null;
+
+    try {
+      const raw = fs.readFileSync(filePath, 'utf8');
+      const payload = JSON.parse(raw);
+      blueprint = parseStrainBlueprint(payload, {
+        filePath,
+        blueprintsRoot,
+        slugRegistry
+      });
+    } catch (error) {
+      if (options.strict) {
+        throw error;
+      }
+
+      // eslint-disable-next-line no-console
+      console.warn(`Failed to load strain blueprint from "${filePath}":`, error);
+    }
+
+    if (!blueprint) {
+      continue;
+    }
+
+    index.set(blueprint.id as Uuid, blueprint);
+  }
+
+  return index;
+}
+
+export function loadAllStrainBlueprints(
+  options: LoadStrainBlueprintOptions = {}
+): Map<Uuid, StrainBlueprint> {
+  if (!blueprintCache) {
+    blueprintCache = buildStrainBlueprintIndex(options);
+  }
+
+  return new Map(blueprintCache);
+}
+
+export function loadStrainBlueprint(
+  strainId: Uuid,
+  options: LoadStrainBlueprintOptions = {}
+): StrainBlueprint | null {
+  if (!blueprintCache) {
+    blueprintCache = buildStrainBlueprintIndex(options);
+  }
+
+  return blueprintCache.get(strainId) ?? null;
+}
+
+export function clearStrainBlueprintCache(): void {
+  blueprintCache = null;
+}
+

--- a/packages/engine/src/backend/src/engine/pipeline/advancePhysiology.ts
+++ b/packages/engine/src/backend/src/engine/pipeline/advancePhysiology.ts
@@ -8,6 +8,7 @@ import type {
 } from '../../domain/world.js';
 import type { EngineRunContext } from '../Engine.js';
 import type { StrainBlueprint } from '../../domain/blueprints/strainBlueprint.js';
+import { loadStrainBlueprint } from '../../domain/blueprints/strainBlueprintLoader.js';
 import { createRng } from '../../util/rng.js';
 import {
   calculateBiomassIncrement,
@@ -37,8 +38,13 @@ function getOrLoadStrainBlueprint(
     return cached;
   }
 
-  // TODO: Load strain blueprint definitions from the filesystem (separate task).
-  return null;
+  const blueprint = loadStrainBlueprint(strainId);
+
+  if (blueprint) {
+    runtime.strainBlueprints.set(strainId, blueprint);
+  }
+
+  return blueprint;
 }
 
 function hasNumericChange(previous: number, next: number): boolean {

--- a/packages/engine/tests/integration/pipeline/plantPhysiology.integration.test.ts
+++ b/packages/engine/tests/integration/pipeline/plantPhysiology.integration.test.ts
@@ -1,24 +1,26 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { runTick, type EngineRunContext } from '@/backend/src/engine/Engine.js';
 import { createDemoWorld, runStages } from '@/backend/src/engine/testHarness.js';
 import type { EngineDiagnostic } from '@/backend/src/engine/Engine.js';
 import type { Plant, Zone } from '@/backend/src/domain/world.js';
+import * as strainLoader from '@/backend/src/domain/blueprints/strainBlueprintLoader.js';
+import { clearStrainBlueprintCache } from '@/backend/src/domain/blueprints/strainBlueprintLoader.js';
+import {
+  AK47_STRAIN_ID,
+  WHITE_WIDOW_STRAIN_ID,
+  createTestPlant
+} from '../../testUtils/strainFixtures.ts';
+
+const FAKE_STRAIN_ID = '44444444-4444-4444-4444-444444444444' as Plant['strainId'];
 
 function createPlant(overrides: Partial<Plant> = {}): Plant {
-  return {
-    id: '33333333-3333-4333-8333-333333333333' as Plant['id'],
+  return createTestPlant({
     name: 'Integration Plant',
     slug: 'integration-plant',
-    strainId: '44444444-4444-4444-4444-444444444444' as Plant['strainId'],
-    lifecycleStage: 'seedling',
-    ageHours: 0,
-    health01: 1,
-    biomass_g: 1,
-    containerId: '55555555-5555-5555-5555-555555555555' as Plant['containerId'],
-    substrateId: '66666666-6666-6666-6666-666666666666' as Plant['substrateId'],
+    strainId: WHITE_WIDOW_STRAIN_ID,
     ...overrides
-  } satisfies Plant;
+  });
 }
 
 describe('advancePhysiology pipeline', () => {
@@ -26,9 +28,14 @@ describe('advancePhysiology pipeline', () => {
     return world.company.structures[0].rooms[0].zones[0];
   }
 
+  beforeEach(() => {
+    clearStrainBlueprintCache();
+    vi.restoreAllMocks();
+  });
+
   it('advances plant age by the tick duration even without strain blueprint', () => {
     const world = createDemoWorld();
-    zone(world).plants = [createPlant({ ageHours: 0 })];
+    zone(world).plants = [createPlant({ ageHours: 0, strainId: FAKE_STRAIN_ID })];
     const ctx: EngineRunContext = { tickDurationHours: 2 };
 
     const { world: nextWorld } = runTick(world, ctx);
@@ -40,7 +47,7 @@ describe('advancePhysiology pipeline', () => {
 
   it('emits diagnostics when strain blueprint is missing', () => {
     const world = createDemoWorld();
-    zone(world).plants = [createPlant({ ageHours: 10 })];
+    zone(world).plants = [createPlant({ ageHours: 10, strainId: FAKE_STRAIN_ID })];
     const diagnostics: EngineDiagnostic[] = [];
     const ctx: EngineRunContext = {
       tickDurationHours: 1,
@@ -70,5 +77,100 @@ describe('advancePhysiology pipeline', () => {
 
     expect(first.ageHours).toBeCloseTo(5.5, 5);
     expect(second.ageHours).toBeCloseTo(15.5, 5);
+  });
+
+  it('advances plant physiology with real strain blueprint (White Widow)', () => {
+    const world = createDemoWorld();
+    const targetZone = zone(world);
+    targetZone.environment = { airTemperatureC: 23, relativeHumidity_pct: 55 } as Zone['environment'];
+    targetZone.ppfd_umol_m2s = 500;
+    targetZone.dli_mol_m2d_inc = 0.5;
+    targetZone.plants = [
+      createPlant({
+        strainId: WHITE_WIDOW_STRAIN_ID,
+        ageHours: 0,
+        biomass_g: 1,
+        lifecycleStage: 'seedling'
+      })
+    ];
+
+    const diagnostics: EngineDiagnostic[] = [];
+    const ctx: EngineRunContext = {
+      tickDurationHours: 1,
+      diagnostics: {
+        emit: (diagnostic) => diagnostics.push(diagnostic)
+      }
+    } satisfies EngineRunContext;
+
+    let currentWorld = world;
+
+    for (let i = 0; i < 10; i += 1) {
+      const { world: nextWorld } = runTick(currentWorld, ctx);
+      currentWorld = nextWorld;
+    }
+
+    const updatedPlant = zone(currentWorld).plants[0];
+
+    expect(updatedPlant.ageHours).toBeCloseTo(10, 5);
+    expect(updatedPlant.lifecycleStage).toBe('seedling');
+    expect(updatedPlant.biomass_g).toBeGreaterThan(1);
+    expect(updatedPlant.health01).toBeGreaterThan(0.9);
+    expect(diagnostics.find((d) => d.code === 'plant.strain.missing')).toBeUndefined();
+  });
+
+  it('transitions plant from seedling to vegetative with real strain', () => {
+    const world = createDemoWorld();
+    const targetZone = zone(world);
+    targetZone.environment = { airTemperatureC: 24, relativeHumidity_pct: 55 } as Zone['environment'];
+    targetZone.ppfd_umol_m2s = 550;
+    targetZone.dli_mol_m2d_inc = 0.6;
+    targetZone.plants = [
+      createPlant({
+        strainId: WHITE_WIDOW_STRAIN_ID,
+        ageHours: 300,
+        lifecycleStage: 'seedling',
+        biomass_g: 50
+      })
+    ];
+
+    const ctx: EngineRunContext = { tickDurationHours: 2 };
+    let currentWorld = world;
+
+    for (let i = 0; i < 15; i += 1) {
+      const { world: nextWorld } = runTick(currentWorld, ctx);
+      currentWorld = nextWorld;
+    }
+
+    const transitionedPlant = zone(currentWorld).plants[0];
+
+    expect(transitionedPlant.ageHours).toBeGreaterThanOrEqual(330);
+    expect(transitionedPlant.lifecycleStage).toBe('vegetative');
+    expect(transitionedPlant.biomass_g).toBeGreaterThan(50);
+  });
+
+  it('handles multiple plants with different strains', () => {
+    const loadSpy = vi.spyOn(strainLoader, 'loadStrainBlueprint');
+    const world = createDemoWorld();
+    const targetZone = zone(world);
+    targetZone.environment = { airTemperatureC: 23, relativeHumidity_pct: 55 } as Zone['environment'];
+    targetZone.ppfd_umol_m2s = 500;
+    targetZone.dli_mol_m2d_inc = 0.5;
+    targetZone.plants = [
+      createPlant({ strainId: WHITE_WIDOW_STRAIN_ID, ageHours: 10 }),
+      createPlant({ strainId: AK47_STRAIN_ID, ageHours: 20 })
+    ];
+
+    const ctx: EngineRunContext = { tickDurationHours: 1 };
+    const { world: nextWorld } = runTick(world, ctx);
+    const [first, second] = zone(nextWorld).plants;
+
+    expect(first.ageHours).toBeGreaterThan(10);
+    expect(second.ageHours).toBeGreaterThan(20);
+    expect(first.biomass_g).toBeGreaterThan(0);
+    expect(second.biomass_g).toBeGreaterThan(0);
+    expect(loadSpy.mock.calls.length).toBeLessThanOrEqual(2);
+    expect(new Set(loadSpy.mock.calls.map((call) => call[0]))).toEqual(
+      new Set([WHITE_WIDOW_STRAIN_ID, AK47_STRAIN_ID])
+    );
   });
 });

--- a/packages/engine/tests/testUtils/strainFixtures.ts
+++ b/packages/engine/tests/testUtils/strainFixtures.ts
@@ -1,0 +1,56 @@
+import { randomUUID } from 'node:crypto';
+
+import type { Plant, Zone, Uuid } from '@/backend/src/domain/entities.js';
+
+export const WHITE_WIDOW_STRAIN_ID = '550e8400-e29b-41d4-a716-446655440001' as Uuid;
+export const AK47_STRAIN_ID = '550e8400-e29b-41d4-a716-446655440000' as Uuid;
+export const SOUR_DIESEL_STRAIN_ID = '8b9a0b6c-2d6c-4f58-9c37-7a6c9d4aa5c2' as Uuid;
+export const NORTHERN_LIGHTS_STRAIN_ID = '3f0f15f4-1b75-4196-b3f3-5f6b6b7cf7a7' as Uuid;
+export const SKUNK_1_STRAIN_ID = '5a6e9e57-0b3a-4f9f-8f19-12f3f8ec3a0e' as Uuid;
+
+export function createTestPlant(overrides: Partial<Plant> = {}): Plant {
+  return {
+    id: (overrides.id ?? randomUUID()) as Plant['id'],
+    name: overrides.name ?? 'Test Plant',
+    slug: overrides.slug ?? 'test-plant',
+    strainId: (overrides.strainId ?? WHITE_WIDOW_STRAIN_ID) as Plant['strainId'],
+    lifecycleStage: overrides.lifecycleStage ?? 'seedling',
+    ageHours: overrides.ageHours ?? 0,
+    health01: overrides.health01 ?? 1,
+    biomass_g: overrides.biomass_g ?? 1,
+    containerId: (overrides.containerId ?? randomUUID()) as Plant['containerId'],
+    substrateId: (overrides.substrateId ?? randomUUID()) as Plant['substrateId'],
+    ...overrides
+  } satisfies Plant;
+}
+
+export function createTestZoneWithOptimalConditions(overrides: Partial<Zone> = {}): Zone {
+  return {
+    id: (overrides.id ?? randomUUID()) as Zone['id'],
+    name: overrides.name ?? 'Test Zone',
+    slug: overrides.slug ?? 'test-zone',
+    floorArea_m2: overrides.floorArea_m2 ?? 20,
+    height_m: overrides.height_m ?? 3,
+    cultivationMethodId: (overrides.cultivationMethodId ?? randomUUID()) as Zone['cultivationMethodId'],
+    irrigationMethodId: (overrides.irrigationMethodId ?? randomUUID()) as Zone['irrigationMethodId'],
+    containerId: (overrides.containerId ?? randomUUID()) as Zone['containerId'],
+    substrateId: (overrides.substrateId ?? randomUUID()) as Zone['substrateId'],
+    lightSchedule:
+      overrides.lightSchedule ?? ({ onHours: 18, offHours: 6, startHour: 0 } as Zone['lightSchedule']),
+    photoperiodPhase: overrides.photoperiodPhase ?? 'vegetative',
+    plants: overrides.plants ?? [],
+    devices: overrides.devices ?? [],
+    airMass_kg: overrides.airMass_kg ?? 500,
+    environment:
+      overrides.environment ??
+      ({
+        airTemperatureC: 23,
+        relativeHumidity_pct: 55
+      } satisfies Zone['environment']),
+    ppfd_umol_m2s: overrides.ppfd_umol_m2s ?? 500,
+    dli_mol_m2d_inc: overrides.dli_mol_m2d_inc ?? 0.5,
+    nutrientBuffer_mg: overrides.nutrientBuffer_mg ?? {},
+    moisture01: overrides.moisture01 ?? 0.5,
+    ...overrides
+  } satisfies Zone;
+}

--- a/packages/engine/tests/unit/domain/strainBlueprintLoader.test.ts
+++ b/packages/engine/tests/unit/domain/strainBlueprintLoader.test.ts
@@ -1,0 +1,91 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  clearStrainBlueprintCache,
+  loadAllStrainBlueprints,
+  loadStrainBlueprint
+} from '@/backend/src/domain/blueprints/strainBlueprintLoader.js';
+import type { StrainBlueprint } from '@/backend/src/domain/blueprints/strainBlueprint.js';
+import type { Uuid } from '@/backend/src/domain/entities.js';
+import { resolveBlueprintPath } from '../../testUtils/paths.js';
+import {
+  AK47_STRAIN_ID,
+  WHITE_WIDOW_STRAIN_ID
+} from '../../testUtils/strainFixtures.ts';
+
+const blueprintsRoot = path.resolve(resolveBlueprintPath(''));
+
+describe('strainBlueprintLoader', () => {
+  beforeEach(() => {
+    clearStrainBlueprintCache();
+    vi.restoreAllMocks();
+  });
+
+  it('loadAllStrainBlueprints loads all strain blueprints', () => {
+    const blueprints = loadAllStrainBlueprints({ blueprintsRoot });
+
+    expect(blueprints.size).toBeGreaterThanOrEqual(5);
+    const whiteWidow = blueprints.get(WHITE_WIDOW_STRAIN_ID);
+    expect(whiteWidow).toBeDefined();
+    expect(whiteWidow?.slug).toBe('white-widow');
+    expect(whiteWidow?.class).toBe('strain.hybrid.balanced');
+  });
+
+  it('loadStrainBlueprint retrieves a specific blueprint', () => {
+    const blueprint = loadStrainBlueprint(WHITE_WIDOW_STRAIN_ID, { blueprintsRoot });
+
+    expect(blueprint).not.toBeNull();
+    expect(blueprint?.name).toBe('White Widow');
+    expect(blueprint?.slug).toBe('white-widow');
+    expect(blueprint?.growthModel).toBeDefined();
+    expect(blueprint?.envBands).toBeDefined();
+  });
+
+  it('loadStrainBlueprint returns null for unknown id', () => {
+    const unknownId = '99999999-9999-9999-9999-999999999999' as Uuid;
+    const blueprint = loadStrainBlueprint(unknownId, { blueprintsRoot });
+
+    expect(blueprint).toBeNull();
+  });
+
+  it('shares cache between loadAllStrainBlueprints calls', () => {
+    const readSpy = vi.spyOn(fs, 'readFileSync');
+
+    const first = loadAllStrainBlueprints({ blueprintsRoot });
+    const initialReads = readSpy.mock.calls.length;
+    const second = loadAllStrainBlueprints({ blueprintsRoot });
+
+    expect(first.size).toBeGreaterThanOrEqual(5);
+    expect(second.size).toBe(first.size);
+    expect(readSpy.mock.calls.length).toBe(initialReads);
+  });
+
+  it('clears cache via clearStrainBlueprintCache', () => {
+    loadAllStrainBlueprints({ blueprintsRoot });
+    clearStrainBlueprintCache();
+
+    const readSpy = vi.spyOn(fs, 'readFileSync');
+    loadAllStrainBlueprints({ blueprintsRoot });
+
+    expect(readSpy).toHaveBeenCalled();
+  });
+
+  it('throws when blueprints root is invalid', () => {
+    expect(() => loadAllStrainBlueprints({ blueprintsRoot: '/invalid/path' })).toThrow();
+  });
+
+  it('loadStrainBlueprint caches individual lookups', () => {
+    const readSpy = vi.spyOn(fs, 'readFileSync');
+
+    const first = loadStrainBlueprint(AK47_STRAIN_ID, { blueprintsRoot });
+    expect(first).not.toBeNull();
+    const afterFirstReads = readSpy.mock.calls.length;
+
+    const second = loadStrainBlueprint(AK47_STRAIN_ID, { blueprintsRoot });
+    expect(second).toBe(first as StrainBlueprint);
+    expect(readSpy.mock.calls.length).toBe(afterFirstReads);
+  });
+});


### PR DESCRIPTION
## Summary
- implement filesystem-backed strain blueprint loader with module cache and barrel exports
- integrate loader into advancePhysiology and add reusable strain fixtures for tests
- expand unit/integration coverage using real blueprint data and document changes in changelog

## Testing
- pnpm --filter @wb/engine test *(fails: vitest binary missing in workspace image)*

------
https://chatgpt.com/codex/tasks/task_e_68e1d2d6935083258ebab850eabe740c