### PR TITLE
feat: enforce pnpm 10.18.0 during installs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### #68 Tooling - enforce pnpm 10.18.0 installs
+
+- Added a `preinstall` guard that aborts `pnpm install` when the package manager is not pnpm 10.18.0, relying on the workspace shim metadata.
+- Exposed a `verify-pnpm` script and helper utility so CI and contributors can assert the correct pnpm version without triggering an install.
+
+
 ### #67 Reporting CLI tooling prerequisites
 
 - Documented Node.js/Corepack/pnpm setup prerequisites and troubleshooting guidance for the seed-to-harvest reporting CLI, clarifying that the repository `packageManager` metadata requires pnpm.

--- a/docs/engine/simulation-reporting.md
+++ b/docs/engine/simulation-reporting.md
@@ -30,6 +30,7 @@ Set up the workspace before invoking the report generator:
 - Install dependencies from the repository root using `pnpm install`.
 
 The workspace `packageManager` metadata in `package.json` pins pnpm and its integrity checksum, so `npm --filter …` and other npm-specific invocations are unsupported for the reporting command.
+A root `preinstall` guard now aborts installs if pnpm 10.18.0 is not in use; run `pnpm run verify-pnpm` to check your environment before installing.
 
 ## 4) CLI usage
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "build": "pnpm -r build",
     "test": "pnpm -r test",
     "lint": "pnpm -r lint",
-    "format": "pnpm -r format"
+    "format": "pnpm -r format",
+    "preinstall": "node ./tools/scripts/ensure-pnpm.mjs",
+    "verify-pnpm": "node ./tools/scripts/ensure-pnpm.mjs"
   },
   "devDependencies": {
     "@eslint/js": "^9.5.0",

--- a/tools/scripts/ensure-pnpm.mjs
+++ b/tools/scripts/ensure-pnpm.mjs
@@ -1,0 +1,78 @@
+import { pathToFileURL } from 'node:url';
+
+const REQUIRED_MANAGER = 'pnpm';
+const REQUIRED_VERSION = '10.18.0';
+
+function parsePnpmVersion(userAgent) {
+  if (typeof userAgent !== 'string' || userAgent.trim() === '') {
+    return null;
+  }
+
+  const tokens = userAgent.split(/\s+/);
+  const pnpmToken = tokens.find((token) => token.startsWith(`${REQUIRED_MANAGER}/`));
+  if (!pnpmToken) {
+    return null;
+  }
+
+  const versionWithMetadata = pnpmToken.slice(pnpmToken.indexOf('/') + 1);
+  const [version] = versionWithMetadata.split('+');
+  return version ?? null;
+}
+
+export function ensurePnpm(env = process.env) {
+  const userAgent = env.npm_config_user_agent;
+  const execPath = env.npm_execpath;
+  const issues = [];
+
+  const detectedVersion = parsePnpmVersion(userAgent);
+
+  if (!detectedVersion) {
+    issues.push(
+      `Detected package manager user agent \"${userAgent ?? 'undefined'}\". ` +
+        `This does not look like pnpm ${REQUIRED_VERSION}.`
+    );
+  } else if (detectedVersion !== REQUIRED_VERSION) {
+    issues.push(
+      `Detected pnpm version ${detectedVersion}. The workspace is pinned to pnpm ${REQUIRED_VERSION}.`
+    );
+  }
+
+  if (typeof execPath === 'string' && execPath.trim() !== '') {
+    const normalizedExecPath = execPath.toLowerCase();
+    if (!normalizedExecPath.includes('pnpm')) {
+      issues.push(`npm_execpath resolved to ${execPath}, which is not a pnpm shim.`);
+    }
+  } else {
+    issues.push('npm_execpath is undefined; unable to confirm pnpm shim usage.');
+  }
+
+  if (issues.length > 0) {
+    const instructions = [
+      `This workspace must be installed with pnpm ${REQUIRED_VERSION}.`,
+      'Use Corepack to activate pnpm before running install commands:',
+      `  corepack use pnpm@${REQUIRED_VERSION}`,
+      '  pnpm install',
+      '',
+      ...issues,
+    ].join('\n');
+
+    throw new Error(`${instructions}\n`);
+  }
+}
+
+function isMainModule(url, argv) {
+  const entryUrl = argv?.[1] ? pathToFileURL(argv[1]).href : undefined;
+  return entryUrl !== undefined && url === entryUrl;
+}
+
+if (isMainModule(import.meta.url, process.argv)) {
+  try {
+    ensurePnpm();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(message);
+    process.exitCode = 1;
+  }
+}
+
+export { parsePnpmVersion };


### PR DESCRIPTION
## Summary
- add an install guard script that ensures dependency installs run under pnpm 10.18.0
- expose the helper via preinstall/verify-pnpm scripts and document the safety check in the changelog and reporting setup docs

## Testing
- npm_config_user_agent='pnpm/10.18.0 npm/? node/22.0.0' npm_execpath='/usr/local/lib/node_modules/pnpm/bin/pnpm.cjs' node tools/scripts/ensure-pnpm.mjs
- npm_config_user_agent='npm/10.0.0 node/22.0.0' npm_execpath='/usr/local/lib/node_modules/npm/bin/npm-cli.js' node tools/scripts/ensure-pnpm.mjs


------
https://chatgpt.com/codex/tasks/task_e_68e1fc7945bc8325a84c59760d736201