### PR TITLE
feat: integrate workforce domain model

### DIFF
--- a/data/configs/task_definitions.json
+++ b/data/configs/task_definitions.json
@@ -2,89 +2,100 @@
   "repair_device": {
     "costModel": { "basis": "perAction", "laborMinutes": 90 },
     "priority": 100,
-    "requiredRole": "Technician",
-    "requiredSkill": "Maintenance",
-    "minSkillLevel": 2,
+    "requiredRoleSlug": "technician",
+    "requiredSkills": [
+      { "skillKey": "maintenance", "minSkill01": 0.4 }
+    ],
     "description": "Repair {deviceName} in {zoneName}"
   },
   "maintain_device": {
     "costModel": { "basis": "perAction", "laborMinutes": 30 },
     "priority": 30,
-    "requiredRole": "Technician",
-    "requiredSkill": "Maintenance",
-    "minSkillLevel": 4,
+    "requiredRoleSlug": "technician",
+    "requiredSkills": [
+      { "skillKey": "maintenance", "minSkill01": 0.8 }
+    ],
     "description": "Maintain {deviceName} in {zoneName}"
   },
   "harvest_plants": {
     "costModel": { "basis": "perPlant", "laborMinutes": 5 },
     "priority": 90,
-    "requiredRole": "Gardener",
-    "requiredSkill": "Gardening",
-    "minSkillLevel": 0,
+    "requiredRoleSlug": "gardener",
+    "requiredSkills": [
+      { "skillKey": "gardening", "minSkill01": 0 }
+    ],
     "description": "Harvest {plantCount} plants in {zoneName}"
   },
   "refill_supplies_water": {
     "costModel": { "basis": "perAction", "laborMinutes": 15 },
     "priority": 80,
-    "requiredRole": "Gardener",
-    "requiredSkill": "Gardening",
-    "minSkillLevel": 0,
+    "requiredRoleSlug": "gardener",
+    "requiredSkills": [
+      { "skillKey": "gardening", "minSkill01": 0 }
+    ],
     "description": "Refill water in {zoneName}"
   },
   "refill_supplies_nutrients": {
     "costModel": { "basis": "perAction", "laborMinutes": 15 },
     "priority": 80,
-    "requiredRole": "Gardener",
-    "requiredSkill": "Gardening",
-    "minSkillLevel": 0,
+    "requiredRoleSlug": "gardener",
+    "requiredSkills": [
+      { "skillKey": "gardening", "minSkill01": 0 }
+    ],
     "description": "Refill nutrients in {zoneName}"
   },
   "clean_zone": {
     "costModel": { "basis": "perSquareMeter", "laborMinutes": 1 },
     "priority": 60,
-    "requiredRole": "Janitor",
-    "requiredSkill": "Cleanliness",
-    "minSkillLevel": 0,
+    "requiredRoleSlug": "janitor",
+    "requiredSkills": [
+      { "skillKey": "cleanliness", "minSkill01": 0 }
+    ],
     "description": "Clean {zoneName} ({area}m²)"
   },
   "overhaul_zone_substrate": {
     "costModel": { "basis": "perSquareMeter", "laborMinutes": 5 },
     "priority": 70,
-    "requiredRole": "Janitor",
-    "requiredSkill": "Cleanliness",
-    "minSkillLevel": 2,
+    "requiredRoleSlug": "janitor",
+    "requiredSkills": [
+      { "skillKey": "cleanliness", "minSkill01": 0.4 }
+    ],
     "description": "Overhaul substrate in {zoneName} ({area}m²)"
   },
   "reset_light_cycle": {
     "costModel": { "basis": "perAction", "laborMinutes": 5 },
     "priority": 50,
-    "requiredRole": "Gardener",
-    "requiredSkill": "Gardening",
-    "minSkillLevel": 0,
+    "requiredRoleSlug": "gardener",
+    "requiredSkills": [
+      { "skillKey": "gardening", "minSkill01": 0 }
+    ],
     "description": "Reset light cycle in {zoneName}"
   },
   "execute_planting_plan": {
     "costModel": { "basis": "perPlant", "laborMinutes": 2 },
     "priority": 40,
-    "requiredRole": "Gardener",
-    "requiredSkill": "Gardening",
-    "minSkillLevel": 0,
+    "requiredRoleSlug": "gardener",
+    "requiredSkills": [
+      { "skillKey": "gardening", "minSkill01": 0 }
+    ],
     "description": "Plant {plantCount} seedlings in {zoneName}"
   },
   "adjust_light_cycle": {
     "costModel": { "basis": "perAction", "laborMinutes": 5 },
     "priority": 80,
-    "requiredRole": "Gardener",
-    "requiredSkill": "Gardening",
-    "minSkillLevel": 3,
+    "requiredRoleSlug": "gardener",
+    "requiredSkills": [
+      { "skillKey": "gardening", "minSkill01": 0.6 }
+    ],
     "description": "Adjust light cycle in {zoneName} for flowering"
   },
   "apply_treatment": {
     "costModel": { "basis": "perPlant", "laborMinutes": 4 },
     "priority": 90,
-    "requiredRole": "Gardener",
-    "requiredSkill": "Gardening",
-    "minSkillLevel": 2,
+    "requiredRoleSlug": "gardener",
+    "requiredSkills": [
+      { "skillKey": "gardening", "minSkill01": 0.4 }
+    ],
     "description": "Apply {treatmentName} to affected plants in {zoneName}"
   }
 }

