### PR TITLE
Add humidity baseline to engine demo harness

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### #77 Demo harness humidity baseline
+
+- Updated the engine test harness demo zone to include a representative
+  `relativeHumidity_pct` value so the fixture aligns with the environment
+  schema used across integration tests and perf harness scenarios.
+
 ### #76 Workforce payroll multipliers & HR intents
 
 - Extended `EmployeeRole` and `Employee` domain models with deterministic compensation metadata: role and employee base rate

--- a/packages/engine/src/backend/src/engine/testHarness.ts
+++ b/packages/engine/src/backend/src/engine/testHarness.ts
@@ -95,7 +95,8 @@ const DEMO_WORLD: SimulationWorld = {
                 },
                 photoperiodPhase: 'vegetative',
                 environment: {
-                  airTemperatureC: 22
+                  airTemperatureC: 22,
+                  relativeHumidity_pct: 55
                 },
                 ppfd_umol_m2s: 0,
                 dli_mol_m2d_inc: 0,


### PR DESCRIPTION
## Summary
- set a representative relative humidity on the demo zone environment in the engine test harness
- document the humidity fixture update in the changelog for visibility

## Testing
- pnpm --filter @wb/engine test

------
https://chatgpt.com/codex/tasks/task_e_68e3475698148325acdbdf70ebb5eedd