### PR TITLE
docs(ci): unify runtime to Node.js 22 (LTS) references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,8 @@ Steer implementation so the codebase **conforms to SEC v0.2.1** while remaining 
 
 ## 1) Platform & Monorepo (must‑haves)
 
-- **Node.js v23+**, **ES Modules** end‑to‑end. (`"type": "module"` in packages.)
-  - `.nvmrc` / `.node-version` pin **Node.js 22** locally for the migration dry-run; adopt it via your version manager, then test on Node.js 23 before merging (ADR-0012).
+- **Node.js 22 (LTS)**, **ES Modules** end‑to‑end. (`"type": "module"` in packages.)
+  - `.nvmrc` / `.node-version` pin **Node.js 22 (LTS)** locally; adopt it via your version manager and match CI, which also runs Node.js 22 (LTS).
 - **TypeScript** (strongly recommended in backend and UI) with strict mode; emit ESM.
 - **pnpm workspaces** monorepo: engine (headless), façade (integration/transport), UI (React+Vite), tools (monitoring/validation).
 - **UI:** React + Vite + Tailwind. "Dumb UI": read‑models in, intents out.

--- a/docs/ADR/ADR-0012-node-version-tooling-alignment.md
+++ b/docs/ADR/ADR-0012-node-version-tooling-alignment.md
@@ -11,6 +11,8 @@
 > - **Binding:** true
 > - **Impacts:** AGENTS, DD
 
+> **Status note:** As of this change, the project standardizes on **Node.js 22 (LTS)** for local and CI. Any references to Node 23 in this ADR are historical.
+
 ## Context
 
 The monorepo targets Node.js 23+ in production and CI, matching the Simulation Engine Contract (SEC) guidance captured in root tooling metadata. However, developers frequently rely on environment managers such as `nvm`, `fnm`, `nodenv`, or `asdf` to synchronise their local runtimes. Without explicit version files, onboarding engineers must manually inspect `package.json` to discover the expected Node release, leading to mismatches between local shells, editor integrations, and automated scripts. The upcoming migration workstream for Node.js 22 LTS requires a deterministic mechanism to coordinate contributor upgrades and smoke-test the toolchain before flipping the enforced `engines.node` constraint.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Required `company.location` metadata with Hamburg defaults and coordinate clamps during validation (ADR-0008).
 - Extended zone state and the light emitter stub with PPFD/DLI telemetry plus guard tests (ADR-0010).
 - Propagated blueprint-declared `effects`/config blocks onto device instances before pipeline evaluation (ADR-0011).
-- Added `.nvmrc`/`.node-version` markers pinning Node.js 22 locally while CI enforces Node.js 23 (ADR-0012).
+- Added `.nvmrc`/`.node-version` markers pinning Node.js 22 (LTS) locally while CI uses Node.js 22 (LTS) (ADR-0012).
 - Embedded the deterministic workforce branch (roles, employees, tasks, KPIs, payroll) into world snapshots (ADR-0013).
 - Implemented seeded workforce identity sourcing with a 500 ms randomuser.me timeout and pseudodata fallback (ADR-0014).
 - Flattened blueprint taxonomy to domain-level folders with explicit subtype metadata and migration tooling (ADR-0015).
@@ -218,8 +218,8 @@ migrate:classes`, `npm run migrate:blueprints`), and documented the taxonomy upd
 
 ### #59 Tooling - Node version manager hints
 
-- Added `.nvmrc` and `.node-version` pointing to Node.js 22 so local environment managers auto-select the target runtime during the LTS migration dry run.
-- Captured the decision in ADR-0012 to document the transitional alignment between local tooling and CI-enforced Node.js 23.
+- Added `.nvmrc` and `.node-version` pointing to Node.js 22 (LTS) so local environment managers auto-select the target runtime.
+- Captured the decision in ADR-0012 to document the unified Node.js 22 (LTS) runtime across local tooling and CI.
 
 ### #58 WB-052 Zod compatibility rollback
 
@@ -746,7 +746,7 @@ migrate:classes`, `npm run migrate:blueprints`), and documented the taxonomy upd
 ### #07 WB-001 pnpm workspace bootstrap
 
 - Initialised pnpm workspaces with shared TypeScript configuration and path aliases for engine, façade, transport, and monitoring packages.
-- Added base linting, formatting, and testing toolchain aligned with Node 23+ ESM requirements.
+- Added base linting, formatting, and testing toolchain aligned with Node.js 22 (LTS) ESM requirements.
 - Provisioned CI workflow executing lint, test, and build stages to guarantee green pipelines.
 
 All notable changes to this repository will be documented in this file.

