### PR TITLE
feat(workforce): add payroll multipliers and HR intents

### DIFF
--- a/docs/ADR/ADR-0013-workforce-domain-model.md
+++ b/docs/ADR/ADR-0013-workforce-domain-model.md
@@ -25,6 +25,10 @@ contract to rely on when modelling labour availability or overtime policies.
   single canonical structure.
 - Extend employee records with deterministic trait assignments and the hiring skill triad so behavioural modifiers stay aligned
   with SEC §10.3 trait catalogues and the scheduler can apply trait hooks without ad-hoc randomness.
+- Track compensation multipliers (`EmployeeRole.baseRateMultiplier`, employee-specific base multipliers, labour market factors,
+  shift premiums), career experience, salary expectations, employment start dates, and raise cadence state on employees so the
+  payroll engine can apply the full SEC rate formula while modelling HR flows (raises, bonuses, termination morale ripples)
+  deterministically.
 
 ## Consequences
 
@@ -33,6 +37,8 @@ contract to rely on when modelling labour availability or overtime policies.
 - Workforce data has a deterministic contract that façade validation, schedulers, and read-model projections can share.
 - UUID v7 enforcement on employee RNG seeds eliminates ambiguous randomness sources and keeps trait generation reproducible.
 - Structured task definitions unblock future automation and intent validation because skills/roles share the same canonical keys.
+- Compensation and HR metadata (experience accumulation, raise cadence, salary expectations, morale ripples) remain available to
+  payroll, telemetry, and façade layers without duplicating calculations outside the engine.
 - Documentation (DD/TDD/Changelog) now captures workforce invariants for onboarding and review.
 
 ### Negative

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+### #76 Workforce payroll multipliers & HR intents
+
+- Extended `EmployeeRole` and `Employee` domain models with deterministic compensation metadata: role and employee base rate
+  multipliers, labour-market factors, shift time premiums, employment start days, cumulative experience tracking, salary
+  expectations, and persisted raise cadence state. Updated the workforce Zod schemas and schema unit tests accordingly.
+- Updated `applyWorkforce` payroll accruals to evaluate the full SEC formula
+  `rate_per_hour = (5 + 10 × skill) × locationIndex × roleMult × employeeMult × experienceMult × laborMarketFactor`, apply shift
+  premiums, and accrue overtime at `1.25×`. Employees now gain experience hours based on work minutes and trait XP multipliers.
+- Introduced a raise cadence service with a 180-day employment gate, deterministic jittered cooldowns, and Accept/Bonus/Ignore
+  intents that adjust morale, salary multipliers, and next eligibility windows. Emitted new telemetry topics for raises and
+  persisted cadence state on employees.
+- Added termination intent handling to `applyWorkforce` removing employees before scheduling, clearing task assignments,
+  applying optional morale ripples to co-workers, and emitting `telemetry.workforce.employee.terminated.v1` events.
+- Surfaced daily payroll snapshots via `telemetry.workforce.payroll_snapshot.v1` and exposed the current payroll state through
+  the façade `createWorkforceView` read-model.
+- Expanded unit/integration coverage: payroll multiplier scaling, raise cadence eligibility and cooldown resets, termination
+  cleanup with telemetry, and façade view assertions.
+
 ### #75 Workforce trait system & façade exposure
 
 - Added workforce trait metadata (`traits.ts`) describing conflict groups, strength ranges, and effect hooks for task duration,