--- a/docs/ADR/ADR-0013-workforce-domain-model.md
+++ b/docs/ADR/ADR-0013-workforce-domain-model.md
@@ -1,0 +1,44 @@
+# ADR-0013: Workforce Domain Model Integration
+
+- **Status:** Accepted
+- **Date:** 2025-10-05
+- **Authors:** Simulation Engine Working Group
+
+## Context
+
+SEC §10 mandates a deterministic workforce directory with reproducible RNG streams, structured task requirements, and
+telemetry-ready KPIs. The reboot branch still stored task metadata in a legacy ad-hoc shape (`requiredRole`, `requiredSkill`,
+`minSkillLevel`) and lacked first-class domain modules or schemas for employees, roles, and workforce KPIs. Without canonical
+schemas the façade could not validate incoming workforce payloads, and simulation snapshots (`SimulationWorld`) had no place to
+persist employee state, task queues, or aggregated labour metrics. Downstream tooling (scheduler, telemetry, UI) therefore had no
+contract to rely on when modelling labour availability or overtime policies.
+
+## Decision
+
+- Introduce dedicated workforce domain modules (`EmployeeRole`, `Employee`, `WorkforceState`, task/KPI structures) inside the
+  backend domain package and expose them through the world barrel so simulation snapshots embed a deterministic workforce branch.
+- Extend the shared Zod schemas with workforce collections, UUID v7 validation for employee RNG seeds, morale/fatigue clamps on the
+  `[0,1]` scale, and explicit working-hour limits (base 5–16 h, overtime ≤ 5 h, days per week 1–7, optional shift start hour 0–23).
+- Normalise `/data/configs/task_definitions.json` to use `requiredRoleSlug` plus structured `requiredSkills` entries (`skillKey`,
+  `minSkill01`), deriving the normalised threshold by mapping the former integer level (`0..5`) onto the SEC skill scale (`level/5`).
+- Embed the workforce branch into `SimulationWorld` so savegame snapshots, telemetry, and downstream analytics can evolve against a
+  single canonical structure.
+
+## Consequences
+
+### Positive
+
+- Workforce data has a deterministic contract that façade validation, schedulers, and read-model projections can share.
+- UUID v7 enforcement on employee RNG seeds eliminates ambiguous randomness sources and keeps trait generation reproducible.
+- Structured task definitions unblock future automation and intent validation because skills/roles share the same canonical keys.
+- Documentation (DD/TDD/Changelog) now captures workforce invariants for onboarding and review.
+
+### Negative
+
+- Data producers must migrate to the new task definition shape before pushing scenarios; the legacy fields are no longer parsed.
+- Additional schema constraints may reject previously tolerated workforce payloads until upstream exporters are aligned.
+
+### Follow-up
+
+- Model skill catalogues and hiring markets as separate data sources once SEC §10.4/§10.5 expands beyond the MVP scope.
+- Extend telemetry/read-model layers to surface workforce KPIs once façade transport coverage begins.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### #69 Workforce domain scaffolding
+
+- Introduced dedicated workforce domain modules (`EmployeeRole`, `Employee`, `WorkforceState`, task and KPI structures) and
+  exposed them through the engine world barrel so simulation snapshots embed deterministic workforce data.
+- Extended the shared domain schemas with workforce collections, UUID v7 validation for employee RNG seeds, 0..1 skill/morale/fatigue
+  clamps, and working-hour limits (base 5–16 h, overtime ≤ 5 h) accompanied by unit coverage in `workforceSchemas.test.ts`.
+- Normalised `/data/configs/task_definitions.json` to use `requiredRoleSlug` plus structured `requiredSkills` entries (`skillKey`,
+  `minSkill01`) keeping thresholds aligned to the SEC skill scale.
+- Documented the workforce branch in `docs/DD.md` and added schema coverage guidance to `docs/TDD.md`.
+
 ### #68 Tooling - enforce pnpm 10.18.0 installs
 
 - Added a `preinstall` guard that aborts `pnpm install` when the package manager is not pnpm 10.18.0, relying on the workspace shim metadata.