--- a/docs/DD.md
+++ b/docs/DD.md
@@ -11,7 +11,7 @@ Weed Breed is a deterministic, tick‑driven cultivation & economy simulator. 
 
 UI component layer: shadcn/ui (on Radix primitives) with Tailwind for styling; icons via lucide-react; micro-animations via Framer Motion. Charts via Recharts, optionally Tremor for dashboard presets. Components are in-repo (shadcn “copy-in” model) to avoid vendor lock and keep them themable with Tailwind.
 
-Local version markers (`.nvmrc`, `.node-version`) pin Node.js 22 for migration dry-runs while CI enforces Node.js 23 until the follow-up runtime ADR lands (ADR-0012).
+Local version markers (`.nvmrc`, `.node-version`) pin Node.js 22 (LTS) for both local development and CI; the entire stack runs Node.js 22 (LTS) per ADR-0012.
 
 ---
 

--- a/docs/SEC.md
+++ b/docs/SEC.md
@@ -18,9 +18,9 @@ This document describes **what the simulation is and should be** at the core lev
 
 We start **fresh**: no external document references; prior proposals are folded in **high-level**. The platform standardizes integration surfaces without constraining the core model.
 
-- **Node.js (v23+, ESM)** — Backend and façade **SHALL** use modern ECMAScript modules.
+- **Node.js 22 (LTS), ESM** — Backend and façade **SHALL** use modern ECMAScript modules.
 
-- **Local version markers** — `.nvmrc` and `.node-version` pin **Node.js 22** for migration dry-runs while CI stays on Node.js 23 until the follow-up runtime migration lands ([ADR-0012](ADR/ADR-0012-node-version-tooling-alignment.md)). Contributors **SHALL** honour the markers locally but verify changes against the enforced Node.js 23 toolchain before release.
+- **Local & CI runtime** — `.nvmrc` and `.node-version` pin **Node.js 22 (LTS)**. Contributors **SHALL** adopt Node.js 22 (LTS) locally and CI runs the same runtime ([ADR-0012](ADR/ADR-0012-node-version-tooling-alignment.md)).
 
 - **TypeScript** — The codebase **SHOULD** use TypeScript for type safety and clearer contracts.
 - **Monorepo with pnpm workspaces** — The repository **SHALL** be a pnpm monorepo (engine, façade, UI, tools).
@@ -673,7 +673,7 @@ Validation occurs at load time; on failure, the engine must not start. Validatio
 | ADR-0015 | Blueprint taxonomy flattened to domain-level folders with explicit subtype metadata                                    | §3.0.1         |
 | ADR-0014 | Workforce identities sourced via deterministic randomuser.me call with pseudodata fallback                             | §10.4          |
 | ADR-0013 | Workforce branch embedded in `SimulationWorld` with structured roles, employees, tasks, KPIs, warnings, payroll        | §3.3, §10      |
-| ADR-0012 | `.nvmrc`/`.node-version` pin Node.js 22 locally while CI enforces Node.js 23                                           | §0.1           |
+| ADR-0012 | `.nvmrc`/`.node-version` pin Node.js 22 (LTS) locally and CI uses Node.js 22 (LTS)                                           | §0.1           |
 | ADR-0011 | Device blueprints declare `effects`/config blocks copied to instances before pipeline evaluation                       | §3.0.1, §6.3   |
 | ADR-0010 | Zones persist PPFD/DLI telemetry updated by the canonical light emitter stub                                           | §6             |
 | ADR-0008 | Company metadata mandates location object with Hamburg defaults and coordinate clamps                                  | §1.2, §2       |

--- a/docs/engine/simulation-reporting.md
+++ b/docs/engine/simulation-reporting.md
@@ -25,7 +25,7 @@ Additional configuration for the orchestrator (e.g. custom world factories or st
 
 Set up the workspace before invoking the report generator:
 
-- Use **Node.js v22 or newer** so the CLI matches the repository engine baseline.
+- Use **Node.js 22 (LTS)** so the CLI matches the repository engine baseline.
 - Enable pnpm via Corepack with `corepack use pnpm@10.18.0`.
 - Install dependencies from the repository root using `pnpm install`.
 


### PR DESCRIPTION
## Summary
- update SEC, DD, AGENTS, changelog, and engine docs to standardize on Node.js 22 (LTS)
- add an ADR-0012 status note clarifying remaining Node 23 references are historical
- ensure local and CI policy statements now reflect the shared Node.js 22 (LTS) runtime

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e3651a21cc8325bdf9a180c602bf65