### PR TITLE
Fix harvest pipeline tests by generating valid plant IDs

### DIFF
--- a/packages/engine/tests/integration/pipeline/applyHarvestAndInventory.int.spec.ts
+++ b/packages/engine/tests/integration/pipeline/applyHarvestAndInventory.int.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { runTick } from '@/backend/src/engine/Engine.js';
 import { createDemoWorld } from '@/backend/src/engine/testHarness.js';
+import { createTestPlant } from '@/tests/testUtils/strainFixtures.js';
 import { inventoryByStructure } from '@/backend/src/readmodels/inventory/inventoryByStructure.js';
 import { inventoryByStorageRoom } from '@/backend/src/readmodels/inventory/inventoryByStorageRoom.js';
 import type { EngineRunContext } from '@/backend/src/engine/Engine.js';
@@ -14,11 +15,11 @@ function prepareHarvestScenario() {
   const structure = world.company.structures[0] as Mutable<typeof world.company.structures[0]>;
   const growRoom = structure.rooms.find((room) => room.purpose === 'growroom') as Mutable<Room>;
   const zone = growRoom.zones[0] as Mutable<Zone>;
-  const plant = zone.plants[0];
+  const basePlant = zone.plants[0] ?? createTestPlant();
 
   zone.plants = [
     {
-      ...plant,
+      ...basePlant,
       lifecycleStage: 'harvest-ready',
       biomass_g: 480,
       health01: 0.88,

--- a/packages/engine/tests/unit/engine/pipeline/applyHarvestAndInventory.unit.spec.ts
+++ b/packages/engine/tests/unit/engine/pipeline/applyHarvestAndInventory.unit.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { applyHarvestAndInventory } from '@/backend/src/engine/pipeline/applyHarvestAndInventory.js';
 import { createDemoWorld } from '@/backend/src/engine/testHarness.js';
+import { createTestPlant } from '@/tests/testUtils/strainFixtures.js';
 import type { EngineDiagnostic, EngineRunContext } from '@/backend/src/engine/Engine.js';
 import type { Plant, Room, Zone } from '@/backend/src/domain/world.js';
 import {
@@ -37,7 +38,7 @@ function createDiagnosticsRecorder() {
 }
 
 function prepareHarvestReadyPlant(zone: Mutable<Zone>): Plant {
-  const basePlant = zone.plants[0];
+  const basePlant = zone.plants[0] ?? createTestPlant();
   const plant: Plant = {
     ...basePlant,
     lifecycleStage: 'harvest-ready',


### PR DESCRIPTION
## Summary
- ensure the harvest unit test creates a fallback plant with a UUID when zones are empty
- ensure the harvest integration scenario reuses createTestPlant for a valid plant id

## Testing
- pnpm --filter @wb/engine test *(fails: vitest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e9337cb88325a015df658d934aa7