### PR TITLE
Ignore reporting artifacts and document workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ dist
 
 # End of https://www.toptal.com/developers/gitignore/api/node
 /.vscode
+/reporting

--- a/docs/engine/simulation-reporting.md
+++ b/docs/engine/simulation-reporting.md
@@ -7,7 +7,8 @@
 `generateSeedToHarvestReport()` composes the deterministic seed-to-harvest orchestrator with the performance harness so teams can
 produce shareable JSON artifacts that capture lifecycle stage transitions, perf traces, and harvest telemetry in a single
 package. The CLI wrapper writes these reports to `/reporting` at the repository root so downstream analysis tools have a stable
-pickup location.
+pickup location. The `/reporting` directory is tracked in the root `.gitignore`, ensuring generated artifacts remain local and are
+never accidentally committed.
 
 ## 2) Inputs & configuration
 


### PR DESCRIPTION
## Summary
- ignore generated simulation reporting artifacts via the new `/reporting` entry in the root `.gitignore`
- document that the reporting directory is gitignored so generated reports stay local

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1f98f170483258d42376ea474c23a