### PR TITLE
Fix blueprint loader defaults for top-level data directory

### DIFF
--- a/packages/engine/src/backend/src/domain/blueprints/strainBlueprintLoader.ts
+++ b/packages/engine/src/backend/src/domain/blueprints/strainBlueprintLoader.ts
@@ -11,8 +11,8 @@ export interface LoadStrainBlueprintOptions {
 }
 
 const DEFAULT_BLUEPRINTS_ROOT = path.resolve(
-  fileURLToPath(new URL('.', import.meta.url)),
-  '../../../../../../data/blueprints'
+  fileURLToPath(new URL('../../../../../../../', import.meta.url)),
+  'data/blueprints'
 );
 
 let blueprintCache: Map<Uuid, StrainBlueprint> | null = null;

--- a/packages/engine/src/backend/src/domain/blueprints/taxonomy.ts
+++ b/packages/engine/src/backend/src/domain/blueprints/taxonomy.ts
@@ -2,8 +2,8 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const DEFAULT_BLUEPRINTS_ROOT = path.resolve(
-  fileURLToPath(new URL('.', import.meta.url)),
-  '../../../../../../data/blueprints'
+  fileURLToPath(new URL('../../../../../../../', import.meta.url)),
+  'data/blueprints'
 );
 const TAXONOMY_SEGMENT_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 


### PR DESCRIPTION
## Summary
- point the strain blueprint loader's default root to the repository-level data/blueprints directory
- fix the taxonomy helper's default root to the same top-level location so taxonomy derivation resolves correctly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e237a674f48325b340c8e185aa3d4f