### PR TITLE
feat: add workforce payroll accruals

### DIFF
--- a/data/payroll/location_index.json
+++ b/data/payroll/location_index.json
@@ -1,0 +1,4 @@
+{
+  "defaultIndex": 1.0,
+  "overrides": []
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### #72 Workforce payroll accruals
+
+- Introduced a `/data/payroll/location_index.json` catalogue and zod-backed loader so structures resolve location multipliers
+  deterministically (city overrides > country overrides > default `1.0`).
+- Extended the workforce state with daily payroll accumulators (`baseMinutes`, `otMinutes`, `baseCost`, `otCost`, `totalLaborCost`)
+  plus per-structure breakdowns. The `applyWorkforce` stage now computes minute-level labour costs via
+  `rate_per_minute = ((5 + 10 × relevantSkill) × locationIndex × otMultiplier) / 60`, flips to `otMultiplier = 1.25` for overtime
+  minutes, and finalises each day with Banker’s rounding before handing totals to the economy stage.
+- Updated `applyEconomyAccrual` to ingest the workforce snapshot so downstream finance modules receive both the current-day view
+  and any newly finalised days. Added unit coverage for overtime boundaries, location factors, rounding, and loader validation.
+
 ### #71 Workforce scheduling pipeline stage
 
 - Added the `applyWorkforce` pipeline phase between irrigation and economy to dispatch queued tasks per structure, enforce role/skill minimums, honor working-hour limits, and update morale/fatigue (including the breakroom recovery rule).

--- a/docs/DD.md
+++ b/docs/DD.md
@@ -172,6 +172,13 @@ targets from the same factor to keep unit conversions deterministic.
     deterministic labour cost models, and integer priorities.
   - `taskQueue`: queued/in-progress task instances used by the dispatcher and telemetry.
   - `kpis`: rolling `WorkforceKpiSnapshot` entries summarising throughput, labour hours, overtime, and aggregate morale/fatigue.
+  - `payroll`: day-indexed accumulators capturing `baseMinutes`, `otMinutes`, `baseCost`, `otCost`, and `totalLaborCost` for the
+    entire company as well as per-structure slices. Each minute billed uses
+    `rate_per_minute = ((5 + 10 × relevantSkill) × locationIndex × otMultiplier) / 60` with
+    `relevantSkill = avg(skill[k])` for task-required skills (fallback: average of all employee skills). Overtime minutes switch to
+    `otMultiplier = 1.25` immediately after the base-day allowance is exhausted. Location factors resolve via
+    `/data/payroll/location_index.json` (city overrides beat country overrides; default is `1.0`). Daily totals close with
+    **Banker’s rounding** before the economy stage consumes the snapshot.
 - `Employee.schedule` constrains base hours to **5–16 h per in-game day**, allows overtime up to **+5 h**, and records the number of
   working days per week (`1..7`) with an optional shift start hour (`0..23`). Schema guards reject violations and normalise seeds to UUID v7.
 - `Employee.skills` and `EmployeeRole.coreSkills` share the `EmployeeSkillRequirement` shape (`skillKey`, `minSkill01 ∈ [0,1]`).

--- a/packages/engine/src/backend/src/domain/payroll/locationIndex.ts
+++ b/packages/engine/src/backend/src/domain/payroll/locationIndex.ts
@@ -1,0 +1,115 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { z } from 'zod';
+
+import type { CompanyLocation } from '../entities.js';
+
+const positiveNumber = z
+  .number({ invalid_type_error: 'Location index values must be numbers.' })
+  .finite('Location index values must be finite numbers.')
+  .min(0, 'Location index values must be greater than or equal to zero.');
+
+const locationOverrideSchema = z
+  .object({
+    countryName: z
+      .string({ invalid_type_error: 'Override countryName must be a string.' })
+      .min(1, 'Override countryName must not be empty.'),
+    cityName: z
+      .string({ invalid_type_error: 'Override cityName must be a string.' })
+      .min(1, 'Override cityName must not be empty.')
+      .optional(),
+    index: positiveNumber,
+  })
+  .strict();
+
+const locationIndexSchema = z
+  .object({
+    defaultIndex: positiveNumber.default(1),
+    overrides: z.array(locationOverrideSchema).default([]),
+  })
+  .strict();
+
+export type LocationIndexOverride = z.infer<typeof locationOverrideSchema>;
+export type LocationIndexTable = z.infer<typeof locationIndexSchema>;
+
+export interface LoadLocationIndexOptions {
+  readonly payrollRoot?: string;
+}
+
+const DEFAULT_PAYROLL_ROOT = path.resolve(
+  fileURLToPath(new URL('../../../../../../../', import.meta.url)),
+  'data/payroll',
+);
+
+let cachedTable: LocationIndexTable | null = null;
+
+function resolvePayrollRoot(root?: string): string {
+  if (!root) {
+    return DEFAULT_PAYROLL_ROOT;
+  }
+
+  return path.isAbsolute(root) ? path.normalize(root) : path.resolve(root);
+}
+
+function readLocationIndexFile(root: string): unknown {
+  const filePath = path.join(root, 'location_index.json');
+
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Location index file "${filePath}" does not exist.`);
+  }
+
+  const raw = fs.readFileSync(filePath, 'utf8');
+  return JSON.parse(raw) as unknown;
+}
+
+function buildLocationIndexTable(options: LoadLocationIndexOptions = {}): LocationIndexTable {
+  const root = resolvePayrollRoot(options.payrollRoot);
+  const payload = readLocationIndexFile(root);
+  return locationIndexSchema.parse(payload);
+}
+
+export function loadLocationIndexTable(
+  options: LoadLocationIndexOptions = {},
+): LocationIndexTable {
+  if (!cachedTable) {
+    cachedTable = buildLocationIndexTable(options);
+  }
+
+  return { ...cachedTable, overrides: [...cachedTable.overrides] } satisfies LocationIndexTable;
+}
+
+export function clearLocationIndexCache(): void {
+  cachedTable = null;
+}
+
+export function resolveLocationIndex(
+  table: LocationIndexTable,
+  location: CompanyLocation | undefined,
+): number {
+  if (!location) {
+    return table.defaultIndex;
+  }
+
+  const city = location.cityName.trim().toLowerCase();
+  const country = location.countryName.trim().toLowerCase();
+
+  for (const override of table.overrides) {
+    if (override.cityName && override.cityName.trim().toLowerCase() === city) {
+      return override.index;
+    }
+  }
+
+  for (const override of table.overrides) {
+    if (!override.cityName && override.countryName.trim().toLowerCase() === country) {
+      return override.index;
+    }
+  }
+
+  return table.defaultIndex;
+}
+
+export function createEmptyLocationIndexTable(): LocationIndexTable {
+  return { defaultIndex: 1, overrides: [] } satisfies LocationIndexTable;
+}

--- a/packages/engine/src/backend/src/domain/schemas.ts
+++ b/packages/engine/src/backend/src/domain/schemas.ts
@@ -177,12 +177,37 @@ export const workforceKpiSnapshotSchema: z.ZodType<WorkforceKpiSnapshot> = z.obj
   averageFatigue01: zeroToOneNumber
 });
 
+const workforcePayrollTotalsSchema = z
+  .object({
+    baseMinutes: finiteNumber.min(0, 'baseMinutes cannot be negative.'),
+    otMinutes: finiteNumber.min(0, 'otMinutes cannot be negative.'),
+    baseCost: finiteNumber.min(0, 'baseCost cannot be negative.'),
+    otCost: finiteNumber.min(0, 'otCost cannot be negative.'),
+    totalLaborCost: finiteNumber.min(0, 'totalLaborCost cannot be negative.'),
+  })
+  .strict();
+
+const workforceStructurePayrollTotalsSchema = workforcePayrollTotalsSchema.extend({
+  structureId: uuidSchema,
+});
+
+const workforcePayrollStateSchema = z
+  .object({
+    dayIndex: finiteNumber
+      .min(0, 'dayIndex cannot be negative.')
+      .transform((value) => Math.trunc(value)),
+    totals: workforcePayrollTotalsSchema,
+    byStructure: z.array(workforceStructurePayrollTotalsSchema).readonly(),
+  })
+  .strict();
+
 export const workforceStateSchema: z.ZodType<WorkforceState> = z.object({
   roles: employeeRoleCollectionSchema,
   employees: employeeCollectionSchema,
   taskDefinitions: z.array(workforceTaskDefinitionSchema).readonly(),
   taskQueue: z.array(workforceTaskInstanceSchema).readonly(),
-  kpis: z.array(workforceKpiSnapshotSchema).readonly()
+  kpis: z.array(workforceKpiSnapshotSchema).readonly(),
+  payroll: workforcePayrollStateSchema,
 });
 
 export const companyLocationSchema: z.ZodType<CompanyLocation> = z.object({

--- a/packages/engine/src/backend/src/domain/workforce/WorkforceState.ts
+++ b/packages/engine/src/backend/src/domain/workforce/WorkforceState.ts
@@ -1,7 +1,26 @@
+import type { Uuid } from '../entities.js';
 import type { Employee } from './Employee.js';
 import type { EmployeeRole } from './EmployeeRole.js';
 import type { WorkforceKpiSnapshot } from './kpis.js';
 import type { WorkforceTaskDefinition, WorkforceTaskInstance } from './tasks.js';
+
+export interface WorkforcePayrollTotals {
+  readonly baseMinutes: number;
+  readonly otMinutes: number;
+  readonly baseCost: number;
+  readonly otCost: number;
+  readonly totalLaborCost: number;
+}
+
+export interface WorkforceStructurePayrollTotals extends WorkforcePayrollTotals {
+  readonly structureId: Uuid;
+}
+
+export interface WorkforcePayrollState {
+  readonly dayIndex: number;
+  readonly totals: WorkforcePayrollTotals;
+  readonly byStructure: readonly WorkforceStructurePayrollTotals[];
+}
 
 /**
  * Aggregated workforce domain state embedded inside the simulation world snapshot.
@@ -17,4 +36,6 @@ export interface WorkforceState {
   readonly taskQueue: readonly WorkforceTaskInstance[];
   /** KPI snapshots aggregated over recent simulation windows. */
   readonly kpis: readonly WorkforceKpiSnapshot[];
+  /** Daily payroll accumulators capturing labour effort and costs. */
+  readonly payroll: WorkforcePayrollState;
 }

--- a/packages/engine/src/backend/src/engine/pipeline/applyEconomyAccrual.ts
+++ b/packages/engine/src/backend/src/engine/pipeline/applyEconomyAccrual.ts
@@ -1,8 +1,53 @@
-import type { SimulationWorld } from '../../domain/world.js';
+import type { SimulationWorld, WorkforcePayrollState } from '../../domain/world.js';
 import type { EngineRunContext } from '../Engine.js';
+import { consumeWorkforcePayrollAccrual } from './applyWorkforce.js';
+
+type Mutable<T> = { -readonly [K in keyof T]: T[K] };
+
+interface WorkforceEconomyAccrualState {
+  readonly current?: WorkforcePayrollState;
+  readonly finalizedDays: readonly WorkforcePayrollState[];
+}
+
+interface EconomyAccrualCarrier extends Mutable<EngineRunContext> {
+  economyAccruals?: {
+    workforce?: WorkforceEconomyAccrualState;
+  };
+}
+
+function mergeFinalizedDays(
+  existing: readonly WorkforcePayrollState[],
+  finalized?: WorkforcePayrollState,
+): WorkforcePayrollState[] {
+  if (!finalized) {
+    return [...existing];
+  }
+
+  const filtered = existing.filter((entry) => entry.dayIndex !== finalized.dayIndex);
+  filtered.push(finalized);
+  return filtered.sort((a, b) => a.dayIndex - b.dayIndex);
+}
 
 export function applyEconomyAccrual(world: SimulationWorld, ctx: EngineRunContext): SimulationWorld {
-  void ctx;
+  const payrollSnapshot = consumeWorkforcePayrollAccrual(ctx);
+
+  if (!payrollSnapshot) {
+    return world;
+  }
+
+  const carrier = ctx as EconomyAccrualCarrier;
+  const existing = carrier.economyAccruals?.workforce ?? { finalizedDays: [] };
+  const finalizedDays = mergeFinalizedDays(existing.finalizedDays ?? [], payrollSnapshot.finalized);
+
+  const nextWorkforceAccrual: WorkforceEconomyAccrualState = {
+    current: payrollSnapshot.current,
+    finalizedDays,
+  };
+
+  carrier.economyAccruals = {
+    ...carrier.economyAccruals,
+    workforce: nextWorkforceAccrual,
+  };
 
   return world;
 }

--- a/packages/engine/src/backend/src/util/math.ts
+++ b/packages/engine/src/backend/src/util/math.ts
@@ -31,3 +31,30 @@ export function clamp(value: number, min: number, max: number): number {
 export function clamp01(value: number): number {
   return clamp(value, 0, 1);
 }
+
+/**
+ * Applies Banker's rounding (round half to even) to the given numeric value.
+ */
+export function bankersRound(value: number, decimals = 2): number {
+  if (!Number.isFinite(value)) {
+    return Number.isNaN(value) ? Number.NaN : value;
+  }
+
+  const factor = 10 ** Math.max(0, Math.trunc(decimals));
+  const scaled = value * factor;
+  const floorValue = Math.floor(scaled);
+  const diff = scaled - floorValue;
+  const epsilon = Number.EPSILON * Math.max(1, Math.abs(scaled));
+
+  if (Math.abs(diff - 0.5) <= epsilon) {
+    const isEven = Math.abs(floorValue) % 2 === 0;
+    const evenValue = isEven ? floorValue : floorValue + Math.sign(scaled || 1);
+    return evenValue / factor;
+  }
+
+  if (diff < 0.5) {
+    return floorValue / factor;
+  }
+
+  return Math.ceil(scaled) / factor;
+}

--- a/packages/engine/tests/integration/workforce/workforceScheduling.integration.test.ts
+++ b/packages/engine/tests/integration/workforce/workforceScheduling.integration.test.ts
@@ -167,6 +167,17 @@ describe('applyWorkforce integration', () => {
       taskDefinitions: definitions,
       taskQueue: queue,
       kpis: [],
+      payroll: {
+        dayIndex: 0,
+        totals: {
+          baseMinutes: 0,
+          otMinutes: 0,
+          baseCost: 0,
+          otCost: 0,
+          totalLaborCost: 0,
+        },
+        byStructure: [],
+      },
     };
 
     const worldWithWorkforce = createWorldWithWorkforce(workforce);
@@ -252,6 +263,17 @@ describe('applyWorkforce integration', () => {
       taskDefinitions: [definition],
       taskQueue: queue,
       kpis: [],
+      payroll: {
+        dayIndex: 0,
+        totals: {
+          baseMinutes: 0,
+          otMinutes: 0,
+          baseCost: 0,
+          otCost: 0,
+          totalLaborCost: 0,
+        },
+        byStructure: [],
+      },
     };
 
     const worldWithWorkforce = createWorldWithWorkforce(workforce);
@@ -354,6 +376,17 @@ describe('applyWorkforce integration', () => {
       taskDefinitions: [maintenanceDefinition, breakroomDefinition],
       taskQueue: queue,
       kpis: [],
+      payroll: {
+        dayIndex: 0,
+        totals: {
+          baseMinutes: 0,
+          otMinutes: 0,
+          baseCost: 0,
+          otCost: 0,
+          totalLaborCost: 0,
+        },
+        byStructure: [],
+      },
     };
 
     const worldWithWorkforce = createWorldWithWorkforce(workforce);

--- a/packages/engine/tests/unit/domain/locationIndex.test.ts
+++ b/packages/engine/tests/unit/domain/locationIndex.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  clearLocationIndexCache,
+  loadLocationIndexTable,
+  resolveLocationIndex,
+  type LocationIndexTable,
+} from '@/backend/src/domain/payroll/locationIndex.js';
+
+const HAMBURG = {
+  lon: 10,
+  lat: 53.55,
+  cityName: 'Hamburg',
+  countryName: 'Germany',
+} as const;
+
+const SEATTLE = {
+  lon: -122.335167,
+  lat: 47.608013,
+  cityName: 'Seattle',
+  countryName: 'United States',
+} as const;
+
+afterEach(() => {
+  clearLocationIndexCache();
+});
+
+describe('location index loader', () => {
+  it('loads the default table with a neutral index', () => {
+    const table = loadLocationIndexTable();
+    expect(table.defaultIndex).toBe(1);
+    expect(table.overrides).toEqual([]);
+  });
+
+  it('prefers city overrides over country and default', () => {
+    const table: LocationIndexTable = {
+      defaultIndex: 0.95,
+      overrides: [
+        { countryName: 'Germany', index: 1.05 },
+        { countryName: 'United States', cityName: 'Seattle', index: 1.3 },
+      ],
+    };
+
+    expect(resolveLocationIndex(table, HAMBURG)).toBe(1.05);
+    expect(resolveLocationIndex(table, SEATTLE)).toBe(1.3);
+    expect(resolveLocationIndex(table, undefined)).toBe(0.95);
+  });
+});

--- a/packages/engine/tests/unit/domain/workforceSchemas.test.ts
+++ b/packages/engine/tests/unit/domain/workforceSchemas.test.ts
@@ -93,7 +93,18 @@ const VALID_WORKFORCE_STATE = {
       averageMorale01: 0.8,
       averageFatigue01: 0.2
     }
-  ]
+  ],
+  payroll: {
+    dayIndex: 0,
+    totals: {
+      baseMinutes: 0,
+      otMinutes: 0,
+      baseCost: 0,
+      otCost: 0,
+      totalLaborCost: 0
+    },
+    byStructure: []
+  }
 };
 
 describe('workforce schemas', () => {

--- a/packages/engine/tests/unit/workforce/payroll.test.ts
+++ b/packages/engine/tests/unit/workforce/payroll.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, it } from 'vitest';
+
+import { createDemoWorld, runStages } from '@/backend/src/engine/testHarness.js';
+import type { EngineRunContext } from '@/backend/src/engine/Engine.js';
+import type {
+  Employee,
+  EmployeeRole,
+  SimulationWorld,
+  WorkforceState,
+  WorkforceTaskDefinition,
+  WorkforceTaskInstance,
+  WorkforcePayrollState,
+} from '@/backend/src/domain/world.js';
+
+function buildRole(id: string, slug: string, skillKey: string, minSkill01: number): EmployeeRole {
+  return {
+    id: id as EmployeeRole['id'],
+    slug,
+    name: slug,
+    coreSkills: [
+      {
+        skillKey,
+        minSkill01,
+      },
+    ],
+  } satisfies EmployeeRole;
+}
+
+function buildEmployee(options: {
+  id: string;
+  name: string;
+  roleId: EmployeeRole['id'];
+  structureId: string;
+  morale01: number;
+  fatigue01: number;
+  skillKey: string;
+  skillLevel01: number;
+  hoursPerDay: number;
+  overtimeHoursPerDay: number;
+}): Employee {
+  return {
+    id: options.id as Employee['id'],
+    name: options.name,
+    roleId: options.roleId,
+    rngSeedUuid: '018f43f1-8b44-7b74-b3ce-5fbd7be3c201',
+    assignedStructureId: options.structureId as Employee['assignedStructureId'],
+    morale01: options.morale01,
+    fatigue01: options.fatigue01,
+    skills: [
+      {
+        skillKey: options.skillKey,
+        level01: options.skillLevel01,
+      },
+    ],
+    schedule: {
+      hoursPerDay: options.hoursPerDay,
+      overtimeHoursPerDay: options.overtimeHoursPerDay,
+      daysPerWeek: 5,
+      shiftStartHour: 6,
+    },
+  } satisfies Employee;
+}
+
+function buildDefinition(options: {
+  taskCode: string;
+  description: string;
+  requiredRoleSlug: string;
+  requiredSkillKey: string;
+  minSkill01: number;
+  priority: number;
+  laborMinutes: number;
+}): WorkforceTaskDefinition {
+  return {
+    taskCode: options.taskCode,
+    description: options.description,
+    requiredRoleSlug: options.requiredRoleSlug,
+    requiredSkills: [
+      {
+        skillKey: options.requiredSkillKey,
+        minSkill01: options.minSkill01,
+      },
+    ],
+    priority: options.priority,
+    costModel: {
+      basis: 'perAction',
+      laborMinutes: options.laborMinutes,
+    },
+  } satisfies WorkforceTaskDefinition;
+}
+
+function createPayrollState(dayIndex: number): WorkforcePayrollState {
+  return {
+    dayIndex,
+    totals: {
+      baseMinutes: 0,
+      otMinutes: 0,
+      baseCost: 0,
+      otCost: 0,
+      totalLaborCost: 0,
+    },
+    byStructure: [],
+  } satisfies WorkforcePayrollState;
+}
+
+describe('workforce payroll accruals', () => {
+  it('accrues base and overtime minutes with location index scaling', () => {
+    const world = createDemoWorld() as SimulationWorld;
+    const structureId = world.company.structures[0].id;
+    world.simTimeHours = 10;
+
+    const gardenerRole = buildRole(
+      '00000000-0000-0000-0000-000000010050',
+      'gardener',
+      'gardening',
+      0.5,
+    );
+
+    const employee = buildEmployee({
+      id: '00000000-0000-0000-0000-000000020050',
+      name: 'Taylor Gardener',
+      roleId: gardenerRole.id,
+      structureId,
+      morale01: 0.9,
+      fatigue01: 0.1,
+      skillKey: 'gardening',
+      skillLevel01: 0.8,
+      hoursPerDay: 8,
+      overtimeHoursPerDay: 2,
+    });
+
+    const taskDefinition = buildDefinition({
+      taskCode: 'long_run',
+      description: 'Extended maintenance shift',
+      requiredRoleSlug: 'gardener',
+      requiredSkillKey: 'gardening',
+      minSkill01: 0.5,
+      priority: 90,
+      laborMinutes: 540,
+    });
+
+    const task: WorkforceTaskInstance = {
+      id: '00000000-0000-0000-0000-000000030050' as WorkforceTaskInstance['id'],
+      taskCode: 'long_run',
+      status: 'queued',
+      createdAtTick: 6,
+      context: { structureId },
+    };
+
+    const workforce: WorkforceState = {
+      roles: [gardenerRole],
+      employees: [employee],
+      taskDefinitions: [taskDefinition],
+      taskQueue: [task],
+      kpis: [],
+      payroll: createPayrollState(0),
+    } satisfies WorkforceState;
+
+    const ctx: EngineRunContext = {
+      payroll: {
+        locationIndexTable: {
+          defaultIndex: 1.2,
+          overrides: [],
+        },
+      },
+    };
+
+    const nextWorld = runStages(
+      { ...world, workforce } satisfies SimulationWorld,
+      ctx,
+      ['applyWorkforce', 'applyEconomyAccrual'],
+    );
+
+    const totals = nextWorld.workforce.payroll.totals;
+
+    expect(totals.baseMinutes).toBe(480);
+    expect(totals.otMinutes).toBe(60);
+    expect(totals.baseCost).toBeCloseTo(124.8, 4);
+    expect(totals.otCost).toBeCloseTo(19.5, 4);
+    expect(totals.totalLaborCost).toBeCloseTo(144.3, 4);
+
+    const economyState = (ctx as { economyAccruals?: any }).economyAccruals;
+    expect(economyState?.workforce?.current?.totals.totalLaborCost).toBeCloseTo(144.3, 4);
+  });
+
+  it('applies city-level location index overrides when available', () => {
+    const world = createDemoWorld() as SimulationWorld;
+    const structureId = world.company.structures[0].id;
+    world.simTimeHours = 8;
+
+    const gardenerRole = buildRole(
+      '00000000-0000-0000-0000-000000010051',
+      'gardener',
+      'gardening',
+      0.4,
+    );
+
+    const employee = buildEmployee({
+      id: '00000000-0000-0000-0000-000000020051',
+      name: 'Jordan',
+      roleId: gardenerRole.id,
+      structureId,
+      morale01: 0.8,
+      fatigue01: 0.2,
+      skillKey: 'gardening',
+      skillLevel01: 0.6,
+      hoursPerDay: 6,
+      overtimeHoursPerDay: 0,
+    });
+
+    const taskDefinition = buildDefinition({
+      taskCode: 'single_task',
+      description: 'Quick pass',
+      requiredRoleSlug: 'gardener',
+      requiredSkillKey: 'gardening',
+      minSkill01: 0.4,
+      priority: 50,
+      laborMinutes: 180,
+    });
+
+    const task: WorkforceTaskInstance = {
+      id: '00000000-0000-0000-0000-000000030051' as WorkforceTaskInstance['id'],
+      taskCode: 'single_task',
+      status: 'queued',
+      createdAtTick: 6,
+      context: { structureId },
+    };
+
+    const workforce: WorkforceState = {
+      roles: [gardenerRole],
+      employees: [employee],
+      taskDefinitions: [taskDefinition],
+      taskQueue: [task],
+      kpis: [],
+      payroll: createPayrollState(0),
+    } satisfies WorkforceState;
+
+    const ctx: EngineRunContext = {
+      payroll: {
+        locationIndexTable: {
+          defaultIndex: 0.9,
+          overrides: [
+            { countryName: 'Germany', index: 1.05 },
+            { countryName: 'Germany', cityName: 'Hamburg', index: 1.4 },
+          ],
+        },
+      },
+    };
+
+    const nextWorld = runStages(
+      { ...world, workforce } satisfies SimulationWorld,
+      ctx,
+      ['applyWorkforce', 'applyEconomyAccrual'],
+    );
+
+    const totals = nextWorld.workforce.payroll.totals;
+    // base rate: (5 + 10 * 0.6) = 11 -> * 1.4 => 15.4 per hour.
+    expect(totals.baseCost).toBeCloseTo((15.4 / 60) * 180, 4);
+  });
+
+  it('finalizes previous day payroll with banker rounding when day rolls over', () => {
+    const world = createDemoWorld() as SimulationWorld;
+    const structureId = world.company.structures[0].id;
+    world.simTimeHours = 24;
+
+    const priorPayroll: WorkforcePayrollState = {
+      dayIndex: 0,
+      totals: {
+        baseMinutes: 30,
+        otMinutes: 0,
+        baseCost: 10.005,
+        otCost: 0,
+        totalLaborCost: 10.005,
+      },
+      byStructure: [
+        {
+          structureId,
+          baseMinutes: 30,
+          otMinutes: 0,
+          baseCost: 10.005,
+          otCost: 0,
+          totalLaborCost: 10.005,
+        },
+      ],
+    } satisfies WorkforcePayrollState;
+
+    const workforce: WorkforceState = {
+      roles: [],
+      employees: [],
+      taskDefinitions: [],
+      taskQueue: [],
+      kpis: [],
+      payroll: priorPayroll,
+    } satisfies WorkforceState;
+
+    const ctx: EngineRunContext = {};
+
+    const nextWorld = runStages(
+      { ...world, workforce } satisfies SimulationWorld,
+      ctx,
+      ['applyWorkforce', 'applyEconomyAccrual'],
+    );
+
+    const nextPayroll = nextWorld.workforce.payroll;
+    expect(nextPayroll.dayIndex).toBe(1);
+    expect(nextPayroll.totals.baseMinutes).toBe(0);
+    expect(nextPayroll.totals.totalLaborCost).toBe(0);
+
+    const finalizedDays = (ctx as { economyAccruals?: any }).economyAccruals?.workforce?.finalizedDays;
+    expect(finalizedDays).toBeDefined();
+    expect(finalizedDays?.[0]?.totals.baseCost).toBe(10);
+    expect(finalizedDays?.[0]?.totals.totalLaborCost).toBe(10);
+  });
+});


### PR DESCRIPTION
## Summary
- add a payroll location index dataset with a typed loader and validation
- extend the workforce stage to accrue daily labour costs, apply Banker's rounding, and expose the snapshot to the economy stage
- cover overtime, location multipliers, rounding edge cases, and document the payroll formula in DD/CHANGELOG

## Testing
- pnpm --filter @wb/engine test *(fails: vitest missing in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e26c8402cc8325b3517c618b021c8d