### PR TITLE
docs: sync tick pipeline and blueprint directory guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,9 @@ Steer implementation so the codebase **conforms to SEC v0.2.1** while remaining 
 
 - **Blueprints** live under `/data/blueprints/**` (strains, devices, cultivationMethods, substrates, containers, …). **Never embed prices** in device blueprints.
     
-- **Contributors guardrail:** Blueprint JSON is the source of truth. Keep each file inside the taxonomy folder that mirrors its `class` (`device/climate/cooling/**`, etc.). The loader fails fast (`BlueprintTaxonomyMismatchError`) whenever the directory and JSON diverge.
+- **Contributors guardrail:** Blueprint JSON is the source of truth. Keep each file inside the taxonomy folder that mirrors its `class` (`device/climate/*.json`, `device/lighting/*.json`, etc.). The loader fails fast (`BlueprintTaxonomyMismatchError`) whenever the directory and JSON diverge.
+
+Blueprint directory rule: All blueprints are auto-discovered under /data/blueprints/<domain>/<file>.json with a maximum depth of two segments (domain + file). Devices are /data/blueprints/device/<category>.json or /data/blueprints/device/<category>/<file>.json limited to two levels; no deeper subfolders are allowed.
 
 - **Price maps** live under `/data/prices/**`.
     
@@ -154,22 +156,18 @@ Every **Zone MUST reference exactly one `cultivationMethod`** (blueprint id). Th
 
 ## 7) Tick Pipeline (SEC §4.2)
 
-Implement the fixed order:
+### Tick Pipeline (Canonical, 9 Phases)
 
-1. **Device Effects**
-    
-2. **Environment Update**
-    
-3. **Irrigation & Nutrients**
-    
-4. **Plant Physiology**
-    
-5. **Harvest & Inventory**
-    
-6. **Economy & Cost Accrual**
-    
-7. **Commit & Telemetry**
-    
+1) Device Effects  
+2) Sensor Sampling  
+3) Environment Update  
+4) Irrigation & Nutrients  
+5) Workforce Scheduling  
+6) Plant Physiology  
+7) Harvest & Inventory  
+8) Economy & Cost Accrual  
+9) Commit & Telemetry
+
 
 > Implement as a small state machine to support pause/step.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased — Blueprint Taxonomy v2
 
+- Docs: standardized blueprint folders to max two levels under /data/blueprints (no deeper subfolders).
 - Flattened `/data/blueprints` to domain-level folders (`device/<category>/*.json`,
   `cultivation-method/*.json`, `room/purpose/*.json`, etc.) and aligned all JSON `class`
   values to domain identifiers (`strain`, `device.climate`, `room.purpose.<slug>`, ...).

--- a/docs/DD.md
+++ b/docs/DD.md
@@ -92,15 +92,15 @@ geometry bounds) before the tick pipeline consumes a scenario payload.
 
 - **Blueprint taxonomy:** All blueprints expose `class` values using a domain-level
   identifier (`strain`, `cultivation-method`, `device.climate`, `room.purpose.growroom`,
-  etc.) plus a kebab-case `slug` unique within that class. Directory layout is flattened
-  to two levels—`/data/blueprints/<domain>/<file>.json`—so loaders can map files to
-  domains without parsing subtype folders. JSON stays authoritative for metadata; the
-  filesystem only provides expectations. When the folder taxonomy and JSON `class`
-  disagree, the loader throws a `BlueprintTaxonomyMismatchError` and rejects the
-  payload. Subtype information (device climate mode, airflow subtype, cultivation
-  family/technique, pathogen, taxon, substrate material/cycle, irrigation
+  etc.) plus a kebab-case `slug` unique within that class. JSON stays authoritative for
+  metadata; the filesystem only provides expectations. When the folder taxonomy and
+  JSON `class` disagree, the loader throws a `BlueprintTaxonomyMismatchError` and
+  rejects the payload. Subtype information (device climate mode, airflow subtype,
+  cultivation family/technique, pathogen, taxon, substrate material/cycle, irrigation
   method/control, etc.) is expressed by explicit fields within the JSON payload instead
   of being inferred from paths.
+
+Blueprint directory rule: All blueprints are auto-discovered under /data/blueprints/<domain>/<file>.json with a maximum depth of two segments (domain + file). Devices are /data/blueprints/device/<category>.json or /data/blueprints/device/<category>/<file>.json limited to two levels; no deeper subfolders are allowed.
 
 ### 4.2 Price Maps
 
