### PR TITLE
Add workforce scheduling pipeline stage

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### #71 Workforce scheduling pipeline stage
+
+- Added the `applyWorkforce` pipeline phase between irrigation and economy to dispatch queued tasks per structure, enforce role/skill minimums, honor working-hour limits, and update morale/fatigue (including the breakroom recovery rule).
+- Captured per-tick workforce KPIs (queue depth, throughput, utilisation, p95 wait, overtime minutes, maintenance backlog) in the world snapshot and exposed a runtime context for telemetry consumers.
+- Extended domain schemas/tests to cover the enriched KPI shape and added integration coverage for priority ordering, deterministic tie resolution, and overtime/breakroom effects.
+- Updated TDD/DD documentation to reflect the nine-stage tick pipeline and the new workforce scheduling responsibilities.
+
 ### #70 Workforce identity pseudodata source
 
 - Added a workforce identity service that queries `randomuser.me` with deterministic seeds,

--- a/docs/DD.md
+++ b/docs/DD.md
@@ -184,16 +184,17 @@ targets from the same factor to keep unit conversions deterministic.
 
 ## 6) Tick Pipeline (SEC §4.2)
 
-Fixed order per tick (8 phases):
+Fixed order per tick (9 phases):
 
 1. **Device Effects** — compute device outputs (light, heat, airflow, CO₂, dehumidification) subject to capacity & efficiency.
 2. **Sensor Sampling** — record zone state before environmental integration so co-housed actuators observe pre-actuation values.
 3. **Environment Update** — integrate device outputs into zone state (well-mixed model baseline).
 4. **Irrigation & Nutrients** — fulfill zone method (manual enqueues tasks; automated fulfills on schedule).
-5. **Plant Physiology** — update age/phase, biomass, stress, disease risk using strain curves and environment.
-6. **Harvest & Inventory** — create lots when criteria met; move yield to inventory.
-7. **Economy & Cost Accrual** — aggregate consumption/costs; maintenance curves progress.
-8. **Commit & Telemetry** — snapshot state and publish read-only events.
+5. **Workforce Scheduling** — dispatch queued labour, enforce structure-binding, skill minimums, working-hour caps, and update morale/fatigue while emitting KPIs.
+6. **Plant Physiology** — update age/phase, biomass, stress, disease risk using strain curves and environment.
+7. **Harvest & Inventory** — create lots when criteria met; move yield to inventory.
+8. **Economy & Cost Accrual** — aggregate consumption/costs; maintenance curves progress.
+9. **Commit & Telemetry** — snapshot state and publish read-only events.
     
 
 ---

--- a/docs/TDD.md
+++ b/docs/TDD.md
@@ -180,10 +180,10 @@ it('rejects zone device in non-grow room', () => {
 
 ## 7) Tick trace instrumentation & perf harness (Engine)
 
-- Canonical order: `applyDeviceEffects → applySensors → updateEnvironment → applyIrrigationAndNutrients → advancePhysiology → applyHarvestAndInventory → applyEconomyAccrual → commitAndTelemetry` (mirrors SEC §4.2).
+- Canonical order: `applyDeviceEffects → applySensors → updateEnvironment → applyIrrigationAndNutrients → applyWorkforce → advancePhysiology → applyHarvestAndInventory → applyEconomyAccrual → commitAndTelemetry` (mirrors SEC §4.2).
 
 **Checklist (order trace):**
-- [ ] runTick(..., { trace: true }) yields exactly 8 phases
+- [ ] runTick(..., { trace: true }) yields exactly 9 phases
 - [ ] Second item is "applySensors" (before environment integration)
 - [ ] No extra or missing phases; names match public stage symbols
 - `runTick(world, ctx, { trace: true })` returns `{ world, trace }` where `world` is the immutable post-tick snapshot and `trace` is an optional {@link TickTrace} with monotonic `startedAtNs`, `durationNs`, `endedAtNs`, and heap metrics for every stage without feeding wall-clock time into simulation logic.

--- a/packages/engine/src/backend/src/domain/schemas.ts
+++ b/packages/engine/src/backend/src/domain/schemas.ts
@@ -162,8 +162,17 @@ export const workforceKpiSnapshotSchema: z.ZodType<WorkforceKpiSnapshot> = z.obj
   tasksCompleted: finiteNumber
     .min(0, 'tasksCompleted cannot be negative.')
     .transform((value) => Math.trunc(value)),
+  queueDepth: finiteNumber
+    .min(0, 'queueDepth cannot be negative.')
+    .transform((value) => Math.trunc(value)),
   laborHoursCommitted: finiteNumber.min(0, 'laborHoursCommitted cannot be negative.'),
   overtimeHoursCommitted: finiteNumber.min(0, 'overtimeHoursCommitted cannot be negative.'),
+  overtimeMinutes: finiteNumber.min(0, 'overtimeMinutes cannot be negative.'),
+  utilization01: zeroToOneNumber,
+  p95WaitTimeHours: finiteNumber.min(0, 'p95WaitTimeHours cannot be negative.'),
+  maintenanceBacklog: finiteNumber
+    .min(0, 'maintenanceBacklog cannot be negative.')
+    .transform((value) => Math.trunc(value)),
   averageMorale01: zeroToOneNumber,
   averageFatigue01: zeroToOneNumber
 });

