### PR TITLE
Fix blueprint loader defaults to resolve relative paths

### DIFF
--- a/packages/engine/src/backend/src/domain/blueprints/strainBlueprintLoader.ts
+++ b/packages/engine/src/backend/src/domain/blueprints/strainBlueprintLoader.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { parseStrainBlueprint, type StrainBlueprint } from './strainBlueprint.js';
 import type { Uuid } from '../entities.js';
@@ -9,7 +10,10 @@ export interface LoadStrainBlueprintOptions {
   readonly strict?: boolean;
 }
 
-const DEFAULT_BLUEPRINTS_ROOT = path.resolve('data/blueprints');
+const DEFAULT_BLUEPRINTS_ROOT = path.resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../../../../../data/blueprints'
+);
 
 let blueprintCache: Map<Uuid, StrainBlueprint> | null = null;
 

--- a/packages/engine/src/backend/src/domain/blueprints/taxonomy.ts
+++ b/packages/engine/src/backend/src/domain/blueprints/taxonomy.ts
@@ -1,6 +1,10 @@
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const DEFAULT_BLUEPRINTS_ROOT = path.resolve('data/blueprints');
+const DEFAULT_BLUEPRINTS_ROOT = path.resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../../../../../data/blueprints'
+);
 const TAXONOMY_SEGMENT_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 export interface BlueprintTaxonomyFromPath {


### PR DESCRIPTION
## Summary
- resolve the default blueprints root relative to the blueprint modules
- add fileURLToPath usage in strain blueprint loader and taxonomy utilities

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e20040388c8325a8dfbd902dcc6520