### PR TITLE
Fix AK-47 stress tolerance blueprint schema violation

### DIFF
--- a/data/blueprints/strain/hybrid/sativa-dominant/ak47.json
+++ b/data/blueprints/strain/hybrid/sativa-dominant/ak47.json
@@ -114,7 +114,8 @@
     "vpd_kPa": 0.15,
     "temp_C": 1.0,
     "rh_frac": 0.05,
-    "co2_ppm": 100
+    "co2_ppm": 100,
+    "ppfd_umol_m2s": 65
   },
   "methodAffinity": {
     "85cc0916-0e8a-495e-af8f-50291abe6855": 0.8,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### #63 AK-47 strain stress tolerance alignment
+
+- Added the missing `ppfd_umol_m2s` tolerance to the AK-47 strain blueprint so it
+  conforms to the strain schema and can load alongside the other hybrid
+  blueprints during physiology integration tests.
+
 ### #62 Harvest storage inventory MVP
 
 - Added deterministic `HarvestLot` and `Inventory` domain models with strict Zod


### PR DESCRIPTION
## Summary
- add the missing `ppfd_umol_m2s` tolerance to the AK-47 strain blueprint so it validates with the existing schema
- document the blueprint fix in the changelog for future traceability

## Testing
- pnpm -r test --filter engine -- --runInBand *(fails: spawn ENOENT because workspace dependencies are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e641a92c8325a8f038896832864c