### PR TITLE
Add deterministic workforce identity source with pseudodata fallback

### DIFF
--- a/docs/ADR/ADR-0014-workforce-identity-pseudodata.md
+++ b/docs/ADR/ADR-0014-workforce-identity-pseudodata.md
@@ -1,0 +1,35 @@
+# ADR-0014: Workforce Identity Pseudodata Guarantees
+
+- **Status:** Accepted
+- **Date:** 2025-10-06
+- **Authors:** Simulation Engine Working Group
+
+## Context
+
+The workforce hiring flow requires human-readable employee identities for UI diagnostics and hiring pipelines. We want to provide plausible names for immersion but must avoid shipping or storing real personally identifiable information. The reboot codebase previously had no canonical mechanism to source deterministic pseudodata identities; prototypes sprinkled ad-hoc `Math.random()` calls or hard-coded placeholder strings, breaking SEC §1 determinism and providing no documentation of the privacy stance.
+
+SEC §10 also mandates that any stochastic employee attributes (names, pronouns, traits) derive from the deterministic RNG interface. Without a documented approach, contributors risk mixing real datasets, leaking unstable seeds, or calling remote APIs without clear fallbacks or privacy expectations.
+
+## Decision
+
+- Introduce a dedicated workforce identity source that first queries `randomuser.me` using an explicit seed and a strict 500 ms timeout. The remote response is mapped onto the engine's gender triad (`m|f|d`) and combined with deterministically sampled traits.
+- When the remote API fails or times out the engine deterministically falls back to curated pseudodata lists under `/data/personnel/**`, selecting gender, first and last names, and traits via `createRng(rngSeedUuid, "employee:<rngSeedUuid>")`.
+- Document in code comments and this ADR that only pseudodata is stored or emitted, and that the RNG stream naming isolates employee identity draws from other simulation randomness.
+
+## Consequences
+
+### Positive
+
+- Workforce identities remain deterministic and reproducible across online/offline environments, satisfying SEC §1 determinism guarantees.
+- The pseudodata fallback ensures we never persist real-world PII while keeping immersion for testers and UI reviewers.
+- Clear documentation enables security reviews to verify that the engine only consumes third-party identity data transiently and never stores it without pseudonymisation.
+
+### Negative
+
+- Reliance on `randomuser.me` introduces a soft dependency on an external service; contributors must ensure CI and offline environments respect the 500 ms timeout and handle failures gracefully.
+- Maintaining pseudodata lists (names, traits) becomes part of release hygiene to avoid repetition or cultural bias.
+
+### Follow-up
+
+- Extend the identity source once SEC clarifies additional demographic attributes (pronouns, locale, avatar URLs) while keeping pseudodata guarantees intact.
+- Consider caching layers or seed registries if future workloads generate large batches of identities in disconnected environments.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### #70 Workforce identity pseudodata source
+
+- Added a workforce identity service that queries `randomuser.me` with deterministic seeds,
+  maps genders onto the engine triad, and enforces a 500 ms timeout before falling back to
+  curated pseudodata lists.
+- Ensured offline pseudodata draws use `createRng` with the documented `employee:<rngSeedUuid>`
+  stream and covered the logic with unit tests for online, timeout, and offline golden seeds.
+- Captured the privacy assumptions in ADR-0014 so reviewers understand that only pseudonymous
+  test data is persisted or emitted.
+
 ### #69 Workforce domain scaffolding
 
 - Introduced dedicated workforce domain modules (`EmployeeRole`, `Employee`, `WorkforceState`, task and KPI structures) and

