### PR TITLE
Allow zero tick hours in resolver

### DIFF
--- a/packages/engine/src/backend/src/engine/resolveTickHours.ts
+++ b/packages/engine/src/backend/src/engine/resolveTickHours.ts
@@ -2,7 +2,7 @@ import { HOURS_PER_TICK } from '../constants/simConstants.js';
 import type { EngineRunContext } from './Engine.js';
 
 function isPositiveFinite(value: unknown): value is number {
-  return typeof value === 'number' && Number.isFinite(value) && value > 0;
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0;
 }
 
 export function resolveTickHoursValue(value: unknown): number {


### PR DESCRIPTION
## Summary
- allow `resolveTickHoursValue` to accept zero duration tick inputs
- keep stub logic aligned with expectations for dt_h = 0 scenarios

## Testing
- pnpm --filter @wb/engine test *(fails: vitest not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e4f277788325aab9741bcaa7c47c