### PR TITLE
docs: add reporting CLI prerequisites

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### #67 Reporting CLI tooling prerequisites
+
+- Documented Node.js/Corepack/pnpm setup prerequisites and troubleshooting guidance for the seed-to-harvest reporting CLI, clarifying that the repository `packageManager` metadata requires pnpm.
+
 ### #66 Seed-to-harvest reporting pipeline
 
 - Added `reporting/generateSeedToHarvestReport.ts` to compose the lifecycle orchestrator with the perf harness and emit

--- a/docs/engine/simulation-reporting.md
+++ b/docs/engine/simulation-reporting.md
@@ -21,7 +21,17 @@ never accidentally committed.
 Additional configuration for the orchestrator (e.g. custom world factories or strain overrides) can be supplied when calling
 `generateSeedToHarvestReport({ seedToHarvest: { … } })` programmatically. The CLI currently targets the demo world baseline.
 
-## 3) CLI usage
+## 3) Prerequisites
+
+Set up the workspace before invoking the report generator:
+
+- Use **Node.js v22 or newer** so the CLI matches the repository engine baseline.
+- Enable pnpm via Corepack with `corepack use pnpm@10.18.0`.
+- Install dependencies from the repository root using `pnpm install`.
+
+The workspace `packageManager` metadata in `package.json` pins pnpm and its integrity checksum, so `npm --filter …` and other npm-specific invocations are unsupported for the reporting command.
+
+## 4) CLI usage
 
 ```
 # Run from repository root. pnpm passes args to the underlying tsx process after --.
@@ -31,7 +41,11 @@ pnpm --filter @wb/engine report:seed-to-harvest -- --ticks 40 --scenario white-w
 The command ensures `/reporting` exists, normalises the tick count, and writes a prettified JSON artifact. The CLI prints the
 absolute path of the generated file on success.
 
-## 4) JSON schema
+### Troubleshooting
+
+If the command fails with `Cannot find module '@npmcli/config'`, npm handled the execution instead of pnpm/Corepack. Reinstall or repair npm so it respects the Corepack shim, or switch to pnpm with `corepack use pnpm@10.18.0` before running the CLI.
+
+## 5) JSON schema
 
 TypeScript-flavoured pseudo schema describing the artifact shape:
 


### PR DESCRIPTION
## Summary
- document the Node.js, Corepack, and pnpm prerequisites before running the reporting CLI
- describe the npm-based module resolution error and how to resolve it
- record the new guidance in the documentation changelog for future releases

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1fbe1c84083259f3ce17993a009e7