--- a/docs/DD.md
+++ b/docs/DD.md
@@ -158,9 +158,27 @@ targets from the same factor to keep unit conversions deterministic.
 **Derived costs**
 
 - Electricity: `kWh = (powerW / 1000) * hoursOn`; `cost = kWh * tariff.kWh`.
-    
+
 - Water: `m3 = liters / 1000`; `cost = m3 * tariff.m3`.
-    
+
+
+## 5a) Workforce Domain (SEC §10)
+
+- `SimulationWorld` embeds a deterministic `workforce` branch alongside the company tree. The branch collects:
+  - `roles`: immutable catalogue of `EmployeeRole` records with SEC-aligned slugs and optional descriptions.
+  - `employees`: directory of `Employee` entities carrying morale/fatigue (`0..1` scale), role assignment, structure assignment, and
+    a deterministic `rngSeedUuid` (UUID v7) for stochastic trait streams.
+  - `taskDefinitions`: scheduling templates that expose `requiredRoleSlug`, structured `requiredSkills` (`skillKey` + `minSkill01`),
+    deterministic labour cost models, and integer priorities.
+  - `taskQueue`: queued/in-progress task instances used by the dispatcher and telemetry.
+  - `kpis`: rolling `WorkforceKpiSnapshot` entries summarising throughput, labour hours, overtime, and aggregate morale/fatigue.
+- `Employee.schedule` constrains base hours to **5–16 h per in-game day**, allows overtime up to **+5 h**, and records the number of
+  working days per week (`1..7`) with an optional shift start hour (`0..23`). Schema guards reject violations and normalise seeds to UUID v7.
+- `Employee.skills` and `EmployeeRole.coreSkills` share the `EmployeeSkillRequirement` shape (`skillKey`, `minSkill01 ∈ [0,1]`).
+- Task definitions in `/data/configs/task_definitions.json` now store deterministic `requiredRoleSlug` values and structured
+  `requiredSkills` arrays. Legacy integer skill levels were mapped onto `minSkill01 = level/5` to preserve intent while aligning to
+  the canonical [0,1] skill scale referenced by SEC §10.
+
 
 ---
 