--- a/packages/engine/src/backend/src/services/workforce/identitySource.ts
+++ b/packages/engine/src/backend/src/services/workforce/identitySource.ts
@@ -1,0 +1,194 @@
+import { createRng, type RandomNumberGenerator } from '../../util/rng.js';
+import type { EmployeeRngSeedUuid } from '../../domain/workforce/Employee.js';
+
+import firstNamesFemaleJson from '../../../../../../../data/personnel/names/firstNamesFemale.json' assert { type: 'json' };
+import firstNamesMaleJson from '../../../../../../../data/personnel/names/firstNamesMale.json' assert { type: 'json' };
+import lastNamesJson from '../../../../../../../data/personnel/names/lastNames.json' assert { type: 'json' };
+import traitsJson from '../../../../../../../data/personnel/traits.json' assert { type: 'json' };
+
+const RANDOM_USER_ENDPOINT = 'https://randomuser.me/api/';
+const RANDOM_USER_TIMEOUT_MS = 500;
+
+const femaleFirstNames = firstNamesFemaleJson as readonly string[];
+const maleFirstNames = firstNamesMaleJson as readonly string[];
+const combinedFirstNames: readonly string[] = [
+  ...new Set([...femaleFirstNames, ...maleFirstNames]),
+];
+const lastNames = lastNamesJson as readonly string[];
+
+export type WorkforceIdentityGender = 'm' | 'f' | 'd';
+
+export interface WorkforceIdentityTrait {
+  readonly id: string;
+  readonly name: string;
+  readonly description: string;
+  readonly type: 'positive' | 'negative';
+}
+
+const traits = traitsJson as readonly WorkforceIdentityTrait[];
+
+export interface WorkforceIdentity {
+  readonly firstName: string;
+  readonly lastName: string;
+  readonly gender: WorkforceIdentityGender;
+  readonly traits: readonly WorkforceIdentityTrait[];
+  readonly source: 'randomuser' | 'fallback';
+}
+
+export interface ResolveWorkforceIdentityOptions {
+  /** Seed forwarded to the randomuser API for deterministic personas. */
+  readonly randomUserSeed: string;
+  /**
+   * Deterministic RNG seed for employee specific draws.
+   *
+   * The stream identifier follows the documented `employee:<rngSeedUuid>` convention so
+   * all employee-related randomness stays isolated from other RNG consumers.
+   */
+  readonly rngSeedUuid: EmployeeRngSeedUuid;
+}
+
+type RandomUserGender = 'male' | 'female' | string;
+
+type RandomUserResponse = {
+  readonly results?: readonly [
+    {
+      readonly gender?: RandomUserGender;
+      readonly name?: { readonly first?: string; readonly last?: string };
+    },
+  ];
+};
+
+/**
+ * Resolves a deterministic workforce identity by preferring the randomuser.me API and falling back to local pseudodata.
+ */
+export async function resolveWorkforceIdentity(
+  options: ResolveWorkforceIdentityOptions,
+): Promise<WorkforceIdentity> {
+  const { randomUserSeed, rngSeedUuid } = options;
+
+  if (!randomUserSeed) {
+    throw new Error('randomUserSeed must be a non-empty string');
+  }
+
+  if (!rngSeedUuid) {
+    throw new Error('rngSeedUuid must be a non-empty string');
+  }
+
+  const rng = createRng(rngSeedUuid, `employee:${rngSeedUuid}`);
+  const selectedTraits = selectTraits(rng);
+
+  const remoteIdentity = await requestRandomUserIdentity(randomUserSeed);
+
+  if (remoteIdentity) {
+    return {
+      ...remoteIdentity,
+      traits: selectedTraits,
+      source: 'randomuser',
+    };
+  }
+
+  const fallbackIdentity = buildFallbackIdentity(rng);
+
+  return {
+    ...fallbackIdentity,
+    traits: selectedTraits,
+    source: 'fallback',
+  };
+}
+
+async function requestRandomUserIdentity(
+  randomUserSeed: string,
+): Promise<Pick<WorkforceIdentity, 'firstName' | 'lastName' | 'gender'> | null> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), RANDOM_USER_TIMEOUT_MS);
+
+  try {
+    const url = new URL(RANDOM_USER_ENDPOINT);
+    url.searchParams.set('seed', randomUserSeed);
+    url.searchParams.set('inc', 'gender,name');
+    url.searchParams.set('noinfo', 'true');
+
+    const response = await fetch(url, { signal: controller.signal });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const payload = (await response.json()) as RandomUserResponse;
+    const result = payload.results?.[0];
+
+    if (!result?.name?.first || !result.name.last) {
+      return null;
+    }
+
+    return {
+      firstName: result.name.first,
+      lastName: result.name.last,
+      gender: mapGender(result.gender),
+    };
+  } catch (error: unknown) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      return null;
+    }
+
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function mapGender(gender?: RandomUserGender): WorkforceIdentityGender {
+  if (gender === 'male') {
+    return 'm';
+  }
+
+  if (gender === 'female') {
+    return 'f';
+  }
+
+  return 'd';
+}
+
+function buildFallbackIdentity(
+  rng: RandomNumberGenerator,
+): Pick<WorkforceIdentity, 'firstName' | 'lastName' | 'gender'> {
+  const gender = rollGender(rng);
+  const firstName = selectFirstName(rng, gender);
+  const lastName = selectLastName(rng);
+
+  return {
+    gender,
+    firstName,
+    lastName,
+  };
+}
+
+function rollGender(rng: RandomNumberGenerator): WorkforceIdentityGender {
+  const roll = rng();
+
+  if (roll < 0.49) {
+    return 'm';
+  }
+
+  if (roll < 0.98) {
+    return 'f';
+  }
+
+  return 'd';
+}
+
+function selectFirstName(rng: RandomNumberGenerator, gender: WorkforceIdentityGender): string {
+  const names =
+    gender === 'm' ? maleFirstNames : gender === 'f' ? femaleFirstNames : combinedFirstNames;
+
+  return names[Math.floor(rng() * names.length) % names.length];
+}
+
+function selectLastName(rng: RandomNumberGenerator): string {
+  return lastNames[Math.floor(rng() * lastNames.length) % lastNames.length];
+}
+
+function selectTraits(rng: RandomNumberGenerator): readonly WorkforceIdentityTrait[] {
+  const index = Math.floor(rng() * traits.length) % traits.length;
+  return [traits[index]];
+}