@@ -226,17 +226,17 @@ targets from the same factor to keep unit conversions deterministic.
 
 ## 6) Tick Pipeline (SEC §4.2)
 
-Fixed order per tick (9 phases):
+### Tick Pipeline (Canonical, 9 Phases)
 
-1. **Device Effects** — compute device outputs (light, heat, airflow, CO₂, dehumidification) subject to capacity & efficiency.
-2. **Sensor Sampling** — record zone state before environmental integration so co-housed actuators observe pre-actuation values.
-3. **Environment Update** — integrate device outputs into zone state (well-mixed model baseline).
-4. **Irrigation & Nutrients** — fulfill zone method (manual enqueues tasks; automated fulfills on schedule).
-5. **Workforce Scheduling** — dispatch queued labour, enforce structure-binding, skill minimums, working-hour caps, and update morale/fatigue while emitting KPIs.
-6. **Plant Physiology** — update age/phase, biomass, stress, disease risk using strain curves and environment.
-7. **Harvest & Inventory** — create lots when criteria met; move yield to inventory.
-8. **Economy & Cost Accrual** — aggregate consumption/costs; maintenance curves progress.
-9. **Commit & Telemetry** — snapshot state and publish read-only events.
+1) Device Effects  
+2) Sensor Sampling  
+3) Environment Update  
+4) Irrigation & Nutrients  
+5) Workforce Scheduling  
+6) Plant Physiology  
+7) Harvest & Inventory  
+8) Economy & Cost Accrual  
+9) Commit & Telemetry
     
 
 ---

--- a/docs/SEC.md
+++ b/docs/SEC.md
@@ -261,10 +261,7 @@ Validation occurs at load time; on failure, the engine must not start. Validatio
   - `room.purpose.<slug>` for room purposes (slug preserved in the class)
   - `personnel.role.<slug>` / `personnel.skill.<slug>` when workforce blueprints are in
     play
-- Directory layout is **two levels maximum**: `data/blueprints/<domain>/<file>.json`.
-  Devices use `data/blueprints/device/<category>/<file>.json`; room purposes use
-  `data/blueprints/room/purpose/<file>.json`. Nested folders beyond this structure are
-  forbidden.
+Blueprint directory rule: All blueprints are auto-discovered under /data/blueprints/<domain>/<file>.json with a maximum depth of two segments (domain + file). Devices are /data/blueprints/device/<category>.json or /data/blueprints/device/<category>/<file>.json limited to two levels; no deeper subfolders are allowed.
 - JSON remains the **single source of truth** for blueprint metadata. Loaders **SHALL**
   trust the JSON payload first, using the filesystem only to derive expectations and to
   surface mismatches when contributors misplace files.
@@ -312,7 +309,7 @@ Validation occurs at load time; on failure, the engine must not start. Validatio
 ### 3.4 Namespaces & Naming Conventions (STRICT)
 
 * **Blueprint taxonomy:** JSON `class` values use domain identifiers (`strain`, `cultivation-method`, `device.climate`, `room.purpose.<slug>`, …). Slugs are **kebab-case**, unique **per class**.
-* **Filesystem alignment:** Blueprint files reside under `/data/blueprints/<domain>/<file>.json` (or sanctioned subfolders) and **MUST** mirror the JSON `class`. Mismatches are loader errors.
+* **Filesystem alignment:** Blueprint files follow the canonical directory rule and **MUST** mirror the JSON `class`. Mismatches are loader errors.
 * **Identifiers:** Entity IDs are UUIDs. Human-facing names are free text but **not** used for referential integrity.
 
 ### 3.5 Identity & UUID Policy (Traceability)
@@ -373,21 +370,17 @@ Validation occurs at load time; on failure, the engine must not start. Validatio
 
 ### 4.2 Phase Order
 
-1. **Device Effects** — compute device outputs (light, heat, airflow, CO₂, dehumidification) subject to capacity & efficiency.
+### Tick Pipeline (Canonical, 9 Phases)
 