--- a/docs/TDD.md
+++ b/docs/TDD.md
@@ -124,7 +124,7 @@ it('stable sequences per stream', () => {
 ## 5) Light Schedule Contract (SEC §8)
 
 - Domains: `onHours ∈ [0,24]`, `offHours ∈ [0,24]`, integer or **0.25h** grid.
-    
+
 - Constraint: `onHours + offHours = 24`.
     
 - Optional: `startHour ∈ [0,24)`.
@@ -146,6 +146,15 @@ describe('Light schedule — SEC §8', () => {
   });
 });
 ```
+
+---
+
+## 5a) Workforce Schema Coverage (SEC §10)
+
+- `employeeSchema` enforces UUID v7 seeds, morale/fatigue bounds (`0..1`), and working-hour policy: base hours **5–16**, overtime **≤ 5**, `daysPerWeek ∈ [1,7]`.
+- `workforceTaskDefinitionSchema` rejects skill thresholds outside `[0,1]` and mandates structured `requiredSkills` entries.
+- `workforceStateSchema` validates the full branch (`roles`, `employees`, `taskDefinitions`, `taskQueue`, `kpis`) embedded in the world snapshot to guard deterministic scheduling inputs.
+- Unit coverage: `tests/unit/domain/workforceSchemas.test.ts` exercises the above constraints and snapshot parsing.
 
 ---
 

--- a/packages/engine/src/backend/src/domain/entities.ts
+++ b/packages/engine/src/backend/src/domain/entities.ts
@@ -1,4 +1,5 @@
 import type { Inventory } from './types/Inventory.js';
+import type { WorkforceState } from './workforce/WorkforceState.js';
 
 /**
  * Branded string type representing a UUID v4 identifier.
@@ -350,4 +351,6 @@ export interface SimulationWorld {
   readonly simTimeHours: number;
   /** Company-centric world tree. */
   readonly company: Company;
+  /** Workforce directory, task queue, and KPI snapshots. */
+  readonly workforce: WorkforceState;
 }

--- a/packages/engine/src/backend/src/domain/workforce/Employee.ts
+++ b/packages/engine/src/backend/src/domain/workforce/Employee.ts
@@ -1,0 +1,55 @@
+import type { DomainEntity, Uuid } from '../entities.js';
+import type { EmployeeSkillRequirement } from './EmployeeRole.js';
+
+/**
+ * Brand describing UUID v7 identifiers that seed RNG streams.
+ */
+export type EmployeeRngSeedUuid = string & { readonly __brand: unique symbol };
+
+/**
+ * Captures the proficiency of an employee for a specific skill key.
+ */
+export interface EmployeeSkillLevel {
+  /** Skill identifier shared across workforce catalogues. */
+  readonly skillKey: string;
+  /** Normalised skill level in the inclusive range [0, 1]. */
+  readonly level01: number;
+}
+
+/**
+ * Working hours configuration for an employee.
+ */
+export interface EmployeeSchedule {
+  /** Planned base working hours per in-game day. */
+  readonly hoursPerDay: number;
+  /** Permitted overtime on top of base hours per in-game day. */
+  readonly overtimeHoursPerDay: number;
+  /** Number of working days planned per in-game week. */
+  readonly daysPerWeek: number;
+  /** Optional shift start expressed as in-game hour of day (0..23). */
+  readonly shiftStartHour?: number;
+}
+
+/**
+ * Canonical representation of an employee in the simulation workforce directory.
+ */
+export interface Employee extends DomainEntity {
+  /** Identifier of the role describing this employee's responsibilities. */
+  readonly roleId: Uuid;
+  /** Deterministic RNG seed (UUID v7) used for stochastic employee traits. */
+  readonly rngSeedUuid: EmployeeRngSeedUuid;
+  /** Identifier of the structure the employee is currently assigned to. */
+  readonly assignedStructureId: Uuid;
+  /** Normalised morale on the inclusive range [0, 1]. */
+  readonly morale01: number;
+  /** Normalised fatigue on the inclusive range [0, 1]. */
+  readonly fatigue01: number;
+  /** Skill proficiencies mastered by the employee. */
+  readonly skills: readonly EmployeeSkillLevel[];
+  /** Optional skill requirements tracked for employee development. */
+  readonly developmentPlan?: readonly EmployeeSkillRequirement[];
+  /** Working hour policy applied to the employee. */
+  readonly schedule: EmployeeSchedule;
+  /** Optional free-form notes aiding HR diagnostics. */
+  readonly notes?: string;
+}

--- a/packages/engine/src/backend/src/domain/workforce/EmployeeRole.ts
+++ b/packages/engine/src/backend/src/domain/workforce/EmployeeRole.ts
@@ -1,0 +1,23 @@
+import type { DomainEntity, SluggedEntity } from '../entities.js';
+
+/**
+ * Describes a unique skill requirement expressed on the normalised 0..1 scale.
+ */
+export interface EmployeeSkillRequirement {
+  /** Canonical skill identifier shared across workforce data catalogues. */
+  readonly skillKey: string;
+  /** Minimum skill proficiency required to satisfy the requirement. */
+  readonly minSkill01: number;
+}
+
+/**
+ * Canonical representation of a workforce role as referenced by tasks and employees.
+ */
+export interface EmployeeRole extends DomainEntity, SluggedEntity {
+  /** Free-form description highlighting responsibilities and scope. */
+  readonly description?: string;
+  /** Skills that are expected for any employee performing this role. */
+  readonly coreSkills: readonly EmployeeSkillRequirement[];
+  /** Optional list of tags that classify the role (e.g. compliance, operations). */
+  readonly tags?: readonly string[];
+}

--- a/packages/engine/src/backend/src/domain/workforce/WorkforceState.ts
+++ b/packages/engine/src/backend/src/domain/workforce/WorkforceState.ts
@@ -1,0 +1,20 @@
+import type { Employee } from './Employee.js';
+import type { EmployeeRole } from './EmployeeRole.js';
+import type { WorkforceKpiSnapshot } from './kpis.js';
+import type { WorkforceTaskDefinition, WorkforceTaskInstance } from './tasks.js';
+
+/**
+ * Aggregated workforce domain state embedded inside the simulation world snapshot.
+ */
+export interface WorkforceState {
+  /** Workforce role catalogue. */
+  readonly roles: readonly EmployeeRole[];
+  /** Deterministic directory of employees employed by the company. */
+  readonly employees: readonly Employee[];
+  /** Task definitions available to the scheduler. */
+  readonly taskDefinitions: readonly WorkforceTaskDefinition[];
+  /** Active task queue containing queued and in-progress tasks. */
+  readonly taskQueue: readonly WorkforceTaskInstance[];
+  /** KPI snapshots aggregated over recent simulation windows. */
+  readonly kpis: readonly WorkforceKpiSnapshot[];
+}

--- a/packages/engine/src/backend/src/domain/workforce/kpis.ts
+++ b/packages/engine/src/backend/src/domain/workforce/kpis.ts
@@ -1,0 +1,17 @@
+/**
+ * Snapshot of workforce performance metrics evaluated at a specific simulation tick.
+ */
+export interface WorkforceKpiSnapshot {
+  /** Simulation tick (in-game hour) when the KPI snapshot was generated. */
+  readonly simTimeHours: number;
+  /** Number of tasks completed during the previous tick window. */
+  readonly tasksCompleted: number;
+  /** Total labour hours committed (base hours only) in the window. */
+  readonly laborHoursCommitted: number;
+  /** Total overtime hours committed in the window. */
+  readonly overtimeHoursCommitted: number;
+  /** Average morale across active employees. */
+  readonly averageMorale01: number;
+  /** Average fatigue across active employees. */
+  readonly averageFatigue01: number;
+}

--- a/packages/engine/src/backend/src/domain/workforce/tasks.ts
+++ b/packages/engine/src/backend/src/domain/workforce/tasks.ts
@@ -1,0 +1,55 @@
+import type { Uuid } from '../entities.js';
+import type { EmployeeSkillRequirement } from './EmployeeRole.js';
+
+/**
+ * Supported bases for labour cost estimations inside task definitions.
+ */
+export type WorkforceTaskCostBasis = 'perAction' | 'perPlant' | 'perSquareMeter';
+
+/**
+ * Describes the deterministic labour cost model for a task definition.
+ */
+export interface WorkforceTaskCostModel {
+  /** Unit on which the labour estimate is based. */
+  readonly basis: WorkforceTaskCostBasis;
+  /** Expected labour demand in minutes for the given basis. */
+  readonly laborMinutes: number;
+}
+
+/**
+ * Canonical definition of a workforce task.
+ */
+export interface WorkforceTaskDefinition {
+  /** Unique identifier for the task definition. */
+  readonly taskCode: string;
+  /** Localised description template supporting token substitution. */
+  readonly description: string;
+  /** Role slug required to execute the task. */
+  readonly requiredRoleSlug: string;
+  /** Skills and minimum proficiency thresholds required to perform the task. */
+  readonly requiredSkills: readonly EmployeeSkillRequirement[];
+  /** Deterministic priority weight for scheduling. */
+  readonly priority: number;
+  /** Labour cost model used for scheduling and economic projections. */
+  readonly costModel: WorkforceTaskCostModel;
+}
+
+/**
+ * Instance representation of a queued or active workforce task.
+ */
+export interface WorkforceTaskInstance {
+  /** Unique identifier of the task instance. */
+  readonly id: Uuid;
+  /** Code referencing the originating task definition. */
+  readonly taskCode: WorkforceTaskDefinition['taskCode'];
+  /** Current lifecycle state of the task. */
+  readonly status: 'queued' | 'in-progress' | 'completed' | 'cancelled';
+  /** Simulation tick (hour) at which the task was created. */
+  readonly createdAtTick: number;
+  /** Optional simulation tick when the task must be completed. */
+  readonly dueTick?: number;
+  /** Identifier of the employee assigned to the task, if any. */
+  readonly assignedEmployeeId?: Uuid;
+  /** Additional contextual data to support assignment heuristics. */
+  readonly context?: Record<string, unknown>;
+}

--- a/packages/engine/src/backend/src/domain/world.ts
+++ b/packages/engine/src/backend/src/domain/world.ts
@@ -13,3 +13,8 @@ export * from './irrigation/waterUsage.js';
 export * from './interfaces/index.js';
 export * from './types/HarvestLot.js';
 export * from './types/Inventory.js';
+export * from './workforce/Employee.js';
+export * from './workforce/EmployeeRole.js';
+export * from './workforce/WorkforceState.js';
+export * from './workforce/tasks.js';
+export * from './workforce/kpis.js';

--- a/packages/engine/tests/unit/domain/workforceSchemas.test.ts
+++ b/packages/engine/tests/unit/domain/workforceSchemas.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  employeeSchema,
+  workforceStateSchema,
+  workforceTaskDefinitionSchema
+} from '@/backend/src/domain/schemas.js';
+
+const VALID_EMPLOYEE = {
+  id: '00000000-0000-0000-0000-000000002001',
+  name: 'Alex Example',
+  roleId: '00000000-0000-0000-0000-000000001001',
+  rngSeedUuid: '018f43f1-8b44-7b74-b3ce-5fbd7be3c201',
+  assignedStructureId: '00000000-0000-0000-0000-000000003001',
+  morale01: 0.75,
+  fatigue01: 0.25,
+  skills: [
+    {
+      skillKey: 'gardening',
+      level01: 0.6
+    }
+  ],
+  developmentPlan: [
+    {
+      skillKey: 'maintenance',
+      minSkill01: 0.5
+    }
+  ],
+  schedule: {
+    hoursPerDay: 8,
+    overtimeHoursPerDay: 2,
+    daysPerWeek: 5,
+    shiftStartHour: 6
+  },
+  notes: 'Senior grow technician'
+};
+
+const VALID_WORKFORCE_STATE = {
+  roles: [
+    {
+      id: '00000000-0000-0000-0000-000000001001',
+      slug: 'gardener',
+      name: 'Gardener',
+      coreSkills: [
+        {
+          skillKey: 'gardening',
+          minSkill01: 0.5
+        }
+      ]
+    }
+  ],
+  employees: [VALID_EMPLOYEE],
+  taskDefinitions: [
+    {
+      taskCode: 'harvest_plants',
+      description: 'Harvest mature plants in a grow zone.',
+      requiredRoleSlug: 'gardener',
+      requiredSkills: [
+        {
+          skillKey: 'gardening',
+          minSkill01: 0.5
+        }
+      ],
+      priority: 80,
+      costModel: {
+        basis: 'perPlant',
+        laborMinutes: 5
+      }
+    }
+  ],
+  taskQueue: [
+    {
+      id: '00000000-0000-0000-0000-000000004001',
+      taskCode: 'harvest_plants',
+      status: 'queued',
+      createdAtTick: 12,
+      context: {
+        zoneId: '00000000-0000-0000-0000-000000005001'
+      }
+    }
+  ],
+  kpis: [
+    {
+      simTimeHours: 24,
+      tasksCompleted: 5,
+      laborHoursCommitted: 12,
+      overtimeHoursCommitted: 3,
+      averageMorale01: 0.8,
+      averageFatigue01: 0.2
+    }
+  ]
+};
+
+describe('workforce schemas', () => {
+  it('accepts a valid employee and enforces deterministic uuid v7 seeds', () => {
+    const parsed = employeeSchema.parse(VALID_EMPLOYEE);
+
+    expect(parsed.rngSeedUuid).toBe(VALID_EMPLOYEE.rngSeedUuid);
+  });
+
+  it('rejects employees with non v7 rng seeds', () => {
+    expect(() =>
+      employeeSchema.parse({
+        ...VALID_EMPLOYEE,
+        rngSeedUuid: '00000000-0000-0000-0000-000000000000'
+      })
+    ).toThrowErrorMatchingInlineSnapshot('"Expected a UUID v7 identifier."');
+  });
+
+  it('rejects employees with schedules outside allowed working hours', () => {
+    expect(() =>
+      employeeSchema.parse({
+        ...VALID_EMPLOYEE,
+        schedule: {
+          ...VALID_EMPLOYEE.schedule,
+          hoursPerDay: 4
+        }
+      })
+    ).toThrowErrorMatchingInlineSnapshot('"hoursPerDay must be at least 5 hours."');
+
+    expect(() =>
+      employeeSchema.parse({
+        ...VALID_EMPLOYEE,
+        schedule: {
+          ...VALID_EMPLOYEE.schedule,
+          overtimeHoursPerDay: 6
+        }
+      })
+    ).toThrowErrorMatchingInlineSnapshot('"overtimeHoursPerDay must not exceed 5 hours."');
+  });
+
+  it('requires skill thresholds to remain within the 0..1 scale', () => {
+    const result = workforceTaskDefinitionSchema.safeParse({
+      taskCode: 'invalid-skill-threshold',
+      description: 'Sanity check task',
+      requiredRoleSlug: 'gardener',
+      requiredSkills: [
+        {
+          skillKey: 'gardening',
+          minSkill01: 1.2
+        }
+      ],
+      priority: 10,
+      costModel: {
+        basis: 'perAction',
+        laborMinutes: 5
+      }
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('parses a full workforce state snapshot', () => {
+    const parsed = workforceStateSchema.parse(VALID_WORKFORCE_STATE);
+
+    expect(parsed.roles).toHaveLength(1);
+    expect(parsed.employees).toHaveLength(1);
+    expect(parsed.taskQueue[0]?.status).toBe('queued');
+  });
+});


### PR DESCRIPTION
## Summary
- add workforce domain modules for employees, roles, tasks, KPIs and expose them through the world exports
- extend shared schemas plus SimulationWorld to embed the workforce branch and cover it with unit tests
- normalise task definitions to structured skill thresholds and document the workforce model (DD/TDD/CHANGELOG, new ADR)

## Testing
- pnpm --filter @wb/engine test *(fails: vitest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e251ef02b883259f510188dd33e4be