--- a/packages/engine/src/backend/src/domain/workforce/kpis.ts
+++ b/packages/engine/src/backend/src/domain/workforce/kpis.ts
@@ -6,10 +6,20 @@ export interface WorkforceKpiSnapshot {
   readonly simTimeHours: number;
   /** Number of tasks completed during the previous tick window. */
   readonly tasksCompleted: number;
+  /** Number of tasks remaining in the queue after scheduling. */
+  readonly queueDepth: number;
   /** Total labour hours committed (base hours only) in the window. */
   readonly laborHoursCommitted: number;
   /** Total overtime hours committed in the window. */
   readonly overtimeHoursCommitted: number;
+  /** Aggregate overtime minutes committed in the window. */
+  readonly overtimeMinutes: number;
+  /** Utilisation ratio across the available labour capacity for the tick window. */
+  readonly utilization01: number;
+  /** 95th percentile wait time (in hours) for tasks completed in the window. */
+  readonly p95WaitTimeHours: number;
+  /** Count of queued maintenance tasks remaining after scheduling. */
+  readonly maintenanceBacklog: number;
   /** Average morale across active employees. */
   readonly averageMorale01: number;
   /** Average fatigue across active employees. */

--- a/packages/engine/src/backend/src/engine/Engine.ts
+++ b/packages/engine/src/backend/src/engine/Engine.ts
@@ -7,6 +7,7 @@ import {
   applyIrrigationAndNutrients,
   clearIrrigationNutrientsRuntime,
 } from './pipeline/applyIrrigationAndNutrients.js';
+import { applyWorkforce, clearWorkforceRuntime } from './pipeline/applyWorkforce.js';
 import { advancePhysiology } from './pipeline/advancePhysiology.js';
 import { applyHarvestAndInventory } from './pipeline/applyHarvestAndInventory.js';
 import { applyEconomyAccrual } from './pipeline/applyEconomyAccrual.js';
@@ -97,6 +98,7 @@ const PIPELINE_DEFINITION: readonly (readonly [StepName, PipelineStage])[] = [
   ['applySensors', applySensors],
   ['updateEnvironment', updateEnvironment],
   ['applyIrrigationAndNutrients', applyIrrigationAndNutrients],
+  ['applyWorkforce', applyWorkforce],
   ['advancePhysiology', advancePhysiology],
   ['applyHarvestAndInventory', applyHarvestAndInventory],
   ['applyEconomyAccrual', applyEconomyAccrual],
@@ -147,6 +149,10 @@ export function runTick(
 
     if (stepName === 'applyIrrigationAndNutrients') {
       clearIrrigationNutrientsRuntime(ctx);
+    }
+
+    if (stepName === 'applyWorkforce') {
+      clearWorkforceRuntime(ctx);
     }
   }
 

--- a/packages/engine/src/backend/src/engine/pipeline/applyWorkforce.ts
+++ b/packages/engine/src/backend/src/engine/pipeline/applyWorkforce.ts
@@ -1,0 +1,573 @@
+import { clamp01 } from '../../util/math.js';
+import type {
+  Employee,
+  EmployeeRole,
+  Room,
+  SimulationWorld,
+  Structure,
+  WorkforceKpiSnapshot,
+  WorkforceState,
+  WorkforceTaskDefinition,
+  WorkforceTaskInstance,
+  Zone,
+} from '../../domain/world.js';
+import type { EngineRunContext as EngineContext } from '../Engine.js';
+
+const SCORE_EPSILON = 1e-6;
+const OVERTIME_MORALE_PENALTY_PER_HOUR = 0.02;
+const MAX_DAILY_MORALE_PENALTY = 0.1;
+const FATIGUE_GAIN_PER_HOUR = 0.01;
+const BREAKROOM_FATIGUE_RECOVERY_PER_HALF_HOUR = 0.02;
+
+interface EmployeeUsage {
+  baseMinutes: number;
+  overtimeMinutes: number;
+  moralePenalty: number;
+}
+
+export interface WorkforceAssignment {
+  readonly taskId: WorkforceTaskInstance['id'];
+  readonly employeeId: Employee['id'];
+  readonly baseMinutes: number;
+  readonly overtimeMinutes: number;
+  readonly waitTimeHours: number;
+}
+
+export interface WorkforceRuntime {
+  readonly assignments: readonly WorkforceAssignment[];
+  readonly kpiSnapshot?: WorkforceKpiSnapshot;
+}
+
+type WorkforceRuntimeMutable = {
+  assignments: WorkforceAssignment[];
+  kpiSnapshot?: WorkforceKpiSnapshot;
+};
+
+type Mutable<T> = { -readonly [K in keyof T]: T[K] };
+
+type WorkforceRuntimeCarrier = Mutable<EngineContext> & {
+  [WORKFORCE_RUNTIME_CONTEXT_KEY]?: WorkforceRuntimeMutable;
+};
+
+const WORKFORCE_RUNTIME_CONTEXT_KEY = '__wb_workforceRuntime' as const;
+
+function setWorkforceRuntime(
+  ctx: EngineContext,
+  runtime: WorkforceRuntimeMutable,
+): WorkforceRuntimeMutable {
+  (ctx as WorkforceRuntimeCarrier)[WORKFORCE_RUNTIME_CONTEXT_KEY] = runtime;
+  return runtime;
+}
+
+export function ensureWorkforceRuntime(ctx: EngineContext): WorkforceRuntimeMutable {
+  return setWorkforceRuntime(ctx, { assignments: [] });
+}
+
+export function getWorkforceRuntime(ctx: EngineContext): WorkforceRuntime | undefined {
+  return (ctx as WorkforceRuntimeCarrier)[WORKFORCE_RUNTIME_CONTEXT_KEY];
+}
+
+export function clearWorkforceRuntime(ctx: EngineContext): void {
+  delete (ctx as WorkforceRuntimeCarrier)[WORKFORCE_RUNTIME_CONTEXT_KEY];
+}
+
+interface CandidateEvaluation {
+  employee: Employee;
+  score: number;
+  baseMinutes: number;
+  overtimeMinutes: number;
+}
+
+function resolveRoleSlug(roleId: EmployeeRole['id'], roles: readonly EmployeeRole[]): string | null {
+  const role = roles.find((entry) => entry.id === roleId);
+  return role?.slug ?? null;
+}
+
+function ensureUsage(map: Map<Employee['id'], EmployeeUsage>, employeeId: Employee['id']): EmployeeUsage {
+  const current = map.get(employeeId);
+
+  if (current) {
+    return current;
+  }
+
+  const usage: EmployeeUsage = {
+    baseMinutes: 0,
+    overtimeMinutes: 0,
+    moralePenalty: 0,
+  };
+  map.set(employeeId, usage);
+  return usage;
+}
+
+function resolveStructureLookups(world: SimulationWorld): {
+  readonly roomToStructure: Map<Room['id'], Structure['id']>;
+  readonly zoneToStructure: Map<Zone['id'], Structure['id']>;
+} {
+  const roomToStructure = new Map<Room['id'], Structure['id']>();
+  const zoneToStructure = new Map<Zone['id'], Structure['id']>();
+
+  for (const structure of world.company.structures) {
+    for (const room of structure.rooms) {
+      roomToStructure.set(room.id, structure.id);
+
+      for (const zone of room.zones) {
+        zoneToStructure.set(zone.id, structure.id);
+      }
+    }
+  }
+
+  return { roomToStructure, zoneToStructure };
+}
+
+function resolveStructureId(
+  task: WorkforceTaskInstance,
+  lookups: ReturnType<typeof resolveStructureLookups>,
+): Structure['id'] | null {
+  const context = (task.context ?? {}) as Record<string, unknown>;
+  const explicitStructure = typeof context.structureId === 'string' ? context.structureId : null;
+
+  if (explicitStructure) {
+    return explicitStructure as Structure['id'];
+  }
+
+  const roomId = typeof context.roomId === 'string' ? (context.roomId as Room['id']) : null;
+  if (roomId) {
+    const structureId = lookups.roomToStructure.get(roomId);
+    if (structureId) {
+      return structureId;
+    }
+  }
+
+  const zoneId = typeof context.zoneId === 'string' ? (context.zoneId as Zone['id']) : null;
+  if (zoneId) {
+    const structureId = lookups.zoneToStructure.get(zoneId);
+    if (structureId) {
+      return structureId;
+    }
+  }
+
+  return null;
+}
+
+function resolveTaskDemandMinutes(
+  task: WorkforceTaskInstance,
+  definition: WorkforceTaskDefinition,
+): number {
+  const baseMinutes = Math.max(0, Number(definition.costModel.laborMinutes) || 0);
+  const context = (task.context ?? {}) as Record<string, unknown>;
+
+  if (baseMinutes <= 0) {
+    return 0;
+  }
+
+  switch (definition.costModel.basis) {
+    case 'perPlant': {
+      const plantCountRaw = context.plantCount ?? context.plants ?? 1;
+      const plantCount = Number(plantCountRaw);
+      return baseMinutes * (Number.isFinite(plantCount) && plantCount > 0 ? plantCount : 1);
+    }
+    case 'perSquareMeter': {
+      const areaRaw = context.area_m2 ?? context.squareMeters ?? context.area ?? 1;
+      const area = Number(areaRaw);
+      return baseMinutes * (Number.isFinite(area) && area > 0 ? area : 1);
+    }
+    default:
+      return baseMinutes;
+  }
+}
+
+function computeSkillScore(
+  employee: Employee,
+  definition: WorkforceTaskDefinition,
+): { valid: boolean; score: number } {
+  if (definition.requiredSkills.length === 0) {
+    const aggregated = employee.skills.reduce((sum, skill) => sum + clamp01(skill.level01), 0);
+    const average = employee.skills.length > 0 ? aggregated / employee.skills.length : 0.5;
+    return { valid: true, score: clamp01(average) };
+  }
+
+  let total = 0;
+
+  for (const requirement of definition.requiredSkills) {
+    const skill = employee.skills.find((entry) => entry.skillKey === requirement.skillKey);
+    const level = clamp01(skill?.level01 ?? 0);
+
+    if (level < clamp01(requirement.minSkill01)) {
+      return { valid: false, score: 0 };
+    }
+
+    total += level;
+  }
+
+  const average = total / definition.requiredSkills.length;
+  return { valid: true, score: clamp01(average) };
+}
+
+function evaluateCandidate(
+  employee: Employee,
+  definition: WorkforceTaskDefinition,
+  demandMinutes: number,
+  usage: EmployeeUsage,
+): CandidateEvaluation | null {
+  const { valid, score: skillScore } = computeSkillScore(employee, definition);
+
+  if (!valid) {
+    return null;
+  }
+
+  const schedule = employee.schedule;
+  const baseCapacity = Math.max(0, schedule.hoursPerDay) * 60;
+  const overtimeCapacity = Math.max(0, schedule.overtimeHoursPerDay) * 60;
+  const totalCapacity = baseCapacity + overtimeCapacity;
+
+  if (totalCapacity <= 0) {
+    return null;
+  }
+
+  const remainingBase = Math.max(0, baseCapacity - usage.baseMinutes);
+  const baseMinutes = Math.min(remainingBase, demandMinutes);
+  const remainingDemand = demandMinutes - baseMinutes;
+  const remainingOvertime = Math.max(0, overtimeCapacity - usage.overtimeMinutes);
+
+  if (remainingDemand > remainingOvertime) {
+    return null;
+  }
+
+  const overtimeMinutes = Math.max(0, remainingDemand);
+  const availability = (remainingBase + remainingOvertime) / totalCapacity;
+  const score = clamp01(skillScore) * clamp01(availability);
+
+  return {
+    employee,
+    score,
+    baseMinutes,
+    overtimeMinutes,
+  } satisfies CandidateEvaluation;
+}
+
+function selectCandidate(
+  candidates: readonly CandidateEvaluation[],
+  structureIndex: number,
+  simTimeHours: number,
+): CandidateEvaluation {
+  if (candidates.length === 1) {
+    return candidates[0];
+  }
+
+  let bestScore = -Infinity;
+
+  for (const candidate of candidates) {
+    if (candidate.score > bestScore) {
+      bestScore = candidate.score;
+    }
+  }
+
+  const bestCandidates = candidates.filter(
+    (candidate) => Math.abs(candidate.score - bestScore) <= SCORE_EPSILON,
+  );
+
+  if (bestCandidates.length === 1) {
+    return bestCandidates[0];
+  }
+
+  const ordered = [...bestCandidates].sort((a, b) => a.employee.id.localeCompare(b.employee.id));
+  const rotation = Math.abs(Math.trunc(simTimeHours) + structureIndex);
+  const index = rotation % ordered.length;
+  return ordered[index] as CandidateEvaluation;
+}
+
+function isBreakroomTask(task: WorkforceTaskInstance): boolean {
+  const context = (task.context ?? {}) as Record<string, unknown>;
+  const purpose = String(context.roomPurpose ?? context.purpose ?? '').toLowerCase();
+
+  if (purpose === 'breakroom') {
+    return true;
+  }
+
+  if (context.breakroom === true) {
+    return true;
+  }
+
+  return task.taskCode.toLowerCase().includes('breakroom');
+}
+
+function isMaintenanceTask(task: WorkforceTaskInstance): boolean {
+  const lowered = task.taskCode.toLowerCase();
+  if (lowered.includes('maint')) {
+    return true;
+  }
+
+  const context = (task.context ?? {}) as Record<string, unknown>;
+  const category = String(context.taskCategory ?? context.category ?? '').toLowerCase();
+  return category === 'maintenance';
+}
+
+function applyEmployeeAdjustments(
+  employee: Employee,
+  usage: EmployeeUsage,
+  evaluation: CandidateEvaluation,
+  task: WorkforceTaskInstance,
+): Employee {
+  const totalMinutes = evaluation.baseMinutes + evaluation.overtimeMinutes;
+  const isBreak = isBreakroomTask(task);
+  let fatigueDelta = 0;
+
+  if (isBreak) {
+    fatigueDelta = -Math.max(0, (totalMinutes / 30) * BREAKROOM_FATIGUE_RECOVERY_PER_HALF_HOUR);
+  } else {
+    fatigueDelta = (totalMinutes / 60) * FATIGUE_GAIN_PER_HOUR;
+  }
+
+  let moraleDelta = 0;
+
+  if (evaluation.overtimeMinutes > 0) {
+    const penaltyHours = evaluation.overtimeMinutes / 60;
+    const potentialPenalty = penaltyHours * OVERTIME_MORALE_PENALTY_PER_HOUR;
+    const remainingCap = Math.max(0, MAX_DAILY_MORALE_PENALTY - usage.moralePenalty);
+    const appliedPenalty = Math.min(potentialPenalty, remainingCap);
+    usage.moralePenalty += appliedPenalty;
+    moraleDelta -= appliedPenalty;
+  }
+
+  const nextMorale = clamp01(employee.morale01 + moraleDelta);
+  const nextFatigue = clamp01(Math.max(0, employee.fatigue01 + fatigueDelta));
+
+  if (nextMorale === employee.morale01 && nextFatigue === employee.fatigue01) {
+    return employee;
+  }
+
+  return {
+    ...employee,
+    morale01: nextMorale,
+    fatigue01: nextFatigue,
+  } satisfies Employee;
+}
+
+function createSnapshot(
+  simTimeHours: number,
+  employees: readonly Employee[],
+  queueDepth: number,
+  maintenanceBacklog: number,
+  tasksCompleted: number,
+  baseMinutes: number,
+  overtimeMinutes: number,
+  waitTimes: readonly number[],
+): WorkforceKpiSnapshot {
+  const totalEmployees = employees.length;
+  const moraleSum = employees.reduce((sum, emp) => sum + clamp01(emp.morale01), 0);
+  const fatigueSum = employees.reduce((sum, emp) => sum + clamp01(emp.fatigue01), 0);
+  const capacityMinutes = employees.reduce((sum, emp) => {
+    const schedule = emp.schedule;
+    const base = Math.max(0, schedule.hoursPerDay) * 60;
+    const overtime = Math.max(0, schedule.overtimeHoursPerDay) * 60;
+    return sum + base + overtime;
+  }, 0);
+  const utilisation = capacityMinutes > 0 ? clamp01((baseMinutes + overtimeMinutes) / capacityMinutes) : 0;
+  const sortedWaits = [...waitTimes].sort((a, b) => a - b);
+  const index = sortedWaits.length > 0 ? Math.max(0, Math.ceil(sortedWaits.length * 0.95) - 1) : 0;
+  const p95Wait = sortedWaits.length > 0 ? sortedWaits[index] ?? 0 : 0;
+
+  return {
+    simTimeHours,
+    tasksCompleted,
+    queueDepth,
+    laborHoursCommitted: baseMinutes / 60,
+    overtimeHoursCommitted: overtimeMinutes / 60,
+    overtimeMinutes,
+    utilization01: utilisation,
+    p95WaitTimeHours: p95Wait,
+    maintenanceBacklog,
+    averageMorale01: totalEmployees > 0 ? moraleSum / totalEmployees : 0,
+    averageFatigue01: totalEmployees > 0 ? fatigueSum / totalEmployees : 0,
+  } satisfies WorkforceKpiSnapshot;
+}
+
+export function applyWorkforce(world: SimulationWorld, ctx: EngineContext): SimulationWorld {
+  const runtime = ensureWorkforceRuntime(ctx);
+  const workforceState = (world as SimulationWorld & { workforce?: WorkforceState }).workforce;
+
+  if (!workforceState) {
+    runtime.kpiSnapshot = createSnapshot(world.simTimeHours, [], 0, 0, 0, 0, 0, []);
+    return world;
+  }
+
+  const lookups = resolveStructureLookups(world);
+  const definitions = new Map<WorkforceTaskDefinition['taskCode'], WorkforceTaskDefinition>(
+    workforceState.taskDefinitions.map((definition) => [definition.taskCode, definition]),
+  );
+  const structureIndexLookup = new Map<Structure['id'], number>();
+  world.company.structures.forEach((structure, index) => {
+    structureIndexLookup.set(structure.id, index);
+  });
+
+  const employeeUsage = new Map<Employee['id'], EmployeeUsage>();
+  const updatedEmployees = new Map<Employee['id'], Employee>();
+  const assignments: WorkforceAssignment[] = [];
+  const waitTimes: number[] = [];
+  const employeesByStructure = new Map<Structure['id'], Employee[]>();
+  for (const employee of workforceState.employees) {
+    const list = employeesByStructure.get(employee.assignedStructureId) ?? [];
+    list.push(employee);
+    employeesByStructure.set(employee.assignedStructureId, list);
+  }
+
+  interface SchedulingEntry {
+    readonly task: WorkforceTaskInstance;
+    readonly definition: WorkforceTaskDefinition;
+    readonly structureId: Structure['id'];
+    readonly queueIndex: number;
+  }
+
+  const schedulingEntries: SchedulingEntry[] = [];
+
+  workforceState.taskQueue.forEach((task, index) => {
+    if (task.status !== 'queued') {
+      return;
+    }
+
+    const definition = definitions.get(task.taskCode);
+
+    if (!definition) {
+      return;
+    }
+
+    const structureId = resolveStructureId(task, lookups);
+
+    if (!structureId) {
+      return;
+    }
+
+    schedulingEntries.push({
+      task,
+      definition,
+      structureId,
+      queueIndex: index,
+    });
+  });
+
+  schedulingEntries.sort((a, b) => {
+    if (b.definition.priority !== a.definition.priority) {
+      return b.definition.priority - a.definition.priority;
+    }
+
+    if (a.task.createdAtTick !== b.task.createdAtTick) {
+      return a.task.createdAtTick - b.task.createdAtTick;
+    }
+
+    return a.queueIndex - b.queueIndex;
+  });
+
+  let totalBaseMinutes = 0;
+  let totalOvertimeMinutes = 0;
+  let tasksCompleted = 0;
+
+  const taskUpdates = new Map<WorkforceTaskInstance['id'], WorkforceTaskInstance>();
+
+  for (const entry of schedulingEntries) {
+    const { task, definition, structureId } = entry;
+    const employees = employeesByStructure.get(structureId) ?? [];
+
+    if (employees.length === 0) {
+      continue;
+    }
+
+    const demandMinutes = resolveTaskDemandMinutes(task, definition);
+    const requiredRole = definition.requiredRoleSlug;
+
+    const candidateEvaluations: CandidateEvaluation[] = [];
+
+    for (const employee of employees) {
+      const slug = resolveRoleSlug(employee.roleId, workforceState.roles);
+
+      if (slug !== requiredRole) {
+        continue;
+      }
+
+      const usage = ensureUsage(employeeUsage, employee.id);
+      const evaluation = evaluateCandidate(employee, definition, demandMinutes, usage);
+
+      if (!evaluation) {
+        continue;
+      }
+
+      candidateEvaluations.push(evaluation);
+    }
+
+    if (candidateEvaluations.length === 0) {
+      continue;
+    }
+
+    const structureIndex = structureIndexLookup.get(structureId) ?? 0;
+    const selected = selectCandidate(candidateEvaluations, structureIndex, world.simTimeHours);
+    const usage = ensureUsage(employeeUsage, selected.employee.id);
+    usage.baseMinutes += selected.baseMinutes;
+    usage.overtimeMinutes += selected.overtimeMinutes;
+
+    const nextEmployee = applyEmployeeAdjustments(
+      updatedEmployees.get(selected.employee.id) ?? selected.employee,
+      usage,
+      selected,
+      task,
+    );
+    updatedEmployees.set(selected.employee.id, nextEmployee);
+
+    const waitTimeHours = Math.max(0, world.simTimeHours - task.createdAtTick);
+    assignments.push({
+      taskId: task.id,
+      employeeId: selected.employee.id,
+      baseMinutes: selected.baseMinutes,
+      overtimeMinutes: selected.overtimeMinutes,
+      waitTimeHours,
+    });
+    waitTimes.push(waitTimeHours);
+
+    totalBaseMinutes += selected.baseMinutes;
+    totalOvertimeMinutes += selected.overtimeMinutes;
+    tasksCompleted += 1;
+
+    taskUpdates.set(task.id, {
+      ...task,
+      status: 'completed',
+      assignedEmployeeId: selected.employee.id,
+    });
+  }
+
+  const nextEmployees = workforceState.employees.map(
+    (employee) => updatedEmployees.get(employee.id) ?? employee,
+  );
+  const updatedTasks = workforceState.taskQueue.map((task) => taskUpdates.get(task.id) ?? task);
+  const queueDepth = updatedTasks.reduce(
+    (count, item) => (item.status === 'queued' ? count + 1 : count),
+    0,
+  );
+  const maintenanceBacklog = updatedTasks.reduce(
+    (count, item) => (item.status === 'queued' && isMaintenanceTask(item) ? count + 1 : count),
+    0,
+  );
+
+  const snapshot = createSnapshot(
+    world.simTimeHours,
+    nextEmployees,
+    queueDepth,
+    maintenanceBacklog,
+    tasksCompleted,
+    totalBaseMinutes,
+    totalOvertimeMinutes,
+    waitTimes,
+  );
+
+  runtime.assignments.push(...assignments);
+  runtime.kpiSnapshot = snapshot;
+
+  const nextWorkforce: WorkforceState = {
+    ...workforceState,
+    employees: nextEmployees,
+    taskQueue: updatedTasks,
+    kpis: [...workforceState.kpis, snapshot],
+  } satisfies WorkforceState;
+
+  return {
+    ...world,
+    workforce: nextWorkforce,
+  } satisfies SimulationWorld;
+}

--- a/packages/engine/src/backend/src/engine/testHarness.ts
+++ b/packages/engine/src/backend/src/engine/testHarness.ts
@@ -8,6 +8,7 @@ import {
 } from './Engine.js';
 import { clearSensorReadingsRuntime } from './pipeline/applySensors.js';
 import { clearIrrigationNutrientsRuntime } from './pipeline/applyIrrigationAndNutrients.js';
+import { clearWorkforceRuntime } from './pipeline/applyWorkforce.js';
 import type { StepName, TickTrace } from './trace.js';
 
 const DEMO_WORLD_ID = '00000000-0000-4000-8000-000000000000' as Uuid;
@@ -134,6 +135,10 @@ export function runStages(
 
     if (stepName === 'applyIrrigationAndNutrients') {
       clearIrrigationNutrientsRuntime(ctx);
+    }
+
+    if (stepName === 'applyWorkforce') {
+      clearWorkforceRuntime(ctx);
     }
   }
 

--- a/packages/engine/src/backend/src/engine/trace.ts
+++ b/packages/engine/src/backend/src/engine/trace.ts
@@ -5,6 +5,7 @@ export type StepName =
   | 'updateEnvironment'
   | 'applySensors'
   | 'applyIrrigationAndNutrients'
+  | 'applyWorkforce'
   | 'advancePhysiology'
   | 'applyHarvestAndInventory'
   | 'applyEconomyAccrual'

--- a/packages/engine/tests/integration/pipeline/order.spec.ts
+++ b/packages/engine/tests/integration/pipeline/order.spec.ts
@@ -8,6 +8,7 @@ const EXPECTED_STAGE_ORDER = [
   'applySensors',
   'updateEnvironment',
   'applyIrrigationAndNutrients',
+  'applyWorkforce',
   'advancePhysiology',
   'applyHarvestAndInventory',
   'applyEconomyAccrual',
@@ -15,7 +16,7 @@ const EXPECTED_STAGE_ORDER = [
 ] as const;
 
 describe('Engine pipeline — order trace', () => {
-  it('executes exactly the 8 SEC §4.2 phases in canonical order', () => {
+  it('executes exactly the 9 SEC §4.2 phases in canonical order', () => {
     const { trace } = runOneTickWithTrace();
     const stageNames = trace.steps.map((step) => step.name);
 

--- a/packages/engine/tests/integration/workforce/workforceScheduling.integration.test.ts
+++ b/packages/engine/tests/integration/workforce/workforceScheduling.integration.test.ts
@@ -1,0 +1,371 @@
+import { describe, expect, it } from 'vitest';
+
+import { createDemoWorld, runStages } from '@/backend/src/engine/testHarness.js';
+import type {
+  Employee,
+  EmployeeRole,
+  SimulationWorld,
+  WorkforceState,
+  WorkforceTaskDefinition,
+  WorkforceTaskInstance,
+} from '@/backend/src/domain/world.js';
+
+type Mutable<T> = { -readonly [K in keyof T]: T[K] };
+
+function buildRole(id: string, slug: string, skillKey: string, minSkill01: number): EmployeeRole {
+  return {
+    id: id as EmployeeRole['id'],
+    slug,
+    name: slug.replace(/(^|_)(\w)/g, (_, __, ch) => ch.toUpperCase()),
+    coreSkills: [
+      {
+        skillKey,
+        minSkill01,
+      },
+    ],
+  } satisfies EmployeeRole;
+}
+
+function buildEmployee(options: {
+  id: string;
+  name: string;
+  roleId: EmployeeRole['id'];
+  structureId: string;
+  morale01: number;
+  fatigue01: number;
+  skillKey: string;
+  skillLevel01: number;
+  hoursPerDay: number;
+  overtimeHoursPerDay: number;
+}): Employee {
+  return {
+    id: options.id as Employee['id'],
+    name: options.name,
+    roleId: options.roleId,
+    rngSeedUuid: '018f43f1-8b44-7b74-b3ce-5fbd7be3c201',
+    assignedStructureId: options.structureId as Employee['assignedStructureId'],
+    morale01: options.morale01,
+    fatigue01: options.fatigue01,
+    skills: [
+      {
+        skillKey: options.skillKey,
+        level01: options.skillLevel01,
+      },
+    ],
+    schedule: {
+      hoursPerDay: options.hoursPerDay,
+      overtimeHoursPerDay: options.overtimeHoursPerDay,
+      daysPerWeek: 5,
+      shiftStartHour: 6,
+    },
+  } satisfies Employee;
+}
+
+function buildDefinition(options: {
+  taskCode: string;
+  description: string;
+  requiredRoleSlug: string;
+  requiredSkillKey: string;
+  minSkill01: number;
+  priority: number;
+  laborMinutes: number;
+  basis?: WorkforceTaskDefinition['costModel']['basis'];
+}): WorkforceTaskDefinition {
+  return {
+    taskCode: options.taskCode,
+    description: options.description,
+    requiredRoleSlug: options.requiredRoleSlug,
+    requiredSkills: [
+      {
+        skillKey: options.requiredSkillKey,
+        minSkill01: options.minSkill01,
+      },
+    ],
+    priority: options.priority,
+    costModel: {
+      basis: options.basis ?? 'perAction',
+      laborMinutes: options.laborMinutes,
+    },
+  } satisfies WorkforceTaskDefinition;
+}
+
+function createWorldWithWorkforce(workforce: WorkforceState): SimulationWorld {
+  const world = createDemoWorld() as Mutable<SimulationWorld>;
+  world.simTimeHours = 12;
+  (world as Mutable<SimulationWorld>).workforce = workforce;
+  return world;
+}
+
+describe('applyWorkforce integration', () => {
+  it('processes queued tasks by priority while respecting skill bounds', () => {
+    const world = createDemoWorld() as Mutable<SimulationWorld>;
+    const structureId = world.company.structures[0].id;
+    const gardenerRole = buildRole(
+      '00000000-0000-0000-0000-000000010001',
+      'gardener',
+      'gardening',
+      0.4,
+    );
+    const definitions: WorkforceTaskDefinition[] = [
+      buildDefinition({
+        taskCode: 'veg_low_priority',
+        description: 'Routine veg maintenance',
+        requiredRoleSlug: 'gardener',
+        requiredSkillKey: 'gardening',
+        minSkill01: 0.4,
+        priority: 30,
+        laborMinutes: 480,
+      }),
+      buildDefinition({
+        taskCode: 'veg_high_priority',
+        description: 'Urgent pest inspection',
+        requiredRoleSlug: 'gardener',
+        requiredSkillKey: 'gardening',
+        minSkill01: 0.6,
+        priority: 90,
+        laborMinutes: 480,
+      }),
+    ];
+
+    const employee = buildEmployee({
+      id: '00000000-0000-0000-0000-000000020001',
+      name: 'Alex Gardener',
+      roleId: gardenerRole.id,
+      structureId,
+      morale01: 0.85,
+      fatigue01: 0.2,
+      skillKey: 'gardening',
+      skillLevel01: 0.75,
+      hoursPerDay: 8,
+      overtimeHoursPerDay: 0,
+    });
+
+    const queue: WorkforceTaskInstance[] = [
+      {
+        id: '00000000-0000-0000-0000-000000030001' as WorkforceTaskInstance['id'],
+        taskCode: 'veg_low_priority',
+        status: 'queued',
+        createdAtTick: 5,
+        context: {
+          structureId,
+        },
+      },
+      {
+        id: '00000000-0000-0000-0000-000000030002' as WorkforceTaskInstance['id'],
+        taskCode: 'veg_high_priority',
+        status: 'queued',
+        createdAtTick: 4,
+        context: {
+          structureId,
+        },
+      },
+    ];
+
+    const workforce: WorkforceState = {
+      roles: [gardenerRole],
+      employees: [employee],
+      taskDefinitions: definitions,
+      taskQueue: queue,
+      kpis: [],
+    };
+
+    const worldWithWorkforce = createWorldWithWorkforce(workforce);
+    const ctx = {};
+
+    const nextWorld = runStages(worldWithWorkforce, ctx, ['applyWorkforce']);
+    const nextQueue = nextWorld.workforce.taskQueue;
+
+    const highPriorityTask = nextQueue.find((task) => task.taskCode === 'veg_high_priority');
+    const lowPriorityTask = nextQueue.find((task) => task.taskCode === 'veg_low_priority');
+
+    expect(highPriorityTask?.status).toBe('completed');
+    expect(lowPriorityTask?.status).toBe('queued');
+    expect(nextWorld.workforce.kpis.at(-1)?.queueDepth).toBe(1);
+  });
+
+  it('distributes ties deterministically based on availability and rotation', () => {
+    const world = createDemoWorld() as Mutable<SimulationWorld>;
+    const structureId = world.company.structures[0].id;
+    const gardenerRole = buildRole(
+      '00000000-0000-0000-0000-000000010002',
+      'gardener',
+      'gardening',
+      0.4,
+    );
+    const definition = buildDefinition({
+      taskCode: 'veg_cycle',
+      description: 'Cycle tasks',
+      requiredRoleSlug: 'gardener',
+      requiredSkillKey: 'gardening',
+      minSkill01: 0.4,
+      priority: 50,
+      laborMinutes: 60,
+    });
+
+    const employees: Employee[] = [
+      buildEmployee({
+        id: '00000000-0000-0000-0000-000000020002',
+        name: 'Casey 1',
+        roleId: gardenerRole.id,
+        structureId,
+        morale01: 0.8,
+        fatigue01: 0.2,
+        skillKey: 'gardening',
+        skillLevel01: 0.65,
+        hoursPerDay: 8,
+        overtimeHoursPerDay: 0,
+      }),
+      buildEmployee({
+        id: '00000000-0000-0000-0000-000000020003',
+        name: 'Casey 2',
+        roleId: gardenerRole.id,
+        structureId,
+        morale01: 0.8,
+        fatigue01: 0.2,
+        skillKey: 'gardening',
+        skillLevel01: 0.65,
+        hoursPerDay: 8,
+        overtimeHoursPerDay: 0,
+      }),
+    ];
+
+    const queue: WorkforceTaskInstance[] = [
+      {
+        id: '00000000-0000-0000-0000-000000030010' as WorkforceTaskInstance['id'],
+        taskCode: 'veg_cycle',
+        status: 'queued',
+        createdAtTick: 3,
+        context: { structureId },
+      },
+      {
+        id: '00000000-0000-0000-0000-000000030011' as WorkforceTaskInstance['id'],
+        taskCode: 'veg_cycle',
+        status: 'queued',
+        createdAtTick: 2,
+        context: { structureId },
+      },
+    ];
+
+    const workforce: WorkforceState = {
+      roles: [gardenerRole],
+      employees,
+      taskDefinitions: [definition],
+      taskQueue: queue,
+      kpis: [],
+    };
+
+    const worldWithWorkforce = createWorldWithWorkforce(workforce);
+    const ctx = {};
+
+    const nextWorld = runStages(worldWithWorkforce, ctx, ['applyWorkforce']);
+    const assignments = nextWorld.workforce.taskQueue.filter((task) => task.status === 'completed');
+    const assignedEmployees = assignments.map((task) => task.assignedEmployeeId);
+
+    expect(new Set(assignedEmployees)).toHaveSize(2);
+  });
+
+  it('applies overtime morale penalties and breakroom fatigue recovery', () => {
+    const world = createDemoWorld() as Mutable<SimulationWorld>;
+    const structureId = world.company.structures[0].id;
+    const technicianRole = buildRole(
+      '00000000-0000-0000-0000-000000010010',
+      'technician',
+      'maintenance',
+      0.5,
+    );
+    const gardenerRole = buildRole(
+      '00000000-0000-0000-0000-000000010011',
+      'gardener',
+      'gardening',
+      0.4,
+    );
+
+    const maintenanceDefinition = buildDefinition({
+      taskCode: 'maintenance_overrun',
+      description: 'Critical maintenance requiring overtime',
+      requiredRoleSlug: 'technician',
+      requiredSkillKey: 'maintenance',
+      minSkill01: 0.6,
+      priority: 90,
+      laborMinutes: 360,
+    });
+
+    const breakroomDefinition = buildDefinition({
+      taskCode: 'breakroom_rest',
+      description: 'Scheduled break',
+      requiredRoleSlug: 'gardener',
+      requiredSkillKey: 'gardening',
+      minSkill01: 0.5,
+      priority: 40,
+      laborMinutes: 60,
+    });
+
+    const technician = buildEmployee({
+      id: '00000000-0000-0000-0000-000000020020',
+      name: 'Morgan Tech',
+      roleId: technicianRole.id,
+      structureId,
+      morale01: 0.9,
+      fatigue01: 0.2,
+      skillKey: 'maintenance',
+      skillLevel01: 0.8,
+      hoursPerDay: 5,
+      overtimeHoursPerDay: 2,
+    });
+
+    const gardener = buildEmployee({
+      id: '00000000-0000-0000-0000-000000020021',
+      name: 'Jamie Gardener',
+      roleId: gardenerRole.id,
+      structureId,
+      morale01: 0.7,
+      fatigue01: 0.5,
+      skillKey: 'gardening',
+      skillLevel01: 0.7,
+      hoursPerDay: 6,
+      overtimeHoursPerDay: 1,
+    });
+
+    const queue: WorkforceTaskInstance[] = [
+      {
+        id: '00000000-0000-0000-0000-000000030020' as WorkforceTaskInstance['id'],
+        taskCode: 'breakroom_rest',
+        status: 'queued',
+        createdAtTick: 8,
+        context: {
+          structureId,
+          roomPurpose: 'breakroom',
+        },
+      },
+      {
+        id: '00000000-0000-0000-0000-000000030021' as WorkforceTaskInstance['id'],
+        taskCode: 'maintenance_overrun',
+        status: 'queued',
+        createdAtTick: 7,
+        context: {
+          structureId,
+        },
+      },
+    ];
+
+    const workforce: WorkforceState = {
+      roles: [technicianRole, gardenerRole],
+      employees: [technician, gardener],
+      taskDefinitions: [maintenanceDefinition, breakroomDefinition],
+      taskQueue: queue,
+      kpis: [],
+    };
+
+    const worldWithWorkforce = createWorldWithWorkforce(workforce);
+    const ctx = {};
+
+    const nextWorld = runStages(worldWithWorkforce, ctx, ['applyWorkforce']);
+    const nextEmployees = nextWorld.workforce.employees;
+    const updatedTechnician = nextEmployees.find((emp) => emp.id === technician.id);
+    const updatedGardener = nextEmployees.find((emp) => emp.id === gardener.id);
+
+    expect(updatedTechnician?.morale01).toBeCloseTo(0.88, 5);
+    expect(updatedGardener?.fatigue01).toBeLessThan(gardener.fatigue01);
+    expect(nextWorld.workforce.kpis.at(-1)?.overtimeMinutes).toBe(60);
+  });
+});

--- a/packages/engine/tests/unit/domain/workforceSchemas.test.ts
+++ b/packages/engine/tests/unit/domain/workforceSchemas.test.ts
@@ -83,8 +83,13 @@ const VALID_WORKFORCE_STATE = {
     {
       simTimeHours: 24,
       tasksCompleted: 5,
+      queueDepth: 3,
       laborHoursCommitted: 12,
       overtimeHoursCommitted: 3,
+      overtimeMinutes: 180,
+      utilization01: 0.7,
+      p95WaitTimeHours: 4,
+      maintenanceBacklog: 1,
       averageMorale01: 0.8,
       averageFatigue01: 0.2
     }
@@ -156,5 +161,6 @@ describe('workforce schemas', () => {
     expect(parsed.roles).toHaveLength(1);
     expect(parsed.employees).toHaveLength(1);
     expect(parsed.taskQueue[0]?.status).toBe('queued');
+    expect(parsed.kpis[0]?.queueDepth).toBe(3);
   });
 });


### PR DESCRIPTION
## Summary
- add an applyWorkforce pipeline stage that schedules tasks per structure, updates morale/fatigue, and persists per-tick workforce KPIs
- extend workforce KPI schema/tests and wire the stage into the engine pipeline with runtime cleanup and order tracing updates
- refresh documentation and changelog to reflect the nine-stage tick pipeline and new workforce scheduling responsibilities

## Testing
- pnpm --filter @wb/engine test *(fails: Unsupported environment, pnpm 10.13.1 < required >=10.17.1)*

------
https://chatgpt.com/codex/tasks/task_e_68e25f8af990832599049a7ebad8def2