-2. **Sensor Sampling** — record zone state before environmental integration so co-housed actuators observe pre-actuation values.
-
-3. **Environment Update** — integrate device outputs into zone state (well-mixed model baseline).
-
-4. **Irrigation & Nutrients** — fulfill zone method (manual enqueues tasks; automated fulfills on schedule).
-
-5. **Plant Physiology** — update age/phase, biomass, stress, disease risk using strain curves and environment.
-
-6. **Harvest & Inventory** — create lots when criteria met; move yield to inventory.
-
-7. **Economy & Cost Accrual** — aggregate consumption/costs; maintenance curves progress.
-
-8. **Commit & Telemetry** — snapshot state and publish read-only events.
+1) Device Effects  
+2) Sensor Sampling  
+3) Environment Update  
+4) Irrigation & Nutrients  
+5) Workforce Scheduling  
+6) Plant Physiology  
+7) Harvest & Inventory  
+8) Economy & Cost Accrual  
+9) Commit & Telemetry
     
 
 ---

--- a/docs/TDD.md
+++ b/docs/TDD.md
@@ -69,6 +69,8 @@ src/
 - **Snapshot location:** `__snapshots__` next to specs (only for low‑volatility payloads; prefer golden JSON files for world states).
 - **Blueprint fixtures:** Repository fixtures **MUST** live inside the domain folders that mirror their `class` (`device/climate/*.json`, `cultivation-method/*.json`, `room/purpose/*.json`, etc.). Specs walk `/data/blueprints/**` to assert the folder-derived taxonomy matches the JSON declaration and fail fast when contributors park files elsewhere.
 
+Blueprint directory rule: All blueprints are auto-discovered under /data/blueprints/<domain>/<file>.json with a maximum depth of two segments (domain + file). Devices are /data/blueprints/device/<category>.json or /data/blueprints/device/<category>/<file>.json limited to two levels; no deeper subfolders are allowed.
+
 ---
 
 ## 3) Data Validation & Fixtures
@@ -185,6 +187,18 @@ it('rejects zone device in non-grow room', () => {
 ---
 
 ## 7) Tick trace instrumentation & perf harness (Engine)
+
+### Tick Pipeline (Canonical, 9 Phases)
+
+1) Device Effects  
+2) Sensor Sampling  
+3) Environment Update  
+4) Irrigation & Nutrients  
+5) Workforce Scheduling  
+6) Plant Physiology  
+7) Harvest & Inventory  
+8) Economy & Cost Accrual  
+9) Commit & Telemetry
 
 - Canonical order: `applyDeviceEffects → applySensors → updateEnvironment → applyIrrigationAndNutrients → applyWorkforce → advancePhysiology → applyHarvestAndInventory → applyEconomyAccrual → commitAndTelemetry` (mirrors SEC §4.2).
 

--- a/docs/VISION_SCOPE.md
+++ b/docs/VISION_SCOPE.md
@@ -8,7 +8,7 @@
 
 **Elevator Pitch.** _Weed Breed_ is a modular, deterministic cultivation & economy simulation. Players plan **Company → Structure → Room → Zone → Plant**, configure climate & devices, balance **cost vs. yield**, and complete cycles from **seeding → harvest → post‑harvest**. The system is open and content‑driven via **JSON blueprints**, enabling modders and researchers to contribute.
 
-> **Modding note:** Blueprint JSON stays authoritative for metadata, but every file **must** live in the domain folders that mirror its declared `class` (`device/climate/*.json`, `cultivation-method/*.json`, etc.). Misplaced files or path/class mismatches are rejected by the loader so the runtime and data set never drift.
+> **Modding note:** Blueprint JSON stays authoritative for metadata, but every file **must** live in the domain folders that mirror its declared `class` (`device/climate/*.json`, `cultivation-method/*.json`, etc.). No subfolders deeper than <domain>/<file>.json are allowed. Misplaced files or path/class mismatches are rejected by the loader so the runtime and data set never drift.
 
 **Why now?** Few titles combine **physically plausible climate & plant physiology**, **deterministic reproducibility**, and a **meaningful economy loop**. _Weed Breed_ fills this gap.
 


### PR DESCRIPTION
## Summary
- align SEC, DD, TDD, and AGENTS to the canonical 9-phase tick pipeline including the workforce stage
- normalize blueprint directory guidance across core docs with the standard two-level rule and clarifiers
- document the folder policy in the changelog and vision scope note for consistency

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3576034848325bc6497e2144717ec