### PR TITLE
Document UI component stack decision

### DIFF
--- a/ADR/ADR-0016-ui-component-stack.md
+++ b/ADR/ADR-0016-ui-component-stack.md
@@ -1,0 +1,28 @@
+# ADR-0016 — UI Component Stack (Tailwind + shadcn/ui on Radix)
+
+## Status
+Accepted
+
+## Context
+The project already standardizes on Tailwind CSS for styling (see SEC §0.1). We need a component layer that:
+- keeps full control of styles and themes in Tailwind,
+- provides robust primitives for overlays/portals/focus management,
+- avoids vendor lock by keeping component code in-repo,
+- accelerates delivery with well-designed patterns (dialog, sheet, tabs, table, toast).
+
+## Decision
+Adopt **shadcn/ui**, which copies unstyled components into the repository and composes **Radix UI primitives**, with Tailwind as the single source of design tokens. Use **lucide-react** for icons, **Framer Motion** for micro-animations, and **Recharts** (optionally **Tremor** for dashboard presets) for charts.
+
+## Consequences
+- **Pros:** Strong a11y primitives, fast delivery of common patterns, full theming control via Tailwind, no runtime vendor lock (components live in the repo).
+- **Neutral:** ARIA/a11y is not a primary gameplay driver but improves quality at low cost.
+- **Cons:** Slightly higher initial setup (component generation/variants) compared to CSS-only.
+
+## Alternatives Considered
+- **Headless UI (Tailwind Labs):** Excellent headless primitives but requires more bespoke wiring for overlays/state; slower team velocity for common patterns.
+- **daisyUI / Flowbite:** Faster out-of-the-box visuals but more opinionated styling and less granular control; potential drift from our Tailwind token system.
+
+## Links
+- SEC §0.1 Platform Baseline (Tailwind as styling choice)
+- DD §1/§15 guardrails referencing UI boundaries
+- AGENTS §1 platform stack

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ Steer implementation so the codebase **conforms to SEC v0.2.1** while remaining 
 - **pnpm workspaces** monorepo: engine (headless), façade (integration/transport), UI (React+Vite), tools (monitoring/validation).
     
 - **UI:** React + Vite + Tailwind. "Dumb UI": read‑models in, intents out.
+
+UI component layer: shadcn/ui (on Radix primitives) with Tailwind for styling; icons via lucide-react; micro-animations via Framer Motion. Charts via Recharts, optionally Tremor for dashboard presets. Components are in-repo (shadcn “copy-in” model) to avoid vendor lock and keep them themable with Tailwind.
     
 - **Terminal monitor:** neo‑blessed (read‑only telemetry). **MUST NOT** send commands over telemetry.
     

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
   new layout, introduced migration scripts (`npm run migrate:folders`, `npm run
   migrate:classes`, `npm run migrate:blueprints`), and documented the taxonomy update in
   SEC/DD/TDD plus a dedicated ADR.
+- Docs/ADR: Adopted Tailwind + shadcn/ui (on Radix) as the UI component stack; updated SEC/DD/AGENTS/VISION_SCOPE and recorded decision in ADR-0016.
 
 ### #77 Demo harness humidity baseline
 

--- a/docs/DD.md
+++ b/docs/DD.md
@@ -9,6 +9,8 @@
 
 Weed Breed is a deterministic, tick‑driven cultivation & economy simulator. The **headless engine** advances a world tree (**Company → Structure → Room → Zone → Plant → Device**) in **fixed one‑hour ticks**. The **façade** validates intents, computes read‑models, and emits **read‑only telemetry** via a transport adapter (Socket.IO default). This DD specifies structure, data flows, invariants, performance budgets, and integration points **exactly aligned** to SEC v0.2.1.
 
+UI component layer: shadcn/ui (on Radix primitives) with Tailwind for styling; icons via lucide-react; micro-animations via Framer Motion. Charts via Recharts, optionally Tremor for dashboard presets. Components are in-repo (shadcn “copy-in” model) to avoid vendor lock and keep them themable with Tailwind.
+
 ---
 
 ## 1) Goals / Non‑Goals

--- a/docs/SEC.md
+++ b/docs/SEC.md
@@ -30,7 +30,9 @@ We start **fresh**: no external document references; prior proposals are folded 
 - **React + Vite** — The UI **SHALL** be a React app built with Vite; the UI remains **dumb** (read models in, intents out).
     
 - **Tailwind CSS** — The UI **SHOULD** use Tailwind for styling.
-    
+
+UI component layer: shadcn/ui (on Radix primitives) with Tailwind for styling; icons via lucide-react; micro-animations via Framer Motion. Charts via Recharts, optionally Tremor for dashboard presets. Components are in-repo (shadcn “copy-in” model) to avoid vendor lock and keep them themable with Tailwind.
+
 - **Terminal Monitor (neo-blessed)** — A read-only terminal monitor **SHOULD** provide live telemetry dashboards; it **MUST NOT** send commands over telemetry.
     
 - **Transport Adapter** — A transport abstraction **SHALL** exist. **Socket.IO SHOULD** be the default transport initially. Alternative transports (e.g., SSE) **MAY** be swapped under the same contract.

--- a/docs/TDD.md
+++ b/docs/TDD.md
@@ -441,7 +441,8 @@ it('30-day run matches golden summary and daily hashes', async () => {
 - `pnpm test:unit`, `test:module`, `test:integration`, `test:conf` scripts; `test:watch` for fast feedback.
     
 - VS Code task maps for common runs; problem matchers surface SEC section in failure message.
-    
+
+Note (UI components): While TDD remains UI-agnostic, downstream UI snapshot/visual tests will assume Tailwind styling with shadcn/ui components (Radix primitives) as per ADR-0016.
 
 ---
 

--- a/docs/VISION_SCOPE.md
+++ b/docs/VISION_SCOPE.md
@@ -283,6 +283,8 @@ function salePrice(basePrice, quality01): number {
 - **Info Hierarchy:** Top: tick/time, daily costs, energy/water, balance; middle: active zone/plant KPIs; bottom: events/tasks.
     
 - **Accessibility:** SI units; tooltips; color‑vision‑friendly palettes; scalable typography.
+
+Implementation note (UI components): We will use Tailwind for styling and adopt shadcn/ui (built on Radix) as our unstyled component layer, keeping full theming control in Tailwind while benefiting from accessible primitives and consistent patterns (dialogs, sheets, tabs, tables, toasts).
     
 
 ---


### PR DESCRIPTION
## Summary
- document Tailwind + shadcn/ui as the standard UI component stack across SEC, DD, AGENTS, VISION_SCOPE, and TDD
- record ADR-0016 detailing the Tailwind + shadcn/ui (on Radix) decision and link related guardrails
- note the documentation update in the changelog

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e35a1aea908325a3c90a7b56c4a660