--- a/docs/TDD.md
+++ b/docs/TDD.md
@@ -156,6 +156,10 @@ describe('Light schedule — SEC §8', () => {
 - `workforceStateSchema` validates the full branch (`roles`, `employees`, `taskDefinitions`, `taskQueue`, `kpis`, `warnings`, `payroll`) embedded in the world snapshot to guard deterministic scheduling inputs. `workforceWarningSchema` clamps severity to `'info' | 'warning' | 'critical'` and requires deterministic codes/messages plus optional structure/employee/task anchors.
 - Unit coverage: `tests/unit/domain/workforceSchemas.test.ts` exercises the above constraints (including warnings) and snapshot parsing.
 - Façade integration coverage: `packages/facade/tests/integration/workforceView.integration.test.ts` projects a simulated workforce state into directory filters, live queue entries, KPI percentages, and decorated warnings via `createWorkforceView`.
+- Payroll scaling, raise cadence, and termination handling are covered by `packages/engine/tests/unit/workforce/payroll.test.ts`,
+  `packages/engine/tests/unit/services/workforce/raises.test.ts`, and
+  `packages/engine/tests/integration/workforce/workforceScheduling.integration.test.ts`, respectively. These suites assert the
+  new rate multipliers, cooldown resets, morale adjustments, task cleanup, and telemetry emission introduced for HR flows.
 - Trait coverage: `packages/engine/tests/unit/workforce/traits.test.ts` validates trait sampling conflicts, stacking modifiers, and salary deltas; `packages/engine/tests/integration/pipeline/workforceTraits.integration.test.ts` asserts runtime assignments expose trait-adjusted duration/error/fatigue data for downstream subsystems; `packages/facade/tests/unit/readModels/traitBreakdownView.test.ts` covers the façade aggregation.
 
 ---

--- a/packages/engine/src/backend/src/domain/workforce/Employee.ts
+++ b/packages/engine/src/backend/src/domain/workforce/Employee.ts
@@ -39,6 +39,32 @@ export interface EmployeeSchedule {
 }
 
 /**
+ * Tracks cumulative workforce experience for an employee.
+ */
+export interface EmployeeExperience {
+  /** Total labour hours accrued over the employee's career. */
+  readonly hoursAccrued: number;
+  /** Normalised experience level on the inclusive range [0, 1]. */
+  readonly level01: number;
+}
+
+/**
+ * Raise cadence metadata recorded per employee so eligibility can be evaluated
+ * deterministically.
+ */
+export interface EmployeeRaiseState {
+  /** Sim day of the most recent raise decision when available. */
+  readonly lastDecisionDay?: number;
+  /** Next sim day when the employee becomes eligible for a new raise. */
+  readonly nextEligibleDay?: number;
+  /**
+   * Sequential counter consumed by the cadence jitter stream to ensure stable
+   * pseudo-random offsets.
+   */
+  readonly cadenceSequence: number;
+}
+
+/**
  * Canonical representation of an employee in the simulation workforce directory.
  */
 export interface Employee extends DomainEntity, TraitSubject {
@@ -64,4 +90,18 @@ export interface Employee extends DomainEntity, TraitSubject {
   readonly schedule: EmployeeSchedule;
   /** Optional free-form notes aiding HR diagnostics. */
   readonly notes?: string;
+  /** Base multiplier applied on top of the role baseline for hourly compensation. */
+  readonly baseRateMultiplier: number;
+  /** Experience tracking metadata (total hours + normalised level). */
+  readonly experience: EmployeeExperience;
+  /** Labour market factor describing negotiated rate adjustments. */
+  readonly laborMarketFactor: number;
+  /** Multiplier applied for shift premiums such as night or weekend work. */
+  readonly timePremiumMultiplier: number;
+  /** Sim day (floor) when the employee started employment. */
+  readonly employmentStartDay: number;
+  /** Expected base hourly salary agreed with the employee. */
+  readonly salaryExpectation_per_h: number;
+  /** Raise cadence metadata ensuring deterministic cooldown progression. */
+  readonly raise: EmployeeRaiseState;
 }

--- a/packages/engine/src/backend/src/domain/workforce/EmployeeRole.ts
+++ b/packages/engine/src/backend/src/domain/workforce/EmployeeRole.ts
@@ -20,4 +20,10 @@ export interface EmployeeRole extends DomainEntity, SluggedEntity {
   readonly coreSkills: readonly EmployeeSkillRequirement[];
   /** Optional list of tags that classify the role (e.g. compliance, operations). */
   readonly tags?: readonly string[];
+  /**
+   * Role-wide multiplier applied to the base hourly wage before employee specific
+   * modifiers are evaluated. Defaults to 1 when omitted for backwards
+   * compatibility with existing blueprints.
+   */
+  readonly baseRateMultiplier?: number;
 }

--- a/packages/engine/src/backend/src/domain/workforce/intents.ts
+++ b/packages/engine/src/backend/src/domain/workforce/intents.ts
@@ -1,5 +1,46 @@
 import type { Uuid } from '../entities.js';
 
+export interface WorkforceRaiseAcceptIntent {
+  readonly type: 'workforce.raise.accept';
+  readonly employeeId: Uuid;
+  /** Optional custom percentage (0.05 = +5%) applied to the hourly base rate. */
+  readonly rateIncreaseFactor?: number;
+  /** Optional morale boost override applied after acceptance. */
+  readonly moraleBoost01?: number;
+}
+
+export interface WorkforceRaiseBonusIntent {
+  readonly type: 'workforce.raise.bonus';
+  readonly employeeId: Uuid;
+  /** Optional lump-sum bonus expressed in company credits for economy hooks. */
+  readonly bonusAmount_cc?: number;
+  /** Optional custom percentage applied to the hourly base rate. */
+  readonly rateIncreaseFactor?: number;
+  /** Optional morale boost override applied after the bonus is granted. */
+  readonly moraleBoost01?: number;
+}
+
+export interface WorkforceRaiseIgnoreIntent {
+  readonly type: 'workforce.raise.ignore';
+  readonly employeeId: Uuid;
+  /** Optional morale penalty override applied when the raise is ignored. */
+  readonly moralePenalty01?: number;
+}
+
+export type WorkforceRaiseIntent =
+  | WorkforceRaiseAcceptIntent
+  | WorkforceRaiseBonusIntent
+  | WorkforceRaiseIgnoreIntent;
+
+export interface WorkforceTerminationIntent {
+  readonly type: 'workforce.employee.terminate';
+  readonly employeeId: Uuid;
+  readonly reasonSlug?: string;
+  readonly severanceCc?: number;
+  /** Optional morale ripple applied to peers in the same structure. */
+  readonly moraleRipple01?: number;
+}
+
 export interface HiringMarketScanIntent {
   readonly type: 'hiring.market.scan';
   readonly structureId: Uuid;
@@ -15,4 +56,8 @@ export interface HiringMarketHireIntent {
   readonly candidate: HiringMarketCandidateRef;
 }
 
-export type WorkforceIntent = HiringMarketScanIntent | HiringMarketHireIntent;
+export type WorkforceIntent =
+  | HiringMarketScanIntent
+  | HiringMarketHireIntent
+  | WorkforceRaiseIntent
+  | WorkforceTerminationIntent;

--- a/packages/engine/src/backend/src/domain/workforce/traits.ts
+++ b/packages/engine/src/backend/src/domain/workforce/traits.ts
@@ -1,4 +1,4 @@
-import traitsJson from '../../../../../../data/personnel/traits.json' assert { type: 'json' };
+import traitsJson from '../../../../../../../data/personnel/traits.json' assert { type: 'json' };
 
 import { clamp01 } from '../../util/math.js';
 import type { RandomNumberGenerator } from '../../util/rng.js';

--- a/packages/engine/src/backend/src/services/workforce/raises.ts
+++ b/packages/engine/src/backend/src/services/workforce/raises.ts
@@ -1,0 +1,125 @@
+import { clamp01 } from '../../util/math.js';
+import { createRng } from '../../util/rng.js';
+import type {
+  Employee,
+  EmployeeRaiseState,
+} from '../../domain/workforce/Employee.js';
+import type {
+  WorkforceRaiseBonusIntent,
+  WorkforceRaiseIntent,
+} from '../../domain/workforce/intents.js';
+
+const RAISE_ACCEPT_DEFAULT_RATE_INCREASE = 0.05;
+const RAISE_BONUS_DEFAULT_RATE_INCREASE = 0.03;
+const RAISE_ACCEPT_DEFAULT_MORALE_BOOST = 0.06;
+const RAISE_BONUS_DEFAULT_MORALE_BOOST = 0.04;
+const RAISE_IGNORE_DEFAULT_MORALE_PENALTY = -0.08;
+const RAISE_JITTER_RANGE_DAYS = 45;
+
+export const RAISE_MIN_EMPLOYMENT_DAYS = 180;
+export const RAISE_BASE_COOLDOWN_DAYS = 180;
+
+export interface RaiseIntentOutcome {
+  readonly employee: Employee;
+  readonly moraleDelta01: number;
+  readonly rateIncreaseFactor: number;
+  readonly action: 'accept' | 'bonus' | 'ignore';
+  readonly bonusAmount_cc?: number;
+}
+
+function resolveMoraleBoost(intent: WorkforceRaiseIntent): number {
+  if (intent.type === 'workforce.raise.ignore') {
+    return intent.moralePenalty01 ?? RAISE_IGNORE_DEFAULT_MORALE_PENALTY;
+  }
+
+  if (intent.type === 'workforce.raise.accept') {
+    return intent.moraleBoost01 ?? RAISE_ACCEPT_DEFAULT_MORALE_BOOST;
+  }
+
+  return intent.moraleBoost01 ?? RAISE_BONUS_DEFAULT_MORALE_BOOST;
+}
+
+function resolveRateIncrease(intent: WorkforceRaiseIntent): number {
+  if (intent.type === 'workforce.raise.accept') {
+    return intent.rateIncreaseFactor ?? RAISE_ACCEPT_DEFAULT_RATE_INCREASE;
+  }
+
+  if (intent.type === 'workforce.raise.bonus') {
+    return intent.rateIncreaseFactor ?? RAISE_BONUS_DEFAULT_RATE_INCREASE;
+  }
+
+  return 0;
+}
+
+function computeNextEligibleDay(
+  employee: Employee,
+  currentSimDay: number,
+  nextSequence: number,
+): number {
+  const rng = createRng(employee.rngSeedUuid, `workforce:raise:${nextSequence}`);
+  const jitter = Math.round((rng() * 2 - 1) * RAISE_JITTER_RANGE_DAYS);
+  const baseTarget = currentSimDay + RAISE_BASE_COOLDOWN_DAYS + jitter;
+  const minimum = currentSimDay + RAISE_MIN_EMPLOYMENT_DAYS;
+  return Math.max(minimum, baseTarget);
+}
+
+export function createInitialRaiseState(
+  employmentStartDay: number,
+): EmployeeRaiseState {
+  const nextEligibleDay = employmentStartDay + RAISE_MIN_EMPLOYMENT_DAYS;
+  return {
+    cadenceSequence: 0,
+    nextEligibleDay,
+  } satisfies EmployeeRaiseState;
+}
+
+export function applyRaiseIntent(options: {
+  readonly employee: Employee;
+  readonly intent: WorkforceRaiseIntent;
+  readonly currentSimDay: number;
+}): RaiseIntentOutcome | null {
+  const { employee, intent, currentSimDay } = options;
+  const minimumEmploymentDay = employee.employmentStartDay + RAISE_MIN_EMPLOYMENT_DAYS;
+  const nextEligibleDay = employee.raise.nextEligibleDay ?? minimumEmploymentDay;
+
+  if (currentSimDay < minimumEmploymentDay || currentSimDay < nextEligibleDay) {
+    return null;
+  }
+
+  const moraleDelta = resolveMoraleBoost(intent);
+  const rateIncrease = resolveRateIncrease(intent);
+  const multiplier = 1 + rateIncrease;
+  const nextSequence = employee.raise.cadenceSequence + 1;
+  const updatedMorale = clamp01(employee.morale01 + moraleDelta);
+  const updatedBaseRateMultiplier = Math.max(0.1, employee.baseRateMultiplier * multiplier);
+  const updatedSalaryExpectation = Math.max(
+    0,
+    employee.salaryExpectation_per_h * multiplier,
+  );
+  const updatedRaiseState: EmployeeRaiseState = {
+    cadenceSequence: nextSequence,
+    lastDecisionDay: currentSimDay,
+    nextEligibleDay: computeNextEligibleDay(employee, currentSimDay, nextSequence),
+  };
+
+  const updatedEmployee: Employee = {
+    ...employee,
+    morale01: updatedMorale,
+    baseRateMultiplier: updatedBaseRateMultiplier,
+    salaryExpectation_per_h: updatedSalaryExpectation,
+    raise: updatedRaiseState,
+  };
+
+  return {
+    employee: updatedEmployee,
+    moraleDelta01: moraleDelta,
+    rateIncreaseFactor: rateIncrease,
+    action:
+      intent.type === 'workforce.raise.accept'
+        ? 'accept'
+        : intent.type === 'workforce.raise.bonus'
+          ? 'bonus'
+          : 'ignore',
+    bonusAmount_cc: (intent as WorkforceRaiseBonusIntent).bonusAmount_cc,
+  } satisfies RaiseIntentOutcome;
+}

--- a/packages/engine/src/backend/src/telemetry/topics.ts
+++ b/packages/engine/src/backend/src/telemetry/topics.ts
@@ -7,3 +7,13 @@ export const TELEMETRY_HIRING_MARKET_SCAN_COMPLETED_V1 =
   'telemetry.hiring.market_scan.completed.v1' as const;
 export const TELEMETRY_HIRING_EMPLOYEE_ONBOARDED_V1 =
   'telemetry.hiring.employee.onboarded.v1' as const;
+export const TELEMETRY_WORKFORCE_PAYROLL_SNAPSHOT_V1 =
+  'telemetry.workforce.payroll_snapshot.v1' as const;
+export const TELEMETRY_WORKFORCE_RAISE_ACCEPTED_V1 =
+  'telemetry.workforce.raise.accepted.v1' as const;
+export const TELEMETRY_WORKFORCE_RAISE_BONUS_V1 =
+  'telemetry.workforce.raise.bonus.v1' as const;
+export const TELEMETRY_WORKFORCE_RAISE_IGNORED_V1 =
+  'telemetry.workforce.raise.ignored.v1' as const;
+export const TELEMETRY_WORKFORCE_EMPLOYEE_TERMINATED_V1 =
+  'telemetry.workforce.employee.terminated.v1' as const;

--- a/packages/engine/tests/unit/domain/workforceSchemas.test.ts
+++ b/packages/engine/tests/unit/domain/workforceSchemas.test.ts
@@ -42,7 +42,14 @@ const VALID_EMPLOYEE = {
     daysPerWeek: 5,
     shiftStartHour: 6
   },
-  notes: 'Senior grow technician'
+  notes: 'Senior grow technician',
+  baseRateMultiplier: 1.05,
+  experience: { hoursAccrued: 420, level01: 0.1 },
+  laborMarketFactor: 1.1,
+  timePremiumMultiplier: 1.2,
+  employmentStartDay: 45,
+  salaryExpectation_per_h: 18.5,
+  raise: { cadenceSequence: 2, lastDecisionDay: 200, nextEligibleDay: 380 }
 };
 
 const VALID_WORKFORCE_STATE = {
@@ -57,6 +64,8 @@ const VALID_WORKFORCE_STATE = {
           minSkill01: 0.5
         }
       ]
+    ,
+      baseRateMultiplier: 1.02,
     }
   ],
   employees: [VALID_EMPLOYEE],

--- a/packages/engine/tests/unit/services/workforce/raises.test.ts
+++ b/packages/engine/tests/unit/services/workforce/raises.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyRaiseIntent,
+  createInitialRaiseState,
+  RAISE_BASE_COOLDOWN_DAYS,
+  RAISE_MIN_EMPLOYMENT_DAYS,
+} from '@/backend/src/services/workforce/raises.js';
+import { createRng } from '@/backend/src/util/rng.js';
+import type { Employee, WorkforceRaiseIntent } from '@/backend/src/domain/world.js';
+
+function createEmployee(overrides: Partial<Employee> = {}): Employee {
+  const base: Employee = {
+    id: '00000000-0000-0000-0000-00000000aaaa' as Employee['id'],
+    name: 'Cadence Tester',
+    roleId: '00000000-0000-0000-0000-00000000bbbb' as Employee['roleId'],
+    rngSeedUuid: '018f43f1-8b44-7b74-b3ce-5fbd7be3c201',
+    assignedStructureId: '00000000-0000-0000-0000-00000000cccc' as Employee['assignedStructureId'],
+    morale01: 0.7,
+    fatigue01: 0.2,
+    skills: [{ skillKey: 'analysis', level01: 0.6 }],
+    skillTriad: {
+      main: { skillKey: 'analysis', level01: 0.6 },
+      secondary: [
+        { skillKey: 'communication', level01: 0.4 },
+        { skillKey: 'operations', level01: 0.3 },
+      ],
+    },
+    traits: [],
+    schedule: {
+      hoursPerDay: 8,
+      overtimeHoursPerDay: 1,
+      daysPerWeek: 5,
+      shiftStartHour: 8,
+    },
+    baseRateMultiplier: 1,
+    experience: { hoursAccrued: 0, level01: 0 },
+    laborMarketFactor: 1,
+    timePremiumMultiplier: 1,
+    employmentStartDay: 0,
+    salaryExpectation_per_h: 18,
+    raise: createInitialRaiseState(0),
+  } satisfies Employee;
+
+  return { ...base, ...overrides } satisfies Employee;
+}
+
+describe('workforce raise cadence', () => {
+  it('blocks raise intents before the employment gate', () => {
+    const employee = createEmployee();
+    const intent: WorkforceRaiseIntent = {
+      type: 'workforce.raise.accept',
+      employeeId: employee.id,
+    };
+
+    const outcome = applyRaiseIntent({ employee, intent, currentSimDay: 90 });
+
+    expect(outcome).toBeNull();
+  });
+
+  it('applies raise acceptance and schedules deterministic cooldowns', () => {
+    const employee = createEmployee();
+    const currentSimDay = RAISE_MIN_EMPLOYMENT_DAYS;
+    const intent: WorkforceRaiseIntent = {
+      type: 'workforce.raise.accept',
+      employeeId: employee.id,
+    };
+
+    const outcome = applyRaiseIntent({ employee, intent, currentSimDay });
+
+    expect(outcome).not.toBeNull();
+    const result = outcome!;
+
+    expect(result.moraleDelta01).toBeCloseTo(0.06);
+    expect(result.rateIncreaseFactor).toBeCloseTo(0.05);
+    expect(result.employee.baseRateMultiplier).toBeCloseTo(1.05, 5);
+    expect(result.employee.salaryExpectation_per_h).toBeCloseTo(18.9, 5);
+    expect(result.employee.morale01).toBeCloseTo(0.76, 5);
+    expect(result.employee.raise.cadenceSequence).toBe(1);
+    expect(result.employee.raise.lastDecisionDay).toBe(currentSimDay);
+
+    const rng = createRng(employee.rngSeedUuid, 'workforce:raise:1');
+    const jitter = Math.round((rng() * 2 - 1) * 45);
+    const expectedNext = Math.max(
+      currentSimDay + RAISE_MIN_EMPLOYMENT_DAYS,
+      currentSimDay + RAISE_BASE_COOLDOWN_DAYS + jitter,
+    );
+    expect(result.employee.raise.nextEligibleDay).toBe(expectedNext);
+  });
+
+  it('resets cadence on ignore and applies morale penalties without rate changes', () => {
+    const previous = createEmployee({
+      morale01: 0.82,
+      baseRateMultiplier: 1.1,
+      raise: { cadenceSequence: 1, lastDecisionDay: 200, nextEligibleDay: 380 },
+      employmentStartDay: 0,
+    });
+
+    const intent: WorkforceRaiseIntent = {
+      type: 'workforce.raise.ignore',
+      employeeId: previous.id,
+    };
+
+    const outcome = applyRaiseIntent({ employee: previous, intent, currentSimDay: 400 });
+
+    expect(outcome).not.toBeNull();
+    const result = outcome!;
+
+    expect(result.employee.baseRateMultiplier).toBeCloseTo(1.1, 5);
+    expect(result.employee.morale01).toBeLessThan(previous.morale01);
+    expect(result.moraleDelta01).toBeCloseTo(-0.08, 5);
+    expect(result.employee.raise.cadenceSequence).toBe(2);
+    expect(result.employee.raise.lastDecisionDay).toBe(400);
+    expect(result.employee.raise.nextEligibleDay).toBeGreaterThanOrEqual(
+      400 + RAISE_MIN_EMPLOYMENT_DAYS,
+    );
+  });
+
+  it('allows bonus raises with custom rate increases', () => {
+    const employee = createEmployee({
+      raise: { cadenceSequence: 4, lastDecisionDay: 500, nextEligibleDay: 680 },
+      employmentStartDay: 0,
+    });
+
+    const intent: WorkforceRaiseIntent = {
+      type: 'workforce.raise.bonus',
+      employeeId: employee.id,
+      rateIncreaseFactor: 0.02,
+      bonusAmount_cc: 500,
+      moraleBoost01: 0.05,
+    };
+
+    const outcome = applyRaiseIntent({ employee, intent, currentSimDay: 700 });
+
+    expect(outcome).not.toBeNull();
+    const result = outcome!;
+
+    expect(result.rateIncreaseFactor).toBeCloseTo(0.02, 5);
+    expect(result.employee.baseRateMultiplier).toBeCloseTo(1.02, 5);
+    expect(result.employee.morale01).toBeCloseTo(employee.morale01 + 0.05, 5);
+    expect(result.employee.raise.cadenceSequence).toBe(5);
+    expect(result.employee.raise.nextEligibleDay).toBeGreaterThanOrEqual(
+      700 + RAISE_MIN_EMPLOYMENT_DAYS,
+    );
+    expect(result.bonusAmount_cc).toBe(500);
+  });
+});

