### PR TITLE
docs: add task backlog specifications

### DIFF
--- a/docs/tasks/0001-golden-master-and-conformance-suite.md
+++ b/docs/tasks/0001-golden-master-and-conformance-suite.md
@@ -1,0 +1,52 @@
+# Golden Master & Conformance Suite
+
+**ID:** 0001  
+**Status:** Planned  
+**Owner:** unassigned  
+**Priority:** P0  
+**Tags:** backend, tests, ci
+
+## Rationale
+Rebuild the canonical golden master so every release can be validated against the deterministic savegame, daily hashes, and tolerance rules called out in [SEC §0.2 Reference Test Simulation](../SEC.md#02-reference-test-simulation-golden-master), [SEC §5 Determinism & RNG](../SEC.md#5-determinism--rng), and [SEC §15 Acceptance Criteria for Engine Conformance](../SEC.md#15-acceptance-criteria-for-engine-conformance). [TDD §12 Golden Master](../TDD.md#12-golden-master-sec-15) and the perf harness guidance in [docs/engine/simulation-reporting.md](../engine/simulation-reporting.md) already prescribe the artifact layout and CI hooks we must enforce.
+
+## Scope
+- Include: canonical save fixture refresh, deterministic 30-day run (720 ticks) with per-day hashes, tolerance enforcement (`EPS_ABS`, `EPS_REL`), CI wiring for conformance suite, artifact retention linked from Appendix references.
+- Include: documentation updates referencing Appendix B and artifact storage expectations.
+- Out of scope: new gameplay content, scenario design changes beyond what the SEC already codifies, alternative RNG engines.
+
+## Deliverables
+- Updated or newly generated golden save fixture under `packages/engine/tests/fixtures/golden/*.json` with schema version metadata.
+- Conformance test suite asserting 30-day deterministic run, per-day hashes, and event counts with tolerance checks.
+- CI workflow or pnpm script invoking the conformance suite and persisting artifacts (daily hashes, summary) to a predictable output directory noted in docs.
+- Documentation updates in `docs/SEC.md` Appendix references and `docs/CHANGELOG.md` describing the refreshed suite.
+
+## Implementation Steps
+1. Refresh or author the canonical save fixture to align with current schema contracts and record expected hashes/summary outputs.
+2. Extend the conformance runner to emit per-day hash files plus a summary JSON, using deterministic formatting rules from SEC §0.2.3.
+3. Add or update Vitest specs under `packages/engine/tests/conformance` to execute a 30-day run and assert hashes and metrics with the SEC tolerances.
+4. Wire a CI/pnpm task (e.g., `pnpm --filter @wb/engine test:conformance`) to run the suite and publish artifacts to `/reporting` or an equivalent directory, noting them in documentation.
+5. Update SEC/TDD references and CHANGELOG entries to link the artifact locations and conformance process; ensure Appendix B references point to the artifacts.
+
+## Acceptance Criteria / DoD
+- 30-day deterministic run produces identical `daily.jsonl` (hash + telemetry counts) and `summary.json` compared to committed expectations using `EPS_ABS = 1e-9` and `EPS_REL = 1e-6` comparisons.
+- CI pipeline executes the conformance suite on every merge request and fails on hash drift; artifacts are uploaded or stored locally per documentation with links captured in README/Appendix.
+- Documentation updates explicitly reference the refreshed artifacts and the CI command, with CHANGELOG noting the update.
+- No additional gameplay or scenario data changes beyond what the SEC mandates.
+
+## Tests
+- Unit tests: hash canonicalisation helpers, tolerance comparison utilities (`packages/engine/tests/unit/util/hash.spec.ts`, `.../tolerance.spec.ts`).
+- Integration tests: `packages/engine/tests/integration/pipeline/runTick.trace.integration.test.ts` ensuring pipeline order; conformance spec `tests/conformance/goldenMaster.spec.ts` executing 30-day runs per [TDD §12](../TDD.md#12-golden-master-sec-15).
+- CI gates: conformance job via pnpm script; ensure runtime stays within perf harness bounds recorded in `docs/engine/simulation-reporting.md` (5 ms avg/tick, <64 MiB heap per TDD guidance).
+
+## Affected Files (indicative)
+- `packages/engine/tests/fixtures/golden/*.json`
+- `packages/engine/tests/conformance/goldenMaster.spec.ts`
+- `packages/engine/src/backend/src/engine/testHarness.ts`
+- `docs/SEC.md` ([§0.2](../SEC.md#02-reference-test-simulation-golden-master), [§15](../SEC.md#15-acceptance-criteria-for-engine-conformance))
+- `docs/TDD.md` ([§12](../TDD.md#12-golden-master-sec-15))
+- `docs/CHANGELOG.md`
+
+## Risks & Mitigations
+- **Risk:** Cross-platform floating-point drift breaks hashes. **Mitigation:** Use canonical JSON ordering and SEC-defined tolerances with deterministic number formatting.
+- **Risk:** CI runtime over budget for 30-day suite. **Mitigation:** Use perf harness batching and parallelisation guidance from TDD; gate execution behind targeted pnpm workspace scripts.
+- **Risk:** Fixture rot when schema evolves. **Mitigation:** Pair fixture updates with CHANGELOG entries and migration notes; document regeneration steps in README.

--- a/docs/tasks/0002-appendix-b-crosswalk-fill.md
+++ b/docs/tasks/0002-appendix-b-crosswalk-fill.md
@@ -1,0 +1,49 @@
+# Appendix B Crosswalk Fill
+
+**ID:** 0002  
+**Status:** Planned  
+**Owner:** unassigned  
+**Priority:** P0  
+**Tags:** docs, governance
+
+## Rationale
+SEC migration guidance requires that every historical proposal from `/docs/task/**` and legacy design notes is mapped into [SEC Appendix B — Task Proposals Crosswalk](../SEC.md#appendix-b--task-proposals-crosswalk-preservation-of-docstask). [SEC §13 Migration Notes](../SEC.md#13-migration-notes-from-legacy-to-re-reboot) explicitly calls for reconciling those sources, and the CHANGELOG tracks prior merges. This task captures the documentation debt so Appendix B stops advertising “to be filled iteratively”.
+
+## Scope
+- Include: inventory of legacy `/docs/task/**` files, relevant items from `docs/proposals/*.md`, and CHANGELOG/ADR outcomes tied to those proposals.
+- Include: populate the Appendix B table with `task_path`, title, summary, target SEC section, status (merged/deferred/contradiction), and notes linking to primary sources.
+- Out of scope: altering historical proposal content or introducing new proposals; revising SEC core semantics beyond cross-referencing work.
+
+## Deliverables
+- Completed Appendix B table in `docs/SEC.md` with one row per legacy proposal, each linking to the source document and the section where it landed.
+- Supplementary notes in `docs/re-reboot/contradictions.md` (if contradictions identified) with backlinks from Appendix B rows.
+- CHANGELOG entry documenting the reconciliation.
+
+## Implementation Steps
+1. Enumerate existing `/docs/task/**` entries and relevant items under `docs/proposals/` to build a master list (path, title, summary, status cues).
+2. For each item, determine whether it is already represented in SEC/DD/TDD; map it to the appropriate section and mark status (`merged`, `deferred`, `contradiction`).
+3. Update Appendix B table in `docs/SEC.md` with rows capturing the mapping and inline links to sources and target sections.
+4. For contradictions, update or create `docs/re-reboot/contradictions.md` entries and reference them in the Appendix notes column.
+5. Add a CHANGELOG entry summarising the reconciliation and referencing Appendix B.
+
+## Acceptance Criteria / DoD
+- Appendix B table in `docs/SEC.md` lists every `/docs/task/**` and relevant legacy proposal with working Markdown links to both the source file and the SEC/DD/TDD section that supersedes or defers it.
+- All contradictions are documented in `docs/re-reboot/contradictions.md` with Appendix B rows pointing to the entry.
+- CHANGELOG entry summarises the crosswalk fill and cites Appendix B.
+- No row is left blank or marked TBD; statuses use only `merged`, `deferred`, or `contradiction`.
+
+## Tests
+- Documentation lint check or Markdown link validator covering `docs/SEC.md` and `docs/re-reboot/contradictions.md` to ensure anchors resolve.
+- Optional script/spec verifying that every file under `/docs/task/**` appears in Appendix B (e.g., unit test under `packages/engine/tests/unit/docs/appendixB.spec.ts`).
+- CI docs build (if configured) passes with updated tables.
+
+## Affected Files (indicative)
+- `docs/SEC.md` ([§13](../SEC.md#13-migration-notes-from-legacy-to-re-reboot), [Appendix B](../SEC.md#appendix-b--task-proposals-crosswalk-preservation-of-docstask))
+- `docs/re-reboot/contradictions.md`
+- `docs/CHANGELOG.md`
+- Legacy sources under `docs/task/**` and `docs/proposals/*.md`
+
+## Risks & Mitigations
+- **Risk:** Missing hidden legacy proposals. **Mitigation:** Use repository search to ensure complete coverage and add a regression test enumerating `/docs/task/**`.
+- **Risk:** Broken anchors when sections rename. **Mitigation:** Cross-check generated anchors after editing; include doc lint in CI.
+- **Risk:** Appendix table becomes unwieldy. **Mitigation:** Keep summaries concise and leverage notes column for extended context with links rather than inline prose.

--- a/docs/tasks/0003-sensors-stage-content-and-noise-model.md
+++ b/docs/tasks/0003-sensors-stage-content-and-noise-model.md
@@ -1,0 +1,53 @@
+# Sensors Stage Content and Noise Model
+
+**ID:** 0003  
+**Status:** Planned  
+**Owner:** unassigned  
+**Priority:** P0  
+**Tags:** backend, simulation, tests
+
+## Rationale
+The ordered tick pipeline mandates sensor sampling immediately after device effects and before environment updates ([SEC Tick Pipeline](../SEC.md#tick-pipeline-canonical-9-phases); [TDD Tick Pipeline](../TDD.md#tick-pipeline-canonical-9-phases)). CHANGELOG entry [#54 WB-047](../CHANGELOG.md#54-wb-047-sensor-sampling-before-environment-integration) locked in that sequencing, and [Interface & Stub proposal §5 Pattern D](../proposals/20251002-interface_stubs.md#pattern-d--sensor--aktuator-in-einem-geh%C3%A4use) explains deterministic noise expectations. We must formalize the sensor stage schema, deterministic noise injection, and ordering validation so the engine stays compliant.
+
+## Scope
+- Include: define canonical sensor output schema (per-sensor readings, timestamps, diagnostics) and deterministic noise hooks consistent with stub guidance.
+- Include: ensure the stage snapshots environment inputs before `updateEnvironment`, emitting immutable readings for downstream telemetry/tasks.
+- Include: tests that assert stage order and deterministic noise behaviour, including integration coverage of sensor+actuator devices.
+- Out of scope: introducing new sensor device types beyond what SEC already enumerates; refactoring downstream environment aggregation logic.
+
+## Deliverables
+- Sensor stage module documentation/spec describing the payload structure and deterministic noise source binding (`createRng` stream ids).
+- Updated engine implementation capturing sensor outputs before environment merge, with clamps/units enforced.
+- Unit tests for noise utilities and schema validation; integration tests covering Pattern D sensor+actuator flows.
+- CHANGELOG note referencing the finalized sensor stage behaviour.
+
+## Implementation Steps
+1. Document the sensor stage contract (fields, units, RNG streams) in code comments and, if needed, supplemental docs under `docs/engine/` referencing SEC/TDD.
+2. Update `applySensors` (or equivalent) to snapshot environment state prior to mutation, apply deterministic noise via dedicated RNG streams, and return structured sensor readings.
+3. Ensure the tick runner maintains the canonical stage order (`applySensors` before `updateEnvironment`) and add assertions/trace checks mirroring TDD guidance.
+4. Add Vitest coverage: unit specs for sensor schema/noise, integration spec for sensor+actuator device verifying readings reflect pre-environment state.
+5. Record the change in CHANGELOG with links back to SEC/TDD references.
+
+## Acceptance Criteria / DoD
+- Sensor outputs include deterministic raw reading and noise metadata per sensor type, using RNG streams scoped like `sensor:<id>` and reproducible across runs.
+- Stage trace from `runTick(..., { trace: true })` shows `applySensors` immediately after `applyDeviceEffects` and before `updateEnvironment`; tests fail if order changes.
+- Pattern D integration test demonstrates that the sensor reading captures the pre-actuation environment state for the same tick and remains stable with noise=0.
+- Documentation/CHANGELOG updated with the finalized contract.
+
+## Tests
+- Unit tests: `packages/engine/tests/unit/sensors/noise.spec.ts` for RNG/noise determinism; schema parser tests ensuring fields are finite and clamped.
+- Integration tests: `packages/engine/tests/integration/pipeline/sensorActuatorPattern.integration.test.ts` extended to assert pre/post environment behaviour and deterministic noise; tick trace test verifying stage order.
+- CI gate: existing pipeline trace test from [TDD §Tick Pipeline](../TDD.md#tick-pipeline-canonical-9-phases) must pass with new assertions.
+
+## Affected Files (indicative)
+- `packages/engine/src/backend/src/engine/pipeline/applySensors.ts`
+- `packages/engine/tests/unit/sensors/*.spec.ts`
+- `packages/engine/tests/integration/pipeline/sensorActuatorPattern.integration.test.ts`
+- `docs/CHANGELOG.md` ([#54](../CHANGELOG.md#54-wb-047-sensor-sampling-before-environment-integration))
+- `docs/proposals/20251002-interface_stubs.md` ([Pattern D](../proposals/20251002-interface_stubs.md#pattern-d--sensor--aktuator-in-einem-geh%C3%A4use))
+- `docs/SEC.md` ([Tick Pipeline](../SEC.md#tick-pipeline-canonical-9-phases))
+
+## Risks & Mitigations
+- **Risk:** Noise model introduces drift. **Mitigation:** Bind all noise to deterministic RNG streams with documented seeds and add golden vector tests.
+- **Risk:** Stage order regressions slip through. **Mitigation:** Extend tick trace integration tests to assert explicit ordering and fail on deviation.
+- **Risk:** Schema churn breaks telemetry consumers. **Mitigation:** Version sensor payload schema and update façade/read-model tests accordingly.

--- a/docs/tasks/0004-co2-actuator-and-environment-coupling.md
+++ b/docs/tasks/0004-co2-actuator-and-environment-coupling.md
@@ -1,0 +1,53 @@
+# CO₂ Actuator and Environment Coupling
+
+**ID:** 0004  
+**Status:** Planned  
+**Owner:** unassigned  
+**Priority:** P0  
+**Tags:** backend, simulation, environment, tests
+
+## Rationale
+SEC environment rules require modelling CO₂ injection as part of the well-mixed zone bucket with device-limited rates ([SEC §6 Environment & Devices](../SEC.md#6-environment--devices-well-mixed-baseline)). The tick pipeline depends on deterministic device interfaces ([SEC Tick Pipeline](../SEC.md#tick-pipeline-canonical-9-phases); [TDD Tick Pipeline](../TDD.md#tick-pipeline-canonical-9-phases)), and maintenance/economy hooks expect energy usage from climate devices to flow into the accrual stage ([SEC §10 Economy Integration](../SEC.md#10-economy-integration-non-intrusive)). We need a CO₂ actuator interface, stub implementation, and environment coupling tests to fulfil that contract.
+
+## Scope
+- Include: define a CO₂ injector device interface with deterministic stub behaviour (flow limits, safety clamps, telemetry) and integrate it into the environment update step.
+- Include: update the well-mixed environment model to incorporate CO₂ deltas from actuators alongside existing climate adjustments.
+- Include: integration tests covering steady-state and ramp scenarios validating CO₂ concentration convergence and economy impacts.
+- Out of scope: advanced mass-balance or spatial CO₂ models beyond the well-mixed baseline; UI visualisations.
+
+## Deliverables
+- CO₂ actuator interface definition and stub (e.g., `Co2InjectorStub`) following existing stub conventions.
+- Environment coupling logic updating zone CO₂ concentration and exposing telemetry/diagnostics.
+- Unit tests for the stub’s deterministic outputs and safety clamps; integration tests for steady-state and ramp scenarios.
+- Documentation updates referencing the new interface and telemetry, plus CHANGELOG entry.
+
+## Implementation Steps
+1. Specify the CO₂ actuator interface in engine code (inputs: target ppm, max flow, duty; outputs: delta ppm, energy usage) referencing SEC limits.
+2. Implement the stub with deterministic RNG-free behaviour, enforcing device-specified maximum injection rates and safety thresholds.
+3. Extend `updateEnvironment` (or equivalent) to apply accumulated CO₂ deltas to the zone state after sensor sampling, ensuring units remain consistent.
+4. Write unit tests validating stub behaviour at bounds (zero flow, max flow, clamped safety) and integration tests for steady vs ramped schedules verifying environment targets and energy accrual.
+5. Update documentation (SEC notes if needed, DD/TDD references if clarifying) and record the change in CHANGELOG.
+
+## Acceptance Criteria / DoD
+- CO₂ actuator interface is defined and implemented with deterministic outputs given device spec and duty cycle; no use of `Math.random`.
+- Environment update applies CO₂ deltas in the correct phase order (after sensors, before irrigation) and maintains deterministic state hashes.
+- Integration tests demonstrate steady-state (holding ppm target) and ramp (increasing ppm over time) scenarios match expected concentration profiles within SEC tolerances.
+- CHANGELOG and relevant docs reference the new interface and coupling.
+
+## Tests
+- Unit tests: `packages/engine/tests/unit/stubs/Co2InjectorStub.spec.ts` verifying clamp behaviour and telemetry outputs.
+- Integration tests: `packages/engine/tests/integration/pipeline/co2Coupling.integration.test.ts` covering steady and ramp scenarios with hash assertions.
+- CI/perf: ensure economy accrual tests still pass (per [TDD §8 Economy & Tariffs](../TDD.md#8-economy--tariffs-sec-36)) and conformance suite stays deterministic.
+
+## Affected Files (indicative)
+- `packages/engine/src/backend/src/devices/Co2Injector.ts`
+- `packages/engine/src/backend/src/engine/pipeline/updateEnvironment.ts`
+- `packages/engine/tests/unit/stubs/Co2InjectorStub.spec.ts`
+- `packages/engine/tests/integration/pipeline/co2Coupling.integration.test.ts`
+- `docs/SEC.md` ([§6](../SEC.md#6-environment--devices-well-mixed-baseline), [§10](../SEC.md#10-economy-integration-non-intrusive))
+- `docs/CHANGELOG.md`
+
+## Risks & Mitigations
+- **Risk:** Incorrect CO₂ units causing instability. **Mitigation:** Align units with SEC/TDD conventions (ppm, mg/m³) and add validation helpers.
+- **Risk:** Stage ordering regression breaking determinism. **Mitigation:** Extend tick trace tests to confirm CO₂ coupling occurs in the documented phase.
+- **Risk:** Economy coupling double-counts energy. **Mitigation:** Reuse existing power→heat coupling patterns and assert accrual totals in integration tests.

--- a/docs/tasks/0005-pest-disease-system-mvp.md
+++ b/docs/tasks/0005-pest-disease-system-mvp.md
@@ -1,0 +1,54 @@
+# Pest & Disease System MVP
+
+**ID:** 0005  
+**Status:** Planned  
+**Owner:** unassigned  
+**Priority:** P0  
+**Tags:** backend, simulation, tasks, telemetry
+
+## Rationale
+Biosecurity is core to the simulation: [SEC §8.5 Pests & Diseases](../SEC.md#85-pests--diseases-health--biosecurity) mandates deterministic risk accumulation, inspection/treatment tasks, quarantine intervals, and telemetry warnings. Tasks and treatments must align with the catalog in [SEC §3.3](../SEC.md#33-task--treatment-catalogs-data-driven). The risk-management pillar in [VISION_SCOPE §1 Experience Pillars](../VISION_SCOPE.md#1-vision) reinforces the gameplay need. We must deliver an MVP pipeline respecting these requirements.
+
+## Scope
+- Include: deterministic risk scoring per zone/room based on environment and hygiene inputs, inspection task scheduling, treatment task emission with cooldowns/quarantine windows.
+- Include: telemetry and read-model updates surfacing risk levels and task emissions.
+- Include: integration of quarantine windows affecting workforce scheduling and economy hooks as required.
+- Out of scope: advanced pathogen modelling beyond risk scores; new UI flows beyond telemetry/read-model outputs.
+
+## Deliverables
+- Risk scoring module consuming environment/hygiene signals and outputting normalized risk values per SEC guidance.
+- Scheduler logic generating inspection and treatment tasks using the catalog (codes, required skills) with deterministic cooldowns/quarantine intervals.
+- Telemetry/read-model updates reporting risk states and emitted tasks; documentation updates describing the workflow.
+- Scenario integration test demonstrating expected task emissions over a representative run.
+
+## Implementation Steps
+1. Define data structures for risk sources (environmental thresholds, hygiene signals) and implement deterministic accumulation respecting SEC invariants.
+2. Integrate risk evaluation into the tick pipeline (likely during workforce or economy stages) and trigger inspection/treatment tasks when thresholds crossed.
+3. Implement quarantine window handling: mark affected zones, suppress conflicting tasks, and record timers.
+4. Emit telemetry events and update read-model projections reflecting risk levels, scheduled tasks, and quarantine status.
+5. Write scenario integration test (e.g., multi-day run) validating risk progression, task emissions, and quarantine enforcement; update docs/CHANGELOG.
+
+## Acceptance Criteria / DoD
+- Risk scores evolve deterministically given identical inputs; tests confirm consistent values across runs.
+- Inspection and treatment tasks are emitted using catalog codes with deterministic cooldowns and quarantine windows; conflicting tasks blocked during quarantine.
+- Telemetry/read-model surfaces risk warnings and task events aligned with SEC requirements; scenario test validates expected sequence.
+- Documentation (SEC references if clarifications added) and CHANGELOG updated with the MVP scope.
+
+## Tests
+- Unit tests: risk scoring pure functions, quarantine timer management, task emission thresholds.
+- Integration tests: scenario run in `packages/engine/tests/integration/pipeline/pestDiseaseMvp.integration.test.ts` verifying risk progression, tasks, and telemetry outputs over multiple days.
+- CI gates: ensure conformance hashes unchanged when risk disabled, and new specs included in pnpm test suite.
+
+## Affected Files (indicative)
+- `packages/engine/src/backend/src/health/pestDiseaseRisk.ts`
+- `packages/engine/src/backend/src/workforce/taskScheduler.ts`
+- `packages/engine/tests/unit/health/pestDiseaseRisk.spec.ts`
+- `packages/engine/tests/integration/pipeline/pestDiseaseMvp.integration.test.ts`
+- `docs/SEC.md` ([§3.3](../SEC.md#33-task--treatment-catalogs-data-driven), [§8.5](../SEC.md#85-pests--diseases-health--biosecurity))
+- `docs/VISION_SCOPE.md` ([Experience Pillars](../VISION_SCOPE.md#1-vision))
+- `docs/CHANGELOG.md`
+
+## Risks & Mitigations
+- **Risk:** Risk model drifts from SEC guidance. **Mitigation:** Keep formulas documented and aligned with SEC thresholds; add golden vector tests.
+- **Risk:** Task spam overwhelms workforce scheduling. **Mitigation:** Implement cooldowns/quarantine windows per SEC and verify via integration tests.
+- **Risk:** Telemetry noise. **Mitigation:** Aggregate risk warnings per tick and ensure channels remain read-only as per SEC §11.

--- a/docs/tasks/0006-save-load-and-migrations.md
+++ b/docs/tasks/0006-save-load-and-migrations.md
@@ -1,0 +1,55 @@
+# Save/Load and Migrations
+
+**ID:** 0006  
+**Status:** Planned  
+**Owner:** unassigned  
+**Priority:** P0  
+**Tags:** backend, persistence, migrations, tests
+
+## Rationale
+The golden master relies on a canonical JSON savegame with schema versioning and deterministic hashes ([SEC §0.2](../SEC.md#02-reference-test-simulation-golden-master)). Migration expectations are documented in [SEC §13](../SEC.md#13-migration-notes-from-legacy-to-re-reboot), and the stability goal in [VISION_SCOPE §3 Success Criteria](../VISION_SCOPE.md#3-success-criteria) requires crash-safe saves with <1 tick data loss. We need a robust save/load pipeline with schema versioning and migration scaffolding plus backward-compat tests.
+
+## Scope
+- Include: define JSON save schema with explicit `schemaVersion`, implement crash-safe save/write mechanism, load validation, and migration scaffolding for version bumps.
+- Include: regression tests ensuring older fixtures load via migrations and reproduce deterministic hashes.
+- Out of scope: new save formats (binary/custom) or UI save slots; scenario authoring tooling beyond schema definition.
+
+## Deliverables
+- Save/load module supporting schema versioning and atomic writes (temp file + rename) to guarantee crash safety.
+- Migration scaffold (directory + API) for applying transformations between schema versions with tests.
+- Backward-compat fixtures covering at least the current and prior schema versions with validation tests ensuring hash stability.
+- Documentation updates (SEC/TDD/CHANGELOG) describing the save pipeline and migration process.
+
+## Implementation Steps
+1. Formalize the save schema (TypeScript types + validation) including `schemaVersion`, metadata, and canonical ordering rules.
+2. Implement crash-safe save writer (write to temp file, fsync, rename) and corresponding loader with validation.
+3. Add migration registry that maps `schemaVersion` → transformer, with initial no-op migration for current version.
+4. Create versioned fixtures under `packages/engine/tests/fixtures/save/` and write tests verifying load, migration, and resulting hashes against expectations.
+5. Update documentation (SEC appendix note, TDD guidance) and CHANGELOG summarizing the new pipeline.
+
+## Acceptance Criteria / DoD
+- Save files include `schemaVersion`, `seed`, `simTime`, and canonical ordering; loading validates structure and rejects unknown versions without migration.
+- Crash-safe write path demonstrated by tests simulating failure between write and rename (e.g., ensuring original file intact).
+- Backward-compat test loads previous version fixture, runs migration, and matches expected state hash summary.
+- Documentation (SEC/TDD/CHANGELOG) updated with save/migration process and fixtures referenced.
+
+## Tests
+- Unit tests: schema validator, migration registry, crash-safe writer (mock fs interactions) under `packages/engine/tests/unit/save/*.spec.ts`.
+- Integration tests: load versioned fixtures, run deterministic ticks, confirm hashes and event counts match expectations.
+- CI gate: conformance suite runs against migrated save to ensure deterministic behaviour remains intact.
+
+## Affected Files (indicative)
+- `packages/engine/src/backend/src/saveLoad/saveManager.ts`
+- `packages/engine/src/backend/src/saveLoad/migrations/*.ts`
+- `packages/engine/tests/unit/save/*.spec.ts`
+- `packages/engine/tests/integration/saveLoad/*.integration.test.ts`
+- `packages/engine/tests/fixtures/save/*.json`
+- `docs/SEC.md` ([§0.2](../SEC.md#02-reference-test-simulation-golden-master), [§13](../SEC.md#13-migration-notes-from-legacy-to-re-reboot))
+- `docs/TDD.md` (update relevant sections)
+- `docs/VISION_SCOPE.md` ([§3](../VISION_SCOPE.md#3-success-criteria))
+- `docs/CHANGELOG.md`
+
+## Risks & Mitigations
+- **Risk:** Partial writes corrupt saves. **Mitigation:** Use atomic write strategy with tests simulating interruptions.
+- **Risk:** Migration drift causing hash changes. **Mitigation:** Record expected hashes post-migration and run conformance suite on migrated worlds.
+- **Risk:** Schema expansion complicates loader. **Mitigation:** Keep schema definitions centralized and documented; require ADR for breaking changes.

--- a/docs/tasks/0007-device-degradation-and-maintenance-flows.md
+++ b/docs/tasks/0007-device-degradation-and-maintenance-flows.md
@@ -1,0 +1,56 @@
+# Device Degradation and Maintenance Flows
+
+**ID:** 0007  
+**Status:** Planned  
+**Owner:** unassigned  
+**Priority:** P1  
+**Tags:** backend, simulation, economy, tests
+
+## Rationale
+Device wear and maintenance economics are defined in [SEC §6.2 Device Quality vs. Condition](../SEC.md#62-device-quality-vs-condition-shall--option-a-adopted) and the per-hour maintenance pricing rules in [SEC §10 Economy Integration](../SEC.md#10-economy-integration-non-intrusive). Price maps supply maintenance curve parameters per [SEC §3.6](../SEC.md#5-data-contracts-from-dd--data) and [TDD §8 Economy & Tariffs](../TDD.md#8-economy--tariffs-sec-36). We must model degradation curves, maintenance scheduling, replacements, and cost coupling consistent with these contracts.
+
+## Scope
+- Include: implement deterministic degradation curves (`m_degrade`, `m_maint`), maintenance window planning, replacement suggestions, and cost accrual tied to price maps.
+- Include: telemetry/read-model outputs reflecting device condition, scheduled maintenance, and replacement advice.
+- Include: long-run simulation validating degradation behaviour and maintenance costs.
+- Out of scope: new device types or price map structures beyond SEC definitions; UI scheduling workflows.
+
+## Deliverables
+- Degradation engine updating `condition01` per tick with configurable curves and RNG-free behaviour.
+- Maintenance planner producing tasks/windows based on condition thresholds and service intervals with deterministic scheduling.
+- Replacement suggestion logic comparing maintenance vs replacement cost using price map data.
+- Long-run (e.g., 120-day) integration test verifying condition decay, maintenance events, and cost accrual totals.
+- Documentation/CHANGELOG updates summarising the flows.
+
+## Implementation Steps
+1. Implement degradation curve helpers using SEC-defined functions (`m_degrade`, `m_maint`) and integrate them into device tick updates.
+2. Build maintenance planner that schedules tasks when condition thresholds reached or service hours elapsed, using task catalog entries.
+3. Add replacement evaluation comparing cumulative maintenance cost vs device CapEx; emit recommendations via telemetry/read-model.
+4. Ensure economy accrual consumes maintenance costs per hour from price maps and records in daily rollups.
+5. Write long-run integration tests simulating device wear to validate condition, maintenance tasks, and accrued costs; document results.
+
+## Acceptance Criteria / DoD
+- Condition decays deterministically according to curve configuration; tests validate expected values at milestones.
+- Maintenance tasks scheduled deterministically and respect workshop purpose policies (SEC §1.1 room/workshop) with telemetry emitted.
+- Replacement suggestions triggered when maintenance cost exceeds replacement threshold and recorded in read-models.
+- Long-run integration test asserts maintenance cost totals align with price map data and conditions remain within [0,1].
+- Documentation/CHANGELOG updated accordingly.
+
+## Tests
+- Unit tests: degradation curve functions, maintenance planner logic, replacement heuristics.
+- Integration tests: `packages/engine/tests/integration/pipeline/deviceMaintenance.integration.test.ts` running >120 days verifying condition/maintenance/cost outputs.
+- CI/perf: ensure long-run test stays within perf budget; optionally run in nightly CI.
+
+## Affected Files (indicative)
+- `packages/engine/src/backend/src/devices/degradation.ts`
+- `packages/engine/src/backend/src/workforce/maintenancePlanner.ts`
+- `packages/engine/tests/unit/devices/degradation.spec.ts`
+- `packages/engine/tests/integration/pipeline/deviceMaintenance.integration.test.ts`
+- `docs/SEC.md` ([§6.2](../SEC.md#62-device-quality-vs-condition-shall--option-a-adopted), [§10](../SEC.md#10-economy-integration-non-intrusive))
+- `docs/TDD.md` ([§8](../TDD.md#8-economy--tariffs-sec-36))
+- `docs/CHANGELOG.md`
+
+## Risks & Mitigations
+- **Risk:** Long-run test flakiness due to perf. **Mitigation:** Use deterministic seeds and minimize scenario complexity; run heavy test in nightly workflow.
+- **Risk:** Maintenance tasks conflict with other workforce priorities. **Mitigation:** Integrate with existing scheduler priorities and add assertions for queue ordering.
+- **Risk:** Replacement heuristics mis-fire. **Mitigation:** Parameterize thresholds and cover with targeted unit tests and scenario validations.

--- a/docs/tasks/0008-economy-accrual-consolidation.md
+++ b/docs/tasks/0008-economy-accrual-consolidation.md
@@ -1,0 +1,56 @@
+# Economy Accrual Consolidation
+
+**ID:** 0008  
+**Status:** Planned  
+**Owner:** unassigned  
+**Priority:** P1  
+**Tags:** backend, economy, tests, ci
+
+## Rationale
+Economy rules require all energy, water, and maintenance flows to accrue costs in the economy stage with per-hour units ([SEC §10](../SEC.md#10-economy-integration-non-intrusive); [AGENTS §5 Data Contracts](../../AGENTS.md#5-data-contracts--price-separation-sec-3)). Price maps must be the sole source for tariffs and maintenance curves, and [TDD §8 Economy & Tariffs](../TDD.md#8-economy--tariffs-sec-36) enforces override precedence. We need to consolidate accrual logic so every device flow feeds into the economy stage and CI checks guard daily totals.
+
+## Scope
+- Include: audit of all device/resource flows (Wh, m³, maintenance hours) to ensure they feed into economy accrual with correct units and tariffs.
+- Include: apply maintenance cost curves based on device price maps and cultivation method costs per SEC §7.5 references.
+- Include: CI check validating daily totals against expected baselines for a reference scenario.
+- Out of scope: introducing new pricing models or dynamic tariffs beyond SEC definitions; UI reporting changes.
+
+## Deliverables
+- Updated economy accrual module aggregating all resource usage and applying tariffs/maintenance costs using price map data.
+- Unit/module tests covering tariff resolution, maintenance curve application, and cultivation method cost accrual.
+- Integration test verifying daily totals for a reference scenario match expected values.
+- CI script/spec ensuring accrual totals remain within tolerance (e.g., ±EPS) and fails on drift.
+- Documentation/CHANGELOG updates noting the consolidation and CI guard.
+
+## Implementation Steps
+1. Inventory all resource usage outputs (device energy, irrigation water, maintenance hours) and ensure they feed into the economy accrual stage.
+2. Refactor economy module to apply tariffs from `/data/prices/utilityPrices.json` and maintenance curves from `/data/prices/devicePrices.json`, respecting override precedence.
+3. Integrate cultivation method recurring costs (containers, substrate policies) into accrual per SEC §7.5 requirements.
+4. Add tests (unit + integration) verifying hourly → daily aggregation, tariff overrides, and maintenance curve scaling.
+5. Create a CI check (Vitest or script) comparing reference scenario daily totals to stored expectations within SEC tolerances; document the workflow.
+
+## Acceptance Criteria / DoD
+- All energy/water/maintenance flows appear in economy accrual outputs with per-hour units; tests enforce no `_per_tick` usage.
+- Tariff overrides vs factors resolved per TDD example (`override` wins); maintenance curves apply correct cost increases over runtime hours.
+- Integration test for reference scenario passes with totals matching expected values within `EPS_REL`/`EPS_ABS` tolerances.
+- CI guard runs automatically (pnpm script) and fails on drift; docs/CHANGELOG updated.
+
+## Tests
+- Unit tests: tariff resolver, maintenance curve evaluator, cultivation method cost calculator.
+- Integration test: `packages/engine/tests/integration/pipeline/economyAccrual.integration.test.ts` verifying daily totals for canonical scenario.
+- CI gate: pnpm task executing the integration test plus tolerance check; optionally run in conformance workflow.
+
+## Affected Files (indicative)
+- `packages/engine/src/backend/src/economy/accrual.ts`
+- `packages/engine/src/backend/src/economy/tariffs.ts`
+- `packages/engine/tests/unit/economy/*.spec.ts`
+- `packages/engine/tests/integration/pipeline/economyAccrual.integration.test.ts`
+- `docs/SEC.md` ([§10](../SEC.md#10-economy-integration-non-intrusive), [§7.5 references](../SEC.md#423-zone-requirement-shall))
+- `docs/TDD.md` ([§8](../TDD.md#8-economy--tariffs-sec-36))
+- `docs/CHANGELOG.md`
+- `AGENTS.md` ([§5](../../AGENTS.md#5-data-contracts--price-separation-sec-3))
+
+## Risks & Mitigations
+- **Risk:** Double-counting resource flows. **Mitigation:** Centralize aggregation in one module and add unit tests ensuring single entry per resource.
+- **Risk:** CI baseline rot when scenario changes. **Mitigation:** Update stored expectations alongside scenario tweaks and log in CHANGELOG.
+- **Risk:** Performance regressions in accrual stage. **Mitigation:** Profile accrual step and cache tariff lookups; ensure perf harness stays within limits.

--- a/docs/tasks/0009-cultivation-method-tasks-runtime.md
+++ b/docs/tasks/0009-cultivation-method-tasks-runtime.md
@@ -1,0 +1,54 @@
+# Cultivation Method Tasks Runtime
+
+**ID:** 0009  
+**Status:** Planned  
+**Owner:** unassigned  
+**Priority:** P1  
+**Tags:** backend, cultivation, tasks, tests
+
+## Rationale
+SEC requires every zone to reference a cultivation method with containers, substrates, reuse policies, and associated tasks ([SEC §7.5](../SEC.md#423-zone-requirement-shall); [AGENTS §5.1](../../AGENTS.md#51-cultivation-methods-are-required-on-zones-sec-75)). Tasks such as repotting, sterilization, disposal, and reuse policy enforcement must emit deterministically and accrue costs ([SEC §3.3](../SEC.md#33-task--treatment-catalogs-data-driven); [SEC §10](../SEC.md#10-economy-integration-non-intrusive)). We need runtime logic that translates cultivation method policies into scheduled tasks.
+
+## Scope
+- Include: derive runtime tasks (repot, sterilize, dispose, reuse) from cultivation method metadata and schedule them deterministically.
+- Include: integrate with workforce scheduler and economy accrual for labor/material costs.
+- Include: acceptance scenario verifying tasks emit per schedule (e.g., service life cycles, reuse limits).
+- Out of scope: new cultivation method schemas beyond SEC definitions; UI interactions.
+
+## Deliverables
+- Runtime module that reads cultivation method policies and produces task schedules (including recurrence, prerequisites) for each zone.
+- Workforce/economy integration ensuring tasks enter queues with correct codes, required roles/skills, and associated costs.
+- Integration test verifying tasks emit according to method schedules over a multi-cycle simulation, including reuse policy resets.
+- Documentation/CHANGELOG updates summarising the runtime behaviour.
+
+## Implementation Steps
+1. Parse cultivation method blueprint metadata (containers, substrates, reuse policy, service life) into runtime descriptors.
+2. Implement scheduler that monitors plant lifecycle/usage counts to trigger tasks (repotting, sterilization, disposal) at deterministic intervals.
+3. Hook into workforce task queue to enqueue tasks with catalog codes and into economy accrual for associated costs.
+4. Add integration test covering multiple cycles verifying expected task emission counts and sequencing; include reuse policy enforcement.
+5. Update documentation (SEC clarifications if needed, TDD) and CHANGELOG.
+
+## Acceptance Criteria / DoD
+- For a given cultivation method, runtime produces deterministic task emission schedule (counts and timing) across runs.
+- Tasks carry correct catalog codes, role/skill requirements, and costs; reuse policies enforce sterilization before reuse beyond allowed cycles.
+- Integration test demonstrates scenario where repot/sterilize/disposal tasks emit at documented intervals; assertions compare against expected counts.
+- Documentation/CHANGELOG updated to reflect runtime behaviour.
+
+## Tests
+- Unit tests: cultivation method parser (ensuring required fields) and task schedule calculator.
+- Integration test: `packages/engine/tests/integration/pipeline/cultivationMethodTasks.integration.test.ts` running multiple growth cycles verifying task emissions and economy impacts.
+- CI: ensure new tests run via pnpm suite; optionally include counts check in golden master summary.
+
+## Affected Files (indicative)
+- `packages/engine/src/backend/src/cultivation/methodRuntime.ts`
+- `packages/engine/src/backend/src/workforce/taskScheduler.ts`
+- `packages/engine/tests/unit/cultivation/methodRuntime.spec.ts`
+- `packages/engine/tests/integration/pipeline/cultivationMethodTasks.integration.test.ts`
+- `docs/SEC.md` ([§7.5](../SEC.md#423-zone-requirement-shall), [§3.3](../SEC.md#33-task--treatment-catalogs-data-driven), [§10](../SEC.md#10-economy-integration-non-intrusive))
+- `AGENTS.md` ([§5.1](../../AGENTS.md#51-cultivation-methods-are-required-on-zones-sec-75))
+- `docs/CHANGELOG.md`
+
+## Risks & Mitigations
+- **Risk:** Task spam due to misconfigured recurrence. **Mitigation:** Validate schedules against service life/reuse data and add assertions for maximum concurrency.
+- **Risk:** Economy coupling duplicates costs. **Mitigation:** Centralize cost calculation in economy accrual and test aggregated totals.
+- **Risk:** Scheduler conflicts with other workforce tasks. **Mitigation:** Prioritize cultivation maintenance appropriately and include integration tests for queue order.

--- a/docs/tasks/0010-vpd-and-stress-signals-finalization.md
+++ b/docs/tasks/0010-vpd-and-stress-signals-finalization.md
@@ -1,0 +1,55 @@
+# VPD and Stress Signals Finalization
+
+**ID:** 0010  
+**Status:** Planned  
+**Owner:** unassigned  
+**Priority:** P1  
+**Tags:** backend, simulation, physiology, tests
+
+## Rationale
+Plant growth/stress coupling depends on environment signals meeting strain tolerance windows ([SEC §8.1](../SEC.md#81-outcomes-shall)). VPD is a core KPI for optimizers ([VISION_SCOPE §1](../VISION_SCOPE.md#1-vision)), and the open question on stress→growth curves ([SEC §14](../SEC.md#14-open-questions-to-be-resolved-iteratively)) needs closure. We must finalize VPD-derived stress signals, tolerance band curves, and ensure deterministic integration over growth phases.
+
+## Scope
+- Include: implement VPD calculation (dewpoint/humidity edge cases) feeding stress/health signals per strain tolerance curves.
+- Include: define tolerance band curves (piecewise or parametric) resolving the open question and integrate them into plant physiology.
+- Include: unit tests around dewpoint calculation and humidity edge cases; integration tests verifying stress accumulation over growth stages.
+- Out of scope: introducing new strain schema fields beyond SEC definitions; UI visualisations of VPD.
+
+## Deliverables
+- VPD computation utility with documented units and clamps for humidity extremes.
+- Stress model integrating VPD, temperature, and strain tolerance curves to produce deterministic health modifiers.
+- Unit tests for dewpoint/VPD calculations at edge humidity values; integration tests covering multi-phase growth verifying stress/health outcomes.
+- Documentation updates resolving the SEC §14 open question and recording the final curve selection.
+
+## Implementation Steps
+1. Implement VPD helper functions (dewpoint, saturation vapour pressure) using existing constants and clamp outputs to avoid NaN/negative cases.
+2. Define tolerance band curves for strains (piecewise or parametric) and integrate them into plant physiology stress calculations.
+3. Update plant physiology stage to consume VPD-derived stress signals, ensuring deterministic transitions across growth phases.
+4. Add unit tests for dewpoint/VPD calculations (including humidity 0%/100%) and integration tests verifying stress effects on growth metrics across lifecycle stages.
+5. Update SEC/TDD (if needed) and CHANGELOG to document finalised VPD/stress model.
+
+## Acceptance Criteria / DoD
+- VPD helper returns deterministic values with finite results for humidity in [0,1]; dewpoint tests cover extreme inputs.
+- Stress model produces consistent modifiers given identical inputs; tolerance curves documented and referenced in SEC/TDD.
+- Integration test covering seed→flowering run shows stress signals respond to VPD excursions and influence growth metrics as expected.
+- Documentation (SEC/TDD/CHANGELOG) updated to close the open question on stress→growth curves.
+
+## Tests
+- Unit tests: `packages/engine/tests/unit/physiology/vpd.spec.ts`, `.../stressCurves.spec.ts` covering dewpoint edges and curve evaluation.
+- Integration tests: `packages/engine/tests/integration/pipeline/plantStress.integration.test.ts` verifying multi-phase stress behaviour.
+- CI/perf: ensure integration test fits within perf budget; optionally include VPD metrics in golden master summary.
+
+## Affected Files (indicative)
+- `packages/engine/src/backend/src/physiology/vpd.ts`
+- `packages/engine/src/backend/src/physiology/stressModel.ts`
+- `packages/engine/tests/unit/physiology/*.spec.ts`
+- `packages/engine/tests/integration/pipeline/plantStress.integration.test.ts`
+- `docs/SEC.md` ([§8](../SEC.md#8-plant-model-lifecycle--growth), [§14](../SEC.md#14-open-questions-to-be-resolved-iteratively))
+- `docs/TDD.md` (update physiology test guidance if needed)
+- `docs/VISION_SCOPE.md` ([§1](../VISION_SCOPE.md#1-vision))
+- `docs/CHANGELOG.md`
+
+## Risks & Mitigations
+- **Risk:** Numerical instability in VPD at extreme humidity. **Mitigation:** Clamp inputs, use double precision, and add golden vector tests.
+- **Risk:** Stress curves misaligned with strain data. **Mitigation:** Document curve parameters per strain and validate via fixtures.
+- **Risk:** Integration test affects conformance hashes. **Mitigation:** Update golden expectations in lockstep and note in CHANGELOG.

--- a/docs/tasks/0011-transport-adapter-hardening.md
+++ b/docs/tasks/0011-transport-adapter-hardening.md
@@ -1,0 +1,52 @@
+# Transport Adapter Hardening
+
+**ID:** 0011  
+**Status:** Planned  
+**Owner:** unassigned  
+**Priority:** P1  
+**Tags:** backend, transport, tests, docs
+
+## Rationale
+The transport adapter must enforce telemetry read-only semantics and separate intent channels per [SEC §11.3 Transport Policy](../SEC.md#113-transport-policy) and [SEC §1 Core Invariants](../SEC.md#1-core-invariants-guardrails). [TDD §11](../TDD.md#11-telemetry-read-only-transport-separation-sec-11) prescribes contract tests, and [AGENTS §2/§4](../../AGENTS.md#2-core-invariants-mirror-sec-1) reiterate determinism and channel separation. We must harden the adapter with negative tests and updated docs.
+
+## Scope
+- Include: enforce read-only telemetry channel, separate intents, adapter-level rejection of inbound telemetry writes.
+- Include: negative tests covering malformed payloads, channel misuse, and failure modes.
+- Include: documentation updates describing adapter contracts.
+- Out of scope: supporting new transport protocols beyond Socket.IO/SSE baseline; UI changes.
+
+## Deliverables
+- Hardened transport adapter implementation with explicit channel separation and guards.
+- Contract tests covering successful subscriptions, rejected telemetry writes, and intent routing.
+- Documentation updates (SEC/TDD or dedicated adapter doc) outlining usage and rejection rules; CHANGELOG entry.
+
+## Implementation Steps
+1. Review adapter implementation to ensure telemetry sockets are receive-only and intents use separate namespace/channel.
+2. Add guards rejecting telemetry writes, malformed payloads, and unauthorized channel usage with deterministic error codes.
+3. Expand test suite with contract tests (unit/integration) covering positive and negative cases, referencing TDD guidance.
+4. Update documentation describing adapter contract and add CHANGELOG note; ensure README/SEC cross-links.
+
+## Acceptance Criteria / DoD
+- Telemetry channel rejects all inbound messages; tests assert failure responses and no state mutation.
+- Intent channel continues to accept validated commands; tests cover separation and no cross-leakage.
+- Documentation updated with contract details and referenced in SEC/TDD; CHANGELOG records hardening.
+- Negative tests executed in CI to guard regressions.
+
+## Tests
+- Unit tests: adapter guard functions, payload validators.
+- Integration tests: `packages/facade/tests/integration/transport/telemetryReadonly.spec.ts` and new negative tests verifying separation.
+- CI: pnpm test suite ensures transport tests run; optional contract test stage in CI pipeline.
+
+## Affected Files (indicative)
+- `packages/facade/src/transport/adapter.ts`
+- `packages/facade/tests/integration/transport/telemetryReadonly.spec.ts`
+- `packages/facade/tests/integration/transport/intentRouting.spec.ts`
+- `docs/SEC.md` ([§11.3](../SEC.md#113-transport-policy))
+- `docs/TDD.md` ([§11](../TDD.md#11-telemetry-read-only-transport-separation-sec-11))
+- `AGENTS.md` ([§2](../../AGENTS.md#2-core-invariants-mirror-sec-1))
+- `docs/CHANGELOG.md`
+
+## Risks & Mitigations
+- **Risk:** Breaking existing clients. **Mitigation:** Document contract clearly and provide integration test fixtures for clients.
+- **Risk:** Error handling introduces nondeterminism. **Mitigation:** Use deterministic error codes/messages and unit tests.
+- **Risk:** Test flakiness due to async behaviour. **Mitigation:** Use deterministic fakes/mocks and ensure timeouts controlled.

--- a/docs/tasks/0012-blueprint-taxonomy-v2-loader-tests.md
+++ b/docs/tasks/0012-blueprint-taxonomy-v2-loader-tests.md
@@ -1,0 +1,51 @@
+# Blueprint Taxonomy v2 Loader Tests
+
+**ID:** 0012  
+**Status:** Planned  
+**Owner:** unassigned  
+**Priority:** P2  
+**Tags:** backend, data, tests
+
+## Rationale
+Blueprint taxonomy rules are strict: [SEC §3.0.1](../SEC.md#301-blueprint-taxonomy-strict-adr-0015) and [AGENTS §5 Data Contracts](../../AGENTS.md#5-data-contracts--price-separation-sec-3) require path↔class alignment with max two directory levels. [TDD §2](../TDD.md#2-test-taxonomy--folder-layout) and [§9a](../TDD.md#9a-stub-tests--test-vectors-phase-1) emphasize loader tests. We need to harden the loader with v2 tests enforcing depth, class alignment, and fast failure.
+
+## Scope
+- Include: enforce maximum two-level directory depth, path/class alignment, and explicit error when mismatched.
+- Include: loader tests covering happy path and failure cases; migration notes if taxonomy changes.
+- Include: documentation updates clarifying loader behaviour.
+- Out of scope: redefining taxonomy structure beyond SEC mandates.
+
+## Deliverables
+- Loader guard implementation ensuring directories deeper than two levels fail and class mismatches raise `BlueprintTaxonomyMismatchError`.
+- Unit tests covering valid and invalid cases; fixtures for misplacement scenarios.
+- Migration notes (if needed) in docs/CHANGELOG to guide contributors.
+
+## Implementation Steps
+1. Update loader to check directory depth and class alignment per SEC/AGENTS guidance; throw deterministic errors on violation.
+2. Add unit tests enumerating valid/invalid paths, including deep nesting and mismatched class names.
+3. Ensure integration tests scanning `/data/blueprints/**` enforce constraints and fail fast.
+4. Update documentation/CHANGELOG to describe loader behaviour and guidance for contributors.
+
+## Acceptance Criteria / DoD
+- Loader rejects any blueprint beyond two directory levels or with path/class mismatch; tests cover each failure case.
+- Valid blueprints continue to load deterministically; regression tests cover canonical directories.
+- Documentation/CHANGELOG updated with loader behaviour and migration guidance.
+
+## Tests
+- Unit tests: `packages/engine/tests/unit/data/blueprintTaxonomy.spec.ts` covering depth/mismatch cases.
+- Integration tests: repo-wide scan ensuring all existing blueprints comply, failing if new invalid files introduced.
+- CI: pnpm test suite includes loader tests; optional lint script verifying file structure.
+
+## Affected Files (indicative)
+- `packages/engine/src/backend/src/data/blueprintLoader.ts`
+- `packages/engine/tests/unit/data/blueprintTaxonomy.spec.ts`
+- `/data/blueprints/**`
+- `docs/SEC.md` ([§3.0.1](../SEC.md#301-blueprint-taxonomy-strict-adr-0015))
+- `docs/TDD.md` ([§2](../TDD.md#2-test-taxonomy--folder-layout), [§9a](../TDD.md#9a-stub-tests--test-vectors-phase-1))
+- `AGENTS.md` ([§5](../../AGENTS.md#5-data-contracts--price-separation-sec-3))
+- `docs/CHANGELOG.md`
+
+## Risks & Mitigations
+- **Risk:** Existing blueprints violate rules. **Mitigation:** Audit repo and add migration notes; fix offenders before enabling guard.
+- **Risk:** Loader changes break mod tooling. **Mitigation:** Document rules clearly and provide migration instructions.
+- **Risk:** Tests slow due to filesystem scans. **Mitigation:** Cache directory listings and limit scope to blueprint tree.

--- a/docs/tasks/0013-open-questions-to-adrs.md
+++ b/docs/tasks/0013-open-questions-to-adrs.md
@@ -1,0 +1,52 @@
+# Open Questions to ADRs
+
+**ID:** 0013  
+**Status:** Planned  
+**Owner:** unassigned  
+**Priority:** P2  
+**Tags:** docs, governance, adr
+
+## Rationale
+[SEC §14 Open Questions](../SEC.md#14-open-questions-to-be-resolved-iteratively) lists outstanding decisions (irrigation minima, stress→growth curve shape, reporting granularity, default zone height). [AGENTS §1.4 Documentation & Governance](../../AGENTS.md#14-documentation--governance-strict) mandates ADR workflow for contract changes. We need to convert these open questions into ADRs capturing decisions and implications.
+
+## Scope
+- Include: author ADRs for each open question with context, decision, consequences, and references to SEC/DD/TDD.
+- Include: update SEC/TDD/VISION as needed to reflect resolved decisions and remove items from open questions section.
+- Include: CHANGELOG entries summarising ADR additions.
+- Out of scope: introducing new topics beyond the listed open questions.
+
+## Deliverables
+- Four ADRs (irrigation minima, stress→growth curves, reporting granularity, default zone height) stored under `docs/ADR/` with consistent template.
+- Updated SEC §14 removing addressed open questions and referencing ADR IDs.
+- Updates to DD/TDD/VISION_SCOPE if decisions affect those documents.
+- CHANGELOG entry summarising ADR publication.
+
+## Implementation Steps
+1. Gather context from SEC/DD/TDD for each open question; draft ADRs with background, decision, consequences.
+2. Review with stakeholders (if process defined) and record final decisions in ADRs.
+3. Update SEC §14 to reference new ADRs and remove resolved items; adjust DD/TDD/VISION_SCOPE to incorporate outcomes.
+4. Add CHANGELOG entry referencing ADR IDs and summarizing resolutions.
+
+## Acceptance Criteria / DoD
+- ADRs exist for all four open questions with clear decisions and linked references; documents updated accordingly.
+- SEC §14 no longer lists unresolved versions of these questions; instead links to ADRs.
+- DD/TDD/VISION_SCOPE reflect decisions (e.g., irrigation minima thresholds, stress curve shape).
+- CHANGELOG notes ADR additions.
+
+## Tests
+- Documentation lint/check (Markdown link validator) over new ADRs and updated sections.
+- Optional unit test verifying SEC §14 references ADR IDs (e.g., doc parsing test).
+
+## Affected Files (indicative)
+- `docs/ADR/ADR-XXXX-*.md` (new)
+- `docs/SEC.md` ([§14](../SEC.md#14-open-questions-to-be-resolved-iteratively))
+- `docs/DD.md`
+- `docs/TDD.md`
+- `docs/VISION_SCOPE.md`
+- `docs/CHANGELOG.md`
+- `AGENTS.md` ([§1.4](../../AGENTS.md#14-documentation--governance-strict))
+
+## Risks & Mitigations
+- **Risk:** Decisions lack consensus. **Mitigation:** Follow ADR review process and capture open issues in ADR status if pending.
+- **Risk:** Documents drift after ADR. **Mitigation:** Update all references immediately and include doc validation in CI.
+- **Risk:** ADR numbering conflicts. **Mitigation:** Reserve IDs before drafting and record in CHANGELOG.

--- a/docs/tasks/0014-performance-budget-in-ci.md
+++ b/docs/tasks/0014-performance-budget-in-ci.md
@@ -1,0 +1,52 @@
+# Performance Budget in CI
+
+**ID:** 0014  
+**Status:** Planned  
+**Owner:** unassigned  
+**Priority:** P2  
+**Tags:** backend, performance, ci, tests
+
+## Rationale
+Performance targets require ≥1 tick/s and memory bounds per [VISION_SCOPE §3 Success Criteria](../VISION_SCOPE.md#3-success-criteria). [TDD Tick Pipeline](../TDD.md#tick-pipeline-canonical-9-phases) and perf harness guidance (`withPerfHarness`, `generateSeedToHarvestReport`) specify measurement tooling, and [TDD §0 Principles](../TDD.md#0-principles) emphasises golden perf checks. We must wire CI gates enforcing ≥5k ticks/min headless throughput and heap plateau <64 MiB per 10k ticks as stated in the prompt.
+
+## Scope
+- Include: implement performance harness invocation in CI measuring ticks/min and heap usage for reference scenario.
+- Include: define regression thresholds and failure policy (warn vs fail) documented in repo.
+- Include: update documentation referencing perf budget enforcement.
+- Out of scope: micro-optimisations beyond meeting the documented thresholds; UI performance.
+
+## Deliverables
+- Perf harness script (pnpm task) executing headless runs (≥10k ticks) capturing throughput and heap metrics.
+- CI job enforcing ≥5k ticks/min and heap plateau <64 MiB per 10k ticks, failing builds on regression beyond threshold policy.
+- Documentation updates (TDD, docs/engine/simulation-reporting) describing CI perf gate configuration.
+- CHANGELOG entry noting the new perf budget checks.
+
+## Implementation Steps
+1. Configure perf harness invocation (`withPerfHarness`, `runTick` loops) to produce metrics for the reference scenario.
+2. Implement analysis script comparing measured throughput/heap against thresholds (with allowed regressions policy) and exit codes accordingly.
+3. Add CI workflow step executing the perf script on suitable hardware (or flagged job) with caching to keep runtime manageable.
+4. Update documentation (TDD/perf sections, simulation-reporting doc) describing usage and thresholds; update CHANGELOG.
+
+## Acceptance Criteria / DoD
+- CI job runs perf harness in headless mode, measuring ≥10k ticks; fails if throughput <5k ticks/min or heap >64 MiB plateau.
+- Threshold policy documented (e.g., percentage regression allowed or manual override procedure).
+- Documentation references new pnpm command and thresholds; CHANGELOG entry added.
+- Perf job integrated into CI pipeline (per branch or nightly) as agreed.
+
+## Tests
+- Automated perf run script verifying thresholds and returning exit status (can be treated as integration test); optional unit tests for threshold parser.
+- Manual verification step documented for local runs (`pnpm --filter @wb/engine perf:ci`).
+- CI: dedicated job executed with gating.
+
+## Affected Files (indicative)
+- `packages/engine/scripts/perf/ciPerfCheck.ts`
+- `.github/workflows/ci.yml` (or equivalent)
+- `docs/TDD.md` ([Tick Pipeline](../TDD.md#tick-pipeline-canonical-9-phases), [Principles](../TDD.md#0-principles))
+- `docs/engine/simulation-reporting.md`
+- `docs/CHANGELOG.md`
+- `docs/VISION_SCOPE.md` ([§3](../VISION_SCOPE.md#3-success-criteria))
+
+## Risks & Mitigations
+- **Risk:** CI hardware variance causes flaky perf results. **Mitigation:** Use relative thresholds with guard band and collect baseline stats; allow manual override with documented procedure.
+- **Risk:** Perf job lengthens CI significantly. **Mitigation:** Run on nightly or cached job, or reduce tick count while maintaining statistical confidence.
+- **Risk:** Perf harness drifts from gameplay scenario. **Mitigation:** Document scenario, tie to golden master, and update together with CHANGELOG entries.

--- a/docs/tasks/0015-terminal-monitor-mvp.md
+++ b/docs/tasks/0015-terminal-monitor-mvp.md
@@ -1,0 +1,53 @@
+# Terminal Monitor MVP
+
+**ID:** 0015  
+**Status:** Planned  
+**Owner:** unassigned  
+**Priority:** P2  
+**Tags:** monitoring, telemetry, docs, frontend
+
+## Rationale
+SEC mandates a read-only terminal monitor built on neo-blessed ([SEC §0.1 Platform & Monorepo](../SEC.md#01-platform--monorepo-baseline-technology-choices)) and reiterates telemetry must remain receive-only ([SEC §11.3](../SEC.md#113-transport-policy)). The experience pillar emphasises surfacing KPIs and warnings ([VISION_SCOPE §1](../VISION_SCOPE.md#1-vision)). We need an MVP dashboard aligned with these rules and documented usage.
+
+## Scope
+- Include: implement read-only terminal dashboard showing key KPIs (e.g., energy, VPD/stress, task queue, costs) sourced from telemetry/read-models.
+- Include: navigation controls (keyboard) without any write capabilities.
+- Include: documentation describing setup/usage and limitations.
+- Out of scope: intent submission, UI interactions beyond read-only views, theming beyond basic layout.
+
+## Deliverables
+- Terminal monitor package/app using neo-blessed that subscribes to telemetry and renders KPIs, warnings, and cost summaries.
+- Read-only enforcement (no command inputs) consistent with transport policy.
+- Usage documentation (README or docs section) outlining commands, KPIs shown, and alignment with SEC.
+- CHANGELOG entry summarising the MVP.
+
+## Implementation Steps
+1. Scaffold terminal monitor entrypoint (pnpm workspace) using neo-blessed and connect to telemetry via transport adapter read-only channel.
+2. Implement KPI panels (e.g., environment, economy, workforce warnings) with deterministic refresh cadence and navigation (keyboard shortcuts).
+3. Ensure monitor enforces read-only behaviour (disable input, guard against command emission) and logs warnings if misconfigured.
+4. Document usage in `docs/` (e.g., `docs/tools/terminal-monitor.md`) referencing SEC requirements; update CHANGELOG.
+
+## Acceptance Criteria / DoD
+- Terminal monitor runs via pnpm script, connects to telemetry, and displays KPIs/warnings/costs without sending any intents.
+- Keyboard navigation works (switch panels, scroll) while input fields remain disabled for commands.
+- Documentation explains setup, KPIs, and confirms read-only compliance; CHANGELOG updated.
+- Basic smoke test ensures monitor can run headless in CI or manual check (if automation not feasible).
+
+## Tests
+- Automated: integration test or script verifying monitor starts, subscribes to telemetry, and does not emit intents (can use transport mocks).
+- Manual checklist: run monitor against test harness and confirm KPIs/warnings render.
+- CI: optional smoke job to run monitor in headless mode ensuring startup success.
+
+## Affected Files (indicative)
+- `packages/monitor-terminal/src/index.ts`
+- `packages/monitor-terminal/package.json`
+- `packages/monitor-terminal/tests/monitor.smoke.spec.ts`
+- `docs/tools/terminal-monitor.md`
+- `docs/SEC.md` ([§0.1](../SEC.md#01-platform--monorepo-baseline-technology-choices), [§11.3](../SEC.md#113-transport-policy))
+- `docs/VISION_SCOPE.md` ([§1](../VISION_SCOPE.md#1-vision))
+- `docs/CHANGELOG.md`
+
+## Risks & Mitigations
+- **Risk:** Terminal monitor accidentally emits intents. **Mitigation:** Enforce read-only transport usage and add tests verifying no outbound messages.
+- **Risk:** Accessibility/usability issues. **Mitigation:** Provide keyboard navigation and clear labeling; gather feedback for iteration.
+- **Risk:** Telemetry schema changes break dashboard. **Mitigation:** Centralize view models and add tests for schema compatibility.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -1,0 +1,24 @@
+# Task Backlog
+
+| ID   | Title | Priority | Status | Owner | Links |
+| ---- | ----- | -------- | ------ | ----- | ----- |
+| 0001 | Golden Master & Conformance Suite | P0 | Planned | unassigned | [task](./0001-golden-master-and-conformance-suite.md) · [SEC](../SEC.md) · [DD](../DD.md) · [TDD](../TDD.md) |
+| 0002 | Appendix B Crosswalk Fill | P0 | Planned | unassigned | [task](./0002-appendix-b-crosswalk-fill.md) · [SEC](../SEC.md) · [DD](../DD.md) · [TDD](../TDD.md) |
+| 0003 | Sensors Stage Content and Noise Model | P0 | Planned | unassigned | [task](./0003-sensors-stage-content-and-noise-model.md) · [SEC](../SEC.md) · [DD](../DD.md) · [TDD](../TDD.md) |
+| 0004 | CO₂ Actuator and Environment Coupling | P0 | Planned | unassigned | [task](./0004-co2-actuator-and-environment-coupling.md) · [SEC](../SEC.md) · [DD](../DD.md) · [TDD](../TDD.md) |
+| 0005 | Pest & Disease System MVP | P0 | Planned | unassigned | [task](./0005-pest-disease-system-mvp.md) · [SEC](../SEC.md) · [DD](../DD.md) · [TDD](../TDD.md) |
+| 0006 | Save/Load and Migrations | P0 | Planned | unassigned | [task](./0006-save-load-and-migrations.md) · [SEC](../SEC.md) · [DD](../DD.md) · [TDD](../TDD.md) |
+| 0007 | Device Degradation and Maintenance Flows | P1 | Planned | unassigned | [task](./0007-device-degradation-and-maintenance-flows.md) · [SEC](../SEC.md) · [DD](../DD.md) · [TDD](../TDD.md) |
+| 0008 | Economy Accrual Consolidation | P1 | Planned | unassigned | [task](./0008-economy-accrual-consolidation.md) · [SEC](../SEC.md) · [DD](../DD.md) · [TDD](../TDD.md) |
+| 0009 | Cultivation Method Tasks Runtime | P1 | Planned | unassigned | [task](./0009-cultivation-method-tasks-runtime.md) · [SEC](../SEC.md) · [DD](../DD.md) · [TDD](../TDD.md) |
+| 0010 | VPD and Stress Signals Finalization | P1 | Planned | unassigned | [task](./0010-vpd-and-stress-signals-finalization.md) · [SEC](../SEC.md) · [DD](../DD.md) · [TDD](../TDD.md) |
+| 0011 | Transport Adapter Hardening | P1 | Planned | unassigned | [task](./0011-transport-adapter-hardening.md) · [SEC](../SEC.md) · [DD](../DD.md) · [TDD](../TDD.md) |
+| 0012 | Blueprint Taxonomy v2 Loader Tests | P2 | Planned | unassigned | [task](./0012-blueprint-taxonomy-v2-loader-tests.md) · [SEC](../SEC.md) · [DD](../DD.md) · [TDD](../TDD.md) |
+| 0013 | Open Questions to ADRs | P2 | Planned | unassigned | [task](./0013-open-questions-to-adrs.md) · [SEC](../SEC.md) · [DD](../DD.md) · [TDD](../TDD.md) |
+| 0014 | Performance Budget in CI | P2 | Planned | unassigned | [task](./0014-performance-budget-in-ci.md) · [SEC](../SEC.md) · [DD](../DD.md) · [TDD](../TDD.md) |
+| 0015 | Terminal Monitor MVP | P2 | Planned | unassigned | [task](./0015-terminal-monitor-mvp.md) · [SEC](../SEC.md) · [DD](../DD.md) · [TDD](../TDD.md) |
+
+## How to work with tasks
+- **Branch naming:** use `feature/<task-id>-short-slug` (e.g., `feature/0004-co2-coupling`) so CI links back to the task.
+- **PR checklist:** reference the task ID, cite relevant SEC/DD/TDD sections, update CHANGELOG/ADR if contracts change, and include test results proving the Acceptance Criteria.
+- **DoD & tests:** align commits with the task’s Acceptance Criteria / DoD section. Attach CI logs or local runs for the listed tests (unit, integration, perf) when opening PRs.


### PR DESCRIPTION
## Summary
- add fifteen SEC-aligned task specifications under `docs/tasks/` using the required template and references
- document the task index in `docs/tasks/README.md` with links to SEC/DD/TDD and workflow guidance

## Testing
- not run (docs-only)


------
https://chatgpt.com/codex/tasks/task_e_68e36102c9a88325a96dac5db19752ca