### PR TITLE
Expand vitest include globs to run spec files

### DIFF
--- a/packages/engine/vitest.config.ts
+++ b/packages/engine/vitest.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: ['tests/**/*.test.ts'],
+    include: ['tests/**/*.{test,spec}.ts'],
     setupFiles: [path.resolve(packageDir, 'tests/setup.ts')],
     coverage: {
       provider: 'v8',

--- a/packages/facade/vitest.config.ts
+++ b/packages/facade/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: ['tests/**/*.test.ts'],
+    include: ['tests/**/*.{test,spec}.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html']

--- a/packages/tools-monitor/vitest.config.ts
+++ b/packages/tools-monitor/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: ['tests/**/*.test.ts'],
+    include: ['tests/**/*.{test,spec}.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html']

--- a/packages/transport-sio/vitest.config.ts
+++ b/packages/transport-sio/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: ['tests/**/*.test.ts'],
+    include: ['tests/**/*.{test,spec}.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html']


### PR DESCRIPTION
## Summary
- update each package Vitest configuration to include both `.test.ts` and `.spec.ts` patterns
- ensure engine, facade, tools-monitor, and transport-sio packages discover spec-style tests during runs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1e318278c8325a62b8ffbac42dca0