### PR TITLE
Fix tariffs test floating point assertion

### DIFF
--- a/packages/engine/tests/unit/tariffs.spec.ts
+++ b/packages/engine/tests/unit/tariffs.spec.ts
@@ -29,10 +29,8 @@ describe('resolveTariffs', () => {
       }
     });
 
-    expect(tariffs).toEqual({
-      price_electricity: 0.525,
-      price_water: 4
-    });
+    expect(tariffs.price_electricity).toBeCloseTo(0.525, 10);
+    expect(tariffs.price_water).toBeCloseTo(4, 10);
   });
 
   it('prefers overrides over base prices when provided without factors', () => {


### PR DESCRIPTION
## Summary
- update the tariffs multiplicative factor test to use `toBeCloseTo` for floating point comparisons

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1e856061883259bf81bc3e12512e7