### PR TITLE
Fix biomass increment unit conversion in growth util

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### #64 Physiology biomass increment unit correction
+
+- Converted the growth model `baseLightUseEfficiency` from kilograms to grams
+  during biomass calculations so strain blueprints keep SI unit storage while
+  the physiology util operates in grams.
+- Removed the redundant tick fraction multiplier from light-driven biomass
+  growth because the daily light integral increment is already scoped per tick,
+  preventing underestimation during multi-hour ticks.
+- Documented the expected units on the strain blueprint schema and refreshed
+  the growth utility tests to assert the revised maintenance scaling.
+
 ### #63 AK-47 strain stress tolerance alignment
 
 - Added the missing `ppfd_umol_m2s` tolerance to the AK-47 strain blueprint so it

--- a/packages/engine/src/backend/src/domain/blueprints/strainBlueprint.ts
+++ b/packages/engine/src/backend/src/domain/blueprints/strainBlueprint.ts
@@ -146,7 +146,9 @@ const harvestIndexSchema = z.union([
 const growthModelSchema = z
   .object({
     maxBiomassDry: positiveNumber,
-    baseLightUseEfficiency: positiveNumber,
+    baseLightUseEfficiency: positiveNumber.describe(
+      'Kilograms of dry matter produced per mol of PAR; converted to grams in growth calculations.'
+    ),
     maintenanceFracPerDay: finiteNumber.nonnegative(),
     dryMatterFraction: dryMatterFractionSchema,
     harvestIndex: harvestIndexSchema,

--- a/packages/engine/src/backend/src/util/growth.ts
+++ b/packages/engine/src/backend/src/util/growth.ts
@@ -120,15 +120,16 @@ export function calculateBiomassIncrement(
   const stressReduction = clamp01(1 - stress01);
   const phaseMultiplier = getPhaseMultiplier(lifecycleStage, growthModel);
   const dryMatterFraction = getDryMatterFraction(growthModel, lifecycleStage);
-  const lightUseEfficiency = growthModel.baseLightUseEfficiency;
+  // Blueprint stores baseLightUseEfficiency in kilograms of dry matter per mol of PAR.
+  // Convert to grams before applying the daily light integral increment which is already tick-scoped.
+  const lightUseEfficiency_g_per_mol = growthModel.baseLightUseEfficiency * 1_000;
   const tickFractionOfDay = tickHours / HOURS_PER_DAY;
   const baseGrowth =
     dli_mol_m2d_inc *
-    lightUseEfficiency *
+    lightUseEfficiency_g_per_mol *
     tempFactor *
     stressReduction *
     phaseMultiplier *
-    tickFractionOfDay *
     dryMatterFraction;
   const maintenanceCost = currentBiomass_g * growthModel.maintenanceFracPerDay * tickFractionOfDay;
   let netGrowth = baseGrowth - maintenanceCost;

--- a/packages/engine/tests/integration/pipeline/applyHarvestAndInventory.int.spec.ts
+++ b/packages/engine/tests/integration/pipeline/applyHarvestAndInventory.int.spec.ts
@@ -6,7 +6,7 @@ import { createTestPlant } from '@/tests/testUtils/strainFixtures.ts';
 import { inventoryByStructure } from '@/backend/src/readmodels/inventory/inventoryByStructure.js';
 import { inventoryByStorageRoom } from '@/backend/src/readmodels/inventory/inventoryByStorageRoom.js';
 import type { EngineRunContext } from '@/backend/src/engine/Engine.js';
-import type { Room, Zone } from '@/backend/src/domain/world.js';
+import type { Plant, Room, Zone } from '@/backend/src/domain/world.js';
 
 type Mutable<T> = { -readonly [K in keyof T]: T[K] };
 
@@ -20,6 +20,7 @@ function prepareHarvestScenario() {
   zone.plants = [
     {
       ...basePlant,
+      id: '00000000-0000-4000-8000-000000000001' as Plant['id'],
       lifecycleStage: 'harvest-ready',
       biomass_g: 480,
       health01: 0.88,
@@ -83,10 +84,10 @@ describe('applyHarvestAndInventory integration', () => {
       "roomId": "00000000-0000-4000-8000-000000000009",
       "source": {
         "plantId": "00000000-0000-4000-8000-000000000001",
-        "zoneId": "00000000-0000-4000-8000-000000000004"
+        "zoneId": "00000000-0000-4000-8000-000000000004",
       },
-      "structureId": "00000000-0000-4000-8000-000000000002"
-    }
+      "structureId": "00000000-0000-4000-8000-000000000002",
+    },
   ],
   "storageSummary": {
     "avgMoisture01": 0.6,
@@ -94,15 +95,15 @@ describe('applyHarvestAndInventory integration', () => {
     "roomId": "00000000-0000-4000-8000-000000000009",
     "structureId": "00000000-0000-4000-8000-000000000002",
     "totalFreshWeight_kg": 0.48,
-    "totalLots": 1
+    "totalLots": 1,
   },
   "structureSummary": {
     "avgMoisture01": 0.6,
     "avgQuality01": 0.85,
     "structureId": "00000000-0000-4000-8000-000000000002",
     "totalFreshWeight_kg": 0.48,
-    "totalLots": 1
-  }
+    "totalLots": 1,
+  },
 }`);
   });
 });

--- a/packages/engine/tests/unit/engine/pipeline/applyHarvestAndInventory.unit.spec.ts
+++ b/packages/engine/tests/unit/engine/pipeline/applyHarvestAndInventory.unit.spec.ts
@@ -41,6 +41,7 @@ function prepareHarvestReadyPlant(zone: Mutable<Zone>): Plant {
   const basePlant = zone.plants[0] ?? createTestPlant();
   const plant: Plant = {
     ...basePlant,
+    id: '00000000-0000-4000-8000-000000000001' as Plant['id'],
     lifecycleStage: 'harvest-ready',
     biomass_g: 500,
     health01: 0.9,

--- a/packages/engine/tests/unit/util/growth.test.ts
+++ b/packages/engine/tests/unit/util/growth.test.ts
@@ -89,29 +89,29 @@ describe('growth utilities', () => {
   describe('calculateBiomassIncrement', () => {
     it('returns positive growth under optimal conditions', () => {
       const strain = mockStrain();
-      const growth = calculateBiomassIncrement(20, 25, 0, strain, 'vegetative', 10, 1, rng(0.5));
+      const growth = calculateBiomassIncrement(0.5, 25, 0, strain, 'vegetative', 10, 1, rng(0.5));
       expect(growth).toBeGreaterThan(0);
     });
 
     it('reduces growth under high stress', () => {
       const strain = mockStrain();
-      const optimal = calculateBiomassIncrement(20, 25, 0, strain, 'vegetative', 10, 1, rng(0.5));
-      const stressed = calculateBiomassIncrement(20, 25, 0.8, strain, 'vegetative', 10, 1, rng(0.5));
+      const optimal = calculateBiomassIncrement(0.5, 25, 0, strain, 'vegetative', 10, 1, rng(0.5));
+      const stressed = calculateBiomassIncrement(0.5, 25, 0.8, strain, 'vegetative', 10, 1, rng(0.5));
       expect(stressed).toBeLessThan(optimal);
     });
 
     it('accounts for maintenance cost at higher biomass', () => {
       const strain = mockStrain();
-      const low = calculateBiomassIncrement(20, 25, 0, strain, 'vegetative', 10, 1, rng(0.5));
-      const high = calculateBiomassIncrement(20, 25, 0, strain, 'vegetative', 100, 1, rng(0.5));
+      const low = calculateBiomassIncrement(0.5, 25, 0, strain, 'vegetative', 10, 1, rng(0.5));
+      const high = calculateBiomassIncrement(0.5, 25, 0, strain, 'vegetative', 100, 1, rng(0.5));
       expect(high).toBeLessThan(low);
     });
 
     it('applies deterministic noise when enabled', () => {
       const strain = mockStrain();
       strain.noise = { enabled: true, pct: 0.1 };
-      const lower = calculateBiomassIncrement(20, 25, 0, strain, 'vegetative', 10, 1, rng(0));
-      const higher = calculateBiomassIncrement(20, 25, 0, strain, 'vegetative', 10, 1, rng(1));
+      const lower = calculateBiomassIncrement(0.5, 25, 0, strain, 'vegetative', 10, 1, rng(0));
+      const higher = calculateBiomassIncrement(0.5, 25, 0, strain, 'vegetative', 10, 1, rng(1));
       expect(lower).toBeLessThan(higher);
     });
 
@@ -127,18 +127,18 @@ describe('growth utilities', () => {
       expect(growth).toBe(0);
     });
 
-    it('scales with tick duration', () => {
+    it('applies higher maintenance costs over longer ticks', () => {
       const strain = mockStrain();
-      const oneHour = calculateBiomassIncrement(20, 25, 0, strain, 'vegetative', 10, 1, rng(0.5));
-      const twoHour = calculateBiomassIncrement(20, 25, 0, strain, 'vegetative', 10, 2, rng(0.5));
-      expect(twoHour).toBeGreaterThan(oneHour);
+      const oneHour = calculateBiomassIncrement(0.5, 25, 0, strain, 'vegetative', 10, 1, rng(0.5));
+      const twoHour = calculateBiomassIncrement(0.5, 25, 0, strain, 'vegetative', 10, 2, rng(0.5));
+      expect(twoHour).toBeLessThanOrEqual(oneHour);
     });
 
     it('scales growth by stage-specific dry matter fraction', () => {
       const strain = mockStrain();
       strain.growthModel.dryMatterFraction = { vegetation: 0.5, flowering: 0.2 };
       const vegetativeGrowth = calculateBiomassIncrement(
-        20,
+        0.5,
         25,
         0,
         strain,
@@ -148,7 +148,7 @@ describe('growth utilities', () => {
         rng(0.5)
       );
       const floweringGrowth = calculateBiomassIncrement(
-        20,
+        0.5,
         25,
         0,
         strain,


### PR DESCRIPTION
## Summary
- convert the biomass increment calculation to operate on grams by converting `baseLightUseEfficiency` and drop the redundant tick fraction
- document the growth model unit expectations on the strain blueprint schema and stabilise harvest fixtures for deterministic IDs
- refresh growth utility tests and CHANGELOG coverage for the corrected physiology behaviour

## Testing
- pnpm --filter @wb/engine test

------
https://chatgpt.com/codex/tasks/task_e_68e1ee98edbc832592bc285c9124e944