--- a/packages/engine/tests/unit/workforce/traits.test.ts
+++ b/packages/engine/tests/unit/workforce/traits.test.ts
@@ -24,7 +24,7 @@ describe('workforce trait utilities', () => {
     let index = 0;
     const rng = () => rngValues[index++ % rngValues.length] ?? 0.3;
 
-    const traits = sampleTraitSet({ rng });
+    const traits = sampleTraitSet({ rng, desiredCount: 2 });
 
     expect(traits).toHaveLength(2);
     const conflicts = new Set(traits.flatMap((trait) => trait.conflictsWith));

--- a/packages/facade/src/readModels/workforceView.ts
+++ b/packages/facade/src/readModels/workforceView.ts
@@ -2,6 +2,7 @@ import type {
   Employee,
   EmployeeRole,
   EmployeeSkillRequirement,
+  WorkforcePayrollState,
   Structure,
   WorkforceKpiSnapshot,
   WorkforceState,
@@ -125,6 +126,7 @@ export interface WorkforceView {
   readonly queue: readonly WorkforceQueueTaskView[];
   readonly latestKpi?: WorkforceKpiView;
   readonly warnings: readonly WorkforceWarningView[];
+  readonly payroll: WorkforcePayrollState;
 }
 
 function resolveEmployeeGender(employee: Employee): WorkforceDirectoryGender {
@@ -324,6 +326,7 @@ export function createWorkforceView(
     employeeDetails,
     queue,
     latestKpi,
-    warnings
+    warnings,
+    payroll: workforce.payroll
   } satisfies WorkforceView;
 }

--- a/packages/facade/tests/integration/workforceView.integration.test.ts
+++ b/packages/facade/tests/integration/workforceView.integration.test.ts
@@ -237,6 +237,7 @@ describe('createWorkforceView', () => {
     const view = createWorkforceView(workforce, options);
 
     expect(view.directory.employees).toHaveLength(2);
+    expect(view.payroll).toEqual(workforce.payroll);
     const [firstEmployee] = view.directory.employees;
     expect(firstEmployee.moralePercent).toBe(82);
     expect(firstEmployee.fatiguePercent).toBe(18);

--- a/packages/facade/tests/unit/readModels/traitBreakdownView.test.ts
+++ b/packages/facade/tests/unit/readModels/traitBreakdownView.test.ts
@@ -18,6 +18,20 @@ function buildEmployee(partial: Partial<Employee>): Employee {
       overtimeHoursPerDay: 0,
       daysPerWeek: 5,
     },
+    skillTriad: {
+      main: { skillKey: 'general', level01: 0.5 },
+      secondary: [
+        { skillKey: 'secondary_a', level01: 0.3 },
+        { skillKey: 'secondary_b', level01: 0.2 },
+      ],
+    },
+    baseRateMultiplier: 1,
+    experience: { hoursAccrued: 0, level01: 0 },
+    laborMarketFactor: 1,
+    timePremiumMultiplier: 1,
+    employmentStartDay: 0,
+    salaryExpectation_per_h: 15,
+    raise: { cadenceSequence: 0, nextEligibleDay: 180 },
     traits: [],
     ...partial,
   } satisfies Employee;
@@ -82,18 +96,6 @@ describe('createTraitBreakdown', () => {
         focusSkills: ['gardening'],
       },
       {
-        id: 'trait_frugal',
-        name: 'Frugal',
-        type: 'positive',
-        count: 1,
-        averageStrength01: 0.5,
-        averageStrengthPercent: 50,
-        description:
-          'Accepts a slightly lower salary than their skills would normally demand.',
-        economyHint: 'Accepts a lower base salary expectation.',
-        focusSkills: [],
-      },
-      {
         id: 'trait_clumsy',
         name: 'Clumsy',
         type: 'negative',
@@ -103,6 +105,18 @@ describe('createTraitBreakdown', () => {
         description:
           'Slightly increases the chance of minor errors during maintenance tasks.',
         economyHint: undefined,
+        focusSkills: [],
+      },
+      {
+        id: 'trait_frugal',
+        name: 'Frugal',
+        type: 'positive',
+        count: 1,
+        averageStrength01: 0.5,
+        averageStrengthPercent: 50,
+        description:
+          'Accepts a slightly lower salary than their skills would normally demand.',
+        economyHint: 'Accepts a lower base salary expectation.',
         focusSkills: [],
       },
     ]);

--- a/packages/facade/vitest.config.ts
+++ b/packages/facade/vitest.config.ts
@@ -20,7 +20,8 @@ export default defineConfig({
   resolve: {
     alias: {
       '@wb/engine': resolve(currentDir, '../engine/src/index.ts'),
-      '@/backend': resolve(currentDir, '../engine/src/backend')
+      '@/backend': resolve(currentDir, '../engine/src/backend'),
+      '@': resolve(currentDir, 'src')
     }
   }
 });


### PR DESCRIPTION
## Summary
- extend workforce domain schemas with compensation multipliers, experience tracking, raise cadence, and salary expectation fields
- update applyWorkforce payroll calculations, add raise/termination intent handling, and emit new telemetry including payroll snapshots
- expose payroll data in the façade workforce view, add raise cadence service, and cover the new flows with unit/integration tests
- refresh documentation (DD/TDD/tasks/ADR/CHANGELOG) to describe the new payroll formula and HR workflows

## Testing
- pnpm -r test *(fails: missing node_modules in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e2bc1481f88325b9f9c57340144446