### PR TITLE
feat(engine): add seed-to-harvest reporting pipeline

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### #66 Seed-to-harvest reporting pipeline
+
+- Added `reporting/generateSeedToHarvestReport.ts` to compose the lifecycle orchestrator with the perf harness and emit
+  structured JSON (stage transitions, telemetry aggregates, perf traces) for downstream analysis.
+- Published a `tsx` CLI entrypoint and `pnpm --filter @wb/engine report:seed-to-harvest` script that persists artifacts to the
+  repository `/reporting` folder with scenario-aware filenames.
+- Documented the workflow in `docs/engine/simulation-reporting.md` and covered invariants via
+  `tests/integration/reporting/seedToHarvest.report.test.ts`.
+
 ### #65 Deterministic seed-to-harvest orchestrator
 
 - Added `seedToHarvest.ts` under the engine backend as a deterministic

--- a/docs/TDD.md
+++ b/docs/TDD.md
@@ -180,6 +180,7 @@ it('rejects zone device in non-grow room', () => {
 - `runTick(world, ctx, { trace: true })` returns `{ world, trace }` where `world` is the immutable post-tick snapshot and `trace` is an optional {@link TickTrace} with monotonic `startedAtNs`, `durationNs`, `endedAtNs`, and heap metrics for every stage without feeding wall-clock time into simulation logic.
 - `runOneTickWithTrace()` (engine test harness) clones the deterministic demo world and returns `{ world, context, trace }` for integration/unit assertions.
 - `withPerfHarness({ ticks })` executes repeated traced ticks and reports `{ traces, totalDurationNs, averageDurationNs, maxHeapUsedBytes }` so perf tests can guard throughput (< 5 ms avg/tick) and heap (< 64 MiB).
+- `generateSeedToHarvestReport({ ticks, scenario })` wraps the orchestrator and perf harness to emit JSON artifacts documenting lifecycle transitions + telemetry; see `docs/engine/simulation-reporting.md` for CLI usage and schema.
 - `createRecordingContext(buffer)` attaches the instrumentation hook so specs can assert that stage completions mirror the trace order.
 
 ---

--- a/docs/engine/simulation-reporting.md
+++ b/docs/engine/simulation-reporting.md
@@ -1,0 +1,75 @@
+# Simulation reporting — seed-to-harvest artifacts
+
+> **Source of truth order:** SEC → DD → TDD → this document. When guidance here and SEC disagree, follow the contract first.
+
+## 1) Purpose
+
+`generateSeedToHarvestReport()` composes the deterministic seed-to-harvest orchestrator with the performance harness so teams can
+produce shareable JSON artifacts that capture lifecycle stage transitions, perf traces, and harvest telemetry in a single
+package. The CLI wrapper writes these reports to `/reporting` at the repository root so downstream analysis tools have a stable
+pickup location.
+
+## 2) Inputs & configuration
+
+| Flag | Description | Default | Notes |
+| ---- | ----------- | ------- | ----- |
+| `--ticks <number>` | Number of traced ticks to capture via the perf harness. | `25` | Must be a finite integer ≥ 1. Mirrors TDD perf baseline guidance. |
+| `--scenario <name>` | Free-form label recorded in the report metadata. | `demo-world` | Use scenario slugs from DD/SEC appendices when running canonical worlds. |
+| `--output <file>` | Relative path (under `/reporting`) for the JSON artifact. | auto-generated using scenario + ISO timestamp | The CLI rejects absolute paths to keep artifacts scoped to `/reporting`. |
+
+Additional configuration for the orchestrator (e.g. custom world factories or strain overrides) can be supplied when calling
+`generateSeedToHarvestReport({ seedToHarvest: { … } })` programmatically. The CLI currently targets the demo world baseline.
+
+## 3) CLI usage
+
+```
+# Run from repository root. pnpm passes args to the underlying tsx process after --.
+pnpm --filter @wb/engine report:seed-to-harvest -- --ticks 40 --scenario white-widow --output white-widow/seed-to-harvest.json
+```
+
+The command ensures `/reporting` exists, normalises the tick count, and writes a prettified JSON artifact. The CLI prints the
+absolute path of the generated file on success.
+
+## 4) JSON schema
+
+TypeScript-flavoured pseudo schema describing the artifact shape:
+
+```ts
+interface SeedToHarvestReport {
+  metadata: {
+    scenario: string;           // scenario label recorded for traceability
+    generatedAt: string;        // ISO-8601 timestamp when the artifact was produced
+  };
+  summary: {
+    ticksElapsed: number;       // ticks required for the orchestrator run
+    totalBiomass_g: number;     // cumulative biomass for the seeded zone at completion
+    harvestedLotCount: number;  // count of harvest lots captured from inventory
+  };
+  stages: {
+    transitions: StageTransitionEvent[];          // per-plant lifecycle changes with tick + zone context
+    photoperiodTransitions: PhotoperiodTransitionEvent[]; // zone-level light regime flips (veg → flower)
+    summary: {
+      totalTransitions: number;                   // transitions.length
+      transitionsByStage: Partial<Record<PlantLifecycleStage, number>>; // counts grouped by target stage
+      photoperiodTransitionCount: number;         // photoperiodTransitions.length
+    };
+  };
+  telemetry: {
+    harvestEvents: HarvestTelemetryEvent[];       // filtered telemetry bus events (harvest created)
+    summary: {
+      totalEvents: number;                        // harvestEvents.length
+      byTopic: Record<string, number>;            // aggregate counts per telemetry topic
+    };
+  };
+  performance: {
+    tickCount: number;                            // perf harness sample size (matches CLI --ticks)
+    totalDurationNs: number;
+    averageDurationNs: number;
+    maxHeapUsedBytes: number;
+    traces: TickTrace[];                          // raw perf trace objects (see engine/trace.ts)
+  };
+}
+```
+
+Consumers can rely on the equality relationships noted in comments (e.g. `totalTransitions === transitions.length`) for
+validation. The schema mirrors the structures asserted in `packages/engine/tests/integration/reporting/seedToHarvest.report.test.ts`.

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -12,7 +12,8 @@
     "test": "vitest run",
     "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\"",
     "format": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\"",
-    "dev": "tsx watch src/index.ts"
+    "dev": "tsx watch src/index.ts",
+    "report:seed-to-harvest": "tsx src/backend/src/engine/reporting/cli.ts"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/packages/engine/src/backend/src/engine/reporting/cli.ts
+++ b/packages/engine/src/backend/src/engine/reporting/cli.ts
@@ -1,0 +1,152 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { generateSeedToHarvestReport } from './generateSeedToHarvestReport.js';
+
+interface CliArguments {
+  readonly ticks?: number;
+  readonly scenario?: string;
+  readonly output?: string;
+  readonly help?: boolean;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.help) {
+    printUsage();
+    return;
+  }
+
+  const scenario = args.scenario?.trim() || 'demo-world';
+  const tickCount = normaliseTickCount(args.ticks);
+  const report = generateSeedToHarvestReport({ ticks: tickCount, scenario });
+
+  const repoRoot = resolveRepoRoot();
+  const reportingDir = path.join(repoRoot, 'reporting');
+  const defaultFileName = buildDefaultFileName(report.metadata.scenario, report.metadata.generatedAt);
+  const outputName = args.output?.trim();
+
+  if (outputName && path.isAbsolute(outputName)) {
+    throw new Error('--output must be a relative path under the /reporting directory.');
+  }
+
+  const resolvedOutput = outputName ?? defaultFileName;
+  const outputPath = path.join(reportingDir, resolvedOutput);
+
+  await mkdir(reportingDir, { recursive: true });
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, JSON.stringify(report, null, 2), 'utf-8');
+
+  process.stdout.write(`Seed-to-harvest report written to ${outputPath}\n`);
+}
+
+function parseArgs(argv: readonly string[]): CliArguments {
+  const result: CliArguments = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const raw = argv[index];
+
+    if (!raw) {
+      continue;
+    }
+
+    if (raw === '--help' || raw === '-h') {
+      result.help = true;
+      continue;
+    }
+
+    const [flag, inlineValue] = raw.split('=', 2) as [string, string | undefined];
+
+    switch (flag) {
+      case '--ticks': {
+        const value = inlineValue ?? argv[++index];
+
+        if (!value) {
+          throw new Error('--ticks requires a numeric value.');
+        }
+
+        const parsed = Number(value);
+
+        if (!Number.isFinite(parsed)) {
+          throw new Error('--ticks must be a finite number.');
+        }
+
+        result.ticks = parsed;
+        break;
+      }
+
+      case '--scenario': {
+        const value = inlineValue ?? argv[++index];
+
+        if (!value) {
+          throw new Error('--scenario requires a value.');
+        }
+
+        result.scenario = value;
+        break;
+      }
+
+      case '--output': {
+        const value = inlineValue ?? argv[++index];
+
+        if (!value) {
+          throw new Error('--output requires a value.');
+        }
+
+        result.output = value;
+        break;
+      }
+
+      default: {
+        throw new Error(`Unknown option: ${flag}`);
+      }
+    }
+  }
+
+  return result;
+}
+
+function printUsage(): void {
+  const usage = `Usage: seed-to-harvest-report [options]\n\n` +
+    `Options:\n` +
+    `  --ticks <number>     Number of ticks to sample for the perf harness (default: 25)\n` +
+    `  --scenario <name>    Scenario label to embed in the report metadata (default: demo-world)\n` +
+    `  --output <file>      Relative path under /reporting for the JSON artifact\n` +
+    `  -h, --help           Show this help message\n`;
+
+  process.stdout.write(usage);
+}
+
+function normaliseTickCount(raw: number | undefined): number {
+  if (typeof raw !== 'number') {
+    return 25;
+  }
+
+  const ticks = Math.max(1, Math.trunc(raw));
+
+  if (!Number.isFinite(ticks)) {
+    throw new Error('Tick count must be a finite integer.');
+  }
+
+  return ticks;
+}
+
+function resolveRepoRoot(): string {
+  const here = fileURLToPath(new URL('.', import.meta.url));
+  return path.resolve(here, '../../../../../../..');
+}
+
+function buildDefaultFileName(scenario: string, generatedAt: string): string {
+  const safeScenario = scenario.replace(/[^a-z0-9\-]+/gi, '-').replace(/-{2,}/g, '-').toLowerCase();
+  const safeTimestamp = generatedAt.replace(/[:]/g, '-');
+  return `seed-to-harvest-${safeScenario}-${safeTimestamp}.json`;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  void main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/packages/engine/src/backend/src/engine/reporting/generateSeedToHarvestReport.ts
+++ b/packages/engine/src/backend/src/engine/reporting/generateSeedToHarvestReport.ts
@@ -1,0 +1,148 @@
+import { runSeedToHarvest, type SeedToHarvestConfig } from '../seedToHarvest.js';
+import { withPerfHarness } from '../testHarness.js';
+import type {
+  HarvestTelemetryEvent,
+  PhotoperiodTransitionEvent,
+  SeedToHarvestResult,
+  StageTransitionEvent
+} from '../seedToHarvest.js';
+import type { TickTrace } from '../trace.js';
+import type { PlantLifecycleStage } from '../../domain/entities.js';
+
+export interface SeedToHarvestReportOptions {
+  readonly scenario?: string;
+  readonly ticks?: number;
+  readonly seedToHarvest?: SeedToHarvestConfig;
+}
+
+export interface SeedToHarvestReportSummary {
+  readonly ticksElapsed: number;
+  readonly totalBiomass_g: number;
+  readonly harvestedLotCount: number;
+}
+
+export interface SeedToHarvestStageSummary {
+  readonly totalTransitions: number;
+  readonly transitionsByStage: Partial<Record<PlantLifecycleStage, number>>;
+  readonly photoperiodTransitionCount: number;
+}
+
+export interface SeedToHarvestTelemetrySummary {
+  readonly totalEvents: number;
+  readonly byTopic: Record<string, number>;
+}
+
+export interface SeedToHarvestPerformanceSummary {
+  readonly tickCount: number;
+  readonly totalDurationNs: number;
+  readonly averageDurationNs: number;
+  readonly maxHeapUsedBytes: number;
+  readonly traces: readonly TickTrace[];
+}
+
+export interface SeedToHarvestReportStages {
+  readonly transitions: readonly StageTransitionEvent[];
+  readonly photoperiodTransitions: readonly PhotoperiodTransitionEvent[];
+  readonly summary: SeedToHarvestStageSummary;
+}
+
+export interface SeedToHarvestReportTelemetry {
+  readonly harvestEvents: readonly HarvestTelemetryEvent[];
+  readonly summary: SeedToHarvestTelemetrySummary;
+}
+
+export interface SeedToHarvestReport {
+  readonly metadata: {
+    readonly scenario: string;
+    readonly generatedAt: string;
+  };
+  readonly summary: SeedToHarvestReportSummary;
+  readonly stages: SeedToHarvestReportStages;
+  readonly telemetry: SeedToHarvestReportTelemetry;
+  readonly performance: SeedToHarvestPerformanceSummary;
+}
+
+const DEFAULT_SCENARIO_NAME = 'demo-world';
+const DEFAULT_PERF_TICKS = 25;
+
+export function generateSeedToHarvestReport(
+  options: SeedToHarvestReportOptions = {}
+): SeedToHarvestReport {
+  const scenario = options.scenario?.trim() || DEFAULT_SCENARIO_NAME;
+  const perfTickBudget = normaliseTickCount(options.ticks ?? DEFAULT_PERF_TICKS);
+  const seedToHarvestConfig = options.seedToHarvest;
+
+  const seedToHarvestResult = runSeedToHarvest(seedToHarvestConfig);
+  const perfHarnessResult = withPerfHarness({
+    ticks: perfTickBudget,
+    worldFactory: seedToHarvestConfig?.worldFactory
+  });
+
+  const stageSummary = summariseStageTransitions(seedToHarvestResult);
+  const telemetrySummary = summariseTelemetry(seedToHarvestResult.harvestTelemetry);
+
+  return {
+    metadata: {
+      scenario,
+      generatedAt: new Date().toISOString()
+    },
+    summary: {
+      ticksElapsed: seedToHarvestResult.ticksElapsed,
+      totalBiomass_g: seedToHarvestResult.totalBiomass_g,
+      harvestedLotCount: seedToHarvestResult.harvestedLots.length
+    },
+    stages: {
+      transitions: seedToHarvestResult.stageTransitions,
+      photoperiodTransitions: seedToHarvestResult.photoperiodTransitions,
+      summary: stageSummary
+    },
+    telemetry: {
+      harvestEvents: seedToHarvestResult.harvestTelemetry,
+      summary: telemetrySummary
+    },
+    performance: {
+      tickCount: perfTickBudget,
+      totalDurationNs: perfHarnessResult.totalDurationNs,
+      averageDurationNs: perfHarnessResult.averageDurationNs,
+      maxHeapUsedBytes: perfHarnessResult.maxHeapUsedBytes,
+      traces: perfHarnessResult.traces
+    }
+  } satisfies SeedToHarvestReport;
+}
+
+function summariseStageTransitions(result: SeedToHarvestResult): SeedToHarvestStageSummary {
+  const byStage: Partial<Record<PlantLifecycleStage, number>> = {};
+
+  for (const transition of result.stageTransitions) {
+    byStage[transition.to] = (byStage[transition.to] ?? 0) + 1;
+  }
+
+  return {
+    totalTransitions: result.stageTransitions.length,
+    transitionsByStage: byStage,
+    photoperiodTransitionCount: result.photoperiodTransitions.length
+  } satisfies SeedToHarvestStageSummary;
+}
+
+function summariseTelemetry(events: readonly HarvestTelemetryEvent[]): SeedToHarvestTelemetrySummary {
+  const byTopic = new Map<string, number>();
+
+  for (const event of events) {
+    byTopic.set(event.topic, (byTopic.get(event.topic) ?? 0) + 1);
+  }
+
+  return {
+    totalEvents: events.length,
+    byTopic: Object.fromEntries(byTopic)
+  } satisfies SeedToHarvestTelemetrySummary;
+}
+
+function normaliseTickCount(value: number): number {
+  const ticks = Math.max(1, Math.trunc(value));
+
+  if (!Number.isFinite(ticks)) {
+    throw new Error('Tick count must be a finite integer value.');
+  }
+
+  return ticks;
+}

--- a/packages/engine/tests/integration/reporting/seedToHarvest.report.test.ts
+++ b/packages/engine/tests/integration/reporting/seedToHarvest.report.test.ts
@@ -1,0 +1,36 @@
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { generateSeedToHarvestReport } from '@/backend/src/engine/reporting/generateSeedToHarvestReport.js';
+
+describe('Seed-to-harvest reporting generator', () => {
+  it('produces a persisted report with consistent summaries', async () => {
+    const scenario = 'integration-test';
+    const tickCount = 5;
+    const report = generateSeedToHarvestReport({ ticks: tickCount, scenario });
+
+    expect(report.summary.ticksElapsed).toBeGreaterThan(0);
+    expect(report.performance.tickCount).toBe(tickCount);
+    expect(report.performance.traces).toHaveLength(tickCount);
+    expect(report.stages.summary.totalTransitions).toBe(report.stages.transitions.length);
+    expect(report.stages.summary.photoperiodTransitionCount).toBe(
+      report.stages.photoperiodTransitions.length
+    );
+    expect(report.telemetry.summary.totalEvents).toBe(report.telemetry.harvestEvents.length);
+
+    const tempDir = await mkdtemp(path.join(tmpdir(), 'wb-report-'));
+    const artifactPath = path.join(tempDir, 'seed-to-harvest.json');
+
+    await writeFile(artifactPath, JSON.stringify(report, null, 2), 'utf-8');
+
+    const persisted = JSON.parse(await readFile(artifactPath, 'utf-8')) as {
+      readonly metadata: { readonly scenario: string };
+      readonly performance: { readonly tickCount: number };
+    };
+
+    expect(persisted.metadata.scenario).toBe(scenario);
+    expect(persisted.performance.tickCount).toBe(tickCount);
+  });
+});


### PR DESCRIPTION
## Summary
- add a reporting generator that composes the seed-to-harvest orchestrator with the perf harness and returns structured JSON
- expose a tsx CLI wired to pnpm so reports land in the repo-level /reporting directory
- cover the workflow with integration tests and documentation, including a changelog entry

## Testing
- pnpm --filter @wb/engine test *(fails: vitest binary missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1f7efef9483259b23c0f8066f004a