### PR TITLE
Align test utility aliases for engine tests

### DIFF
--- a/packages/engine/tests/integration/pipeline/applyHarvestAndInventory.int.spec.ts
+++ b/packages/engine/tests/integration/pipeline/applyHarvestAndInventory.int.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { runTick } from '@/backend/src/engine/Engine.js';
 import { createDemoWorld } from '@/backend/src/engine/testHarness.js';
-import { createTestPlant } from '@/tests/testUtils/strainFixtures.js';
+import { createTestPlant } from '@/tests/testUtils/strainFixtures.ts';
 import { inventoryByStructure } from '@/backend/src/readmodels/inventory/inventoryByStructure.js';
 import { inventoryByStorageRoom } from '@/backend/src/readmodels/inventory/inventoryByStorageRoom.js';
 import type { EngineRunContext } from '@/backend/src/engine/Engine.js';

--- a/packages/engine/tests/unit/engine/pipeline/applyHarvestAndInventory.unit.spec.ts
+++ b/packages/engine/tests/unit/engine/pipeline/applyHarvestAndInventory.unit.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { applyHarvestAndInventory } from '@/backend/src/engine/pipeline/applyHarvestAndInventory.js';
 import { createDemoWorld } from '@/backend/src/engine/testHarness.js';
-import { createTestPlant } from '@/tests/testUtils/strainFixtures.js';
+import { createTestPlant } from '@/tests/testUtils/strainFixtures.ts';
 import type { EngineDiagnostic, EngineRunContext } from '@/backend/src/engine/Engine.js';
 import type { Plant, Room, Zone } from '@/backend/src/domain/world.js';
 import {

--- a/packages/engine/vitest.config.ts
+++ b/packages/engine/vitest.config.ts
@@ -9,7 +9,8 @@ export default defineConfig({
   resolve: {
     alias: {
       '@wb/engine': path.resolve(packageDir, 'src/index.ts'),
-      '@/backend': path.resolve(packageDir, 'src/backend')
+      '@/backend': path.resolve(packageDir, 'src/backend'),
+      '@/tests': path.resolve(packageDir, 'tests')
     }
   },
   test: {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -43,6 +43,9 @@
       ],
       "@/backend/*": [
         "packages/engine/src/backend/*"
+      ],
+      "@/tests/*": [
+        "packages/engine/tests/*"
       ]
     }
   },


### PR DESCRIPTION
## Summary
- add the @/tests alias to the engine Vitest config so helper files resolve
- mirror the alias in the workspace tsconfig for TypeScript awareness
- update harvest pipeline specs to import the TypeScript strain fixtures directly

## Testing
- pnpm --filter @wb/engine test *(fails: vitest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1ee1b531883259042b2878fe263c8