--- a/packages/engine/tests/unit/services/workforce/identitySource.test.ts
+++ b/packages/engine/tests/unit/services/workforce/identitySource.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { EmployeeRngSeedUuid } from '@/backend/src/domain/workforce/Employee.js';
+import { resolveWorkforceIdentity } from '@/backend/src/services/workforce/identitySource.js';
+
+describe('resolveWorkforceIdentity', () => {
+  const ONLINE_SEED = 'online-seed';
+  const RNG_SEED_ALPHA = '018f29ce-0000-7000-8000-0000000000a1' as EmployeeRngSeedUuid;
+  const RNG_SEED_BRAVO = '018f29ce-0000-7000-8000-0000000000b2' as EmployeeRngSeedUuid;
+  const RNG_SEED_CHARLIE = '018f29ce-0000-7000-8000-0000000000c3' as EmployeeRngSeedUuid;
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('returns identity from randomuser when the HTTP request succeeds', async () => {
+    const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>(() =>
+      Promise.resolve({
+        ok: true,
+        json: async () => ({
+          results: [
+            {
+              gender: 'male',
+              name: { first: 'Jordan', last: 'Rivera' },
+            },
+          ],
+        }),
+      } as unknown as Response),
+    );
+
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+
+    const identity = await resolveWorkforceIdentity({
+      randomUserSeed: ONLINE_SEED,
+      rngSeedUuid: RNG_SEED_ALPHA,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const requestUrl = fetchMock.mock.calls[0][0] as URL;
+    expect(requestUrl).toBeInstanceOf(URL);
+    expect(requestUrl.searchParams.get('seed')).toBe(ONLINE_SEED);
+    expect(requestUrl.searchParams.get('inc')).toBe('gender,name');
+    expect(requestUrl.searchParams.get('noinfo')).toBe('true');
+
+    expect(identity).toMatchObject({
+      firstName: 'Jordan',
+      lastName: 'Rivera',
+      gender: 'm',
+      source: 'randomuser',
+    });
+
+    expect(identity.traits).toMatchInlineSnapshot(`
+      [
+        {
+          "description": "Slightly increases the chance of minor errors during maintenance tasks.",
+          "id": "trait_clumsy",
+          "name": "Clumsy",
+          "type": "negative",
+        },
+      ]
+    `);
+  });
+
+  it('falls back to pseudodata when the randomuser request times out', async () => {
+    const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>((_, init) =>
+      new Promise((_, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          reject(new DOMException('aborted', 'AbortError'));
+        });
+      }),
+    );
+
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+    vi.useFakeTimers();
+
+    const identityPromise = resolveWorkforceIdentity({
+      randomUserSeed: ONLINE_SEED,
+      rngSeedUuid: RNG_SEED_BRAVO,
+    });
+
+    await vi.advanceTimersByTimeAsync(600);
+    const identity = await identityPromise;
+
+    expect(identity).toMatchObject({ source: 'fallback' });
+    expect(identity).toMatchInlineSnapshot(`
+      {
+        "firstName": "Aria",
+        "gender": "f",
+        "lastName": "Banerjee",
+        "source": "fallback",
+        "traits": [
+          {
+            "description": "Accepts a slightly lower salary than their skills would normally demand.",
+            "id": "trait_frugal",
+            "name": "Frugal",
+            "type": "positive",
+          },
+        ],
+      }
+    `);
+  });
+
+  it('uses deterministic pseudodata when the HTTP request fails', async () => {
+    const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>(() =>
+      Promise.reject(new Error('network unavailable')),
+    );
+
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+
+    const identity = await resolveWorkforceIdentity({
+      randomUserSeed: 'unused-seed',
+      rngSeedUuid: RNG_SEED_CHARLIE,
+    });
+
+    expect(identity).toMatchObject({ source: 'fallback' });
+    expect(identity).toMatchInlineSnapshot(`
+      {
+        "firstName": "Jessica",
+        "gender": "f",
+        "lastName": "Chavez",
+        "source": "fallback",
+        "traits": [
+          {
+            "description": "Slightly increases the chance of minor errors during maintenance tasks.",
+            "id": "trait_clumsy",
+            "name": "Clumsy",
+            "type": "negative",
+          },
+        ],
+      }
+    `);
+  });
+});


### PR DESCRIPTION
## Summary
- add a workforce identity resolver that prefers randomuser.me with a 500 ms timeout and maps API genders into the engine triad
- seed the offline pseudodata fallback with `createRng` using the `employee:<rngSeedUuid>` stream so names and traits remain deterministic
- exercise online, timeout, and offline paths with unit tests and document the privacy stance in ADR-0014 plus the changelog

## Testing
- `pnpm --filter @wb/engine exec vitest run tests/unit/services/workforce/identitySource.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68e254142590832585b6d8ef676f2b1e