### PR TITLE
feat(task:0004): pest & disease risk MVP

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added `ICo2Injector`/`Co2InjectorStub`, enriched zone environment state with `co2_ppm`, and covered steady-state/ramp scenarios via `Co2InjectorStub.test.ts` and `co2Coupling.integration.test.ts`.
 - Added `.nvmrc`/`.node-version` markers pinning Node.js 22 (LTS) locally while CI uses Node.js 22 (LTS) (ADR-0012).
 - Embedded the deterministic workforce branch (roles, employees, tasks, KPIs, payroll) into world snapshots (ADR-0013).
+- Delivered the pest & disease MVP (Task 0004): deterministic zone risk scoring from environment/hygiene signals, automatic inspection/treatment task emission with 72 h quarantine windows, telemetry topics for risk/task events, and unit/integration coverage.
 - Implemented seeded workforce identity sourcing with a 500 ms randomuser.me timeout and pseudodata fallback (ADR-0014).
 - Flattened blueprint taxonomy to domain-level folders with explicit subtype metadata and migration tooling (ADR-0015).
 - Ratified the shadcn/ui + Tailwind + Radix UI stack (lucide icons, Framer Motion, Recharts/Tremor) for UI components (ADR-0016).

--- a/docs/SEC.md
+++ b/docs/SEC.md
@@ -485,6 +485,7 @@ Validation occurs at load time; on failure, the engine must not start. Validatio
 - **Risk accumulation:** Pests/diseases accumulate deterministic **risk scores** from environment and hygiene signals; no random outbreaks without RNG stream use.
 - **Inspections & treatments:** Represented as tasks with deterministic effects and cooldowns; successful treatments reduce risk and may impose quarantine intervals.
 - **Biosecurity hooks:** Room purposes and workflows may reduce cross-contamination via scheduled sanitation tasks. Telemetry surfaces warnings when risk exceeds thresholds.
+- **MVP implementation:** Zones track risk tiers (`low`/`moderate`/`high`) derived from environment + hygiene inputs. Moderate risk emits inspection tasks; high risk emits treatment tasks and applies a 72 h quarantine suppressing conflicting work. Telemetry publishes `telemetry.health.pest_disease.risk.v1` and `telemetry.health.pest_disease.task_emitted.v1` events so read-models/UI surface warnings.
 
 ---
 

--- a/packages/engine/src/backend/src/domain/entities.ts
+++ b/packages/engine/src/backend/src/domain/entities.ts
@@ -1,4 +1,5 @@
 import type { Inventory } from './types/Inventory.js';
+import type { HealthState } from './health/pestDisease.js';
 import type { WorkforceState } from './workforce/WorkforceState.js';
 
 /**
@@ -372,4 +373,6 @@ export interface SimulationWorld {
   readonly company: Company;
   /** Workforce directory, task queue, and KPI snapshots. */
   readonly workforce: WorkforceState;
+  /** Aggregated health state including pest and disease risk signals. */
+  readonly health?: HealthState;
 }

--- a/packages/engine/src/backend/src/domain/health/pestDisease.ts
+++ b/packages/engine/src/backend/src/domain/health/pestDisease.ts
@@ -1,0 +1,38 @@
+import type { Uuid } from '../entities.js';
+
+export type PestDiseaseRiskLevel = 'low' | 'moderate' | 'high';
+
+export interface PestDiseaseZoneRiskState {
+  readonly zoneId: Uuid;
+  readonly roomId: Uuid;
+  readonly structureId: Uuid;
+  readonly risk01: number;
+  readonly riskLevel: PestDiseaseRiskLevel;
+  readonly hygieneScore01: number;
+  readonly updatedTick: number;
+  readonly lastInspectionTick?: number;
+  readonly lastTreatmentTick?: number;
+  readonly quarantineUntilTick?: number;
+}
+
+export interface PestDiseaseHygieneSignal {
+  readonly roomId: Uuid;
+  readonly hygieneScore01: number;
+  readonly updatedTick: number;
+}
+
+export interface PestDiseaseSystemState {
+  readonly zoneRisks: readonly PestDiseaseZoneRiskState[];
+  readonly hygieneSignals: readonly PestDiseaseHygieneSignal[];
+}
+
+export interface HealthState {
+  readonly pestDisease: PestDiseaseSystemState;
+}
+
+export const DEFAULT_HEALTH_STATE: HealthState = {
+  pestDisease: {
+    zoneRisks: [],
+    hygieneSignals: [],
+  },
+};

--- a/packages/engine/src/backend/src/domain/world.ts
+++ b/packages/engine/src/backend/src/domain/world.ts
@@ -21,3 +21,4 @@ export * from './workforce/kpis.js';
 export * from './workforce/warnings.js';
 export * from './workforce/intents.js';
 export * from './workforce/traits.js';
+export * from './health/pestDisease.js';

--- a/packages/engine/src/backend/src/health/pestDiseaseRisk.ts
+++ b/packages/engine/src/backend/src/health/pestDiseaseRisk.ts
@@ -1,0 +1,87 @@
+import { clamp, clamp01 } from '../util/math.js';
+import type { ZoneEnvironment } from '../domain/world.js';
+import type { PestDiseaseRiskLevel } from '../domain/health/pestDisease.js';
+
+export interface PestDiseaseRiskInputs {
+  readonly environment: ZoneEnvironment;
+  readonly hygieneScore01: number;
+  readonly previousRisk01: number;
+  readonly isQuarantined: boolean;
+}
+
+export interface PestDiseaseRiskContributions {
+  readonly temperature: number;
+  readonly humidity: number;
+  readonly hygiene: number;
+  readonly decay: number;
+}
+
+export interface PestDiseaseRiskResult {
+  readonly risk01: number;
+  readonly contributions: PestDiseaseRiskContributions;
+}
+
+export const PEST_DISEASE_RISK_LEVEL_THRESHOLDS = {
+  moderate: 0.35,
+  high: 0.7,
+} as const;
+
+export const TEMPERATURE_COMFORT_RANGE_C = { min: 20, max: 26 } as const;
+export const HUMIDITY_COMFORT_RANGE_PCT = { min: 45, max: 60 } as const;
+export const MAX_TEMPERATURE_DEVIATION_C = 10;
+export const MAX_HUMIDITY_DEVIATION_PCT = 25;
+export const TEMPERATURE_WEIGHT = 0.35;
+export const HUMIDITY_WEIGHT = 0.25;
+export const HYGIENE_WEIGHT = 0.4;
+export const BASE_DECAY_RATE = 0.12;
+export const QUARANTINE_DECAY_BONUS = 0.18;
+
+function normalisedDeviation(value: number, range: { min: number; max: number }, maxDeviation: number): number {
+  const clamped = clamp(value, range.min, range.max);
+  const deviation = Math.abs(value - clamped);
+  if (maxDeviation <= 0) {
+    return 0;
+  }
+  return clamp01(deviation / maxDeviation);
+}
+
+export function resolveRiskLevel(risk01: number): PestDiseaseRiskLevel {
+  if (risk01 >= PEST_DISEASE_RISK_LEVEL_THRESHOLDS.high) {
+    return 'high';
+  }
+
+  if (risk01 >= PEST_DISEASE_RISK_LEVEL_THRESHOLDS.moderate) {
+    return 'moderate';
+  }
+
+  return 'low';
+}
+
+export function evaluatePestDiseaseRisk(inputs: PestDiseaseRiskInputs): PestDiseaseRiskResult {
+  const temperaturePressure =
+    normalisedDeviation(inputs.environment.airTemperatureC, TEMPERATURE_COMFORT_RANGE_C, MAX_TEMPERATURE_DEVIATION_C) *
+    TEMPERATURE_WEIGHT;
+  const humidityPressure =
+    normalisedDeviation(
+      inputs.environment.relativeHumidity_pct,
+      HUMIDITY_COMFORT_RANGE_PCT,
+      MAX_HUMIDITY_DEVIATION_PCT,
+    ) * HUMIDITY_WEIGHT;
+  const hygienePressure = clamp01(1 - clamp01(inputs.hygieneScore01)) * HYGIENE_WEIGHT;
+  const totalPressure = temperaturePressure + humidityPressure + hygienePressure;
+
+  const decayRate = BASE_DECAY_RATE + (inputs.isQuarantined ? QUARANTINE_DECAY_BONUS : 0);
+  const decay = clamp01(inputs.previousRisk01 * decayRate);
+  const retainedRisk = clamp01(inputs.previousRisk01 - decay);
+  const risk01 = clamp01(retainedRisk + totalPressure);
+
+  return {
+    risk01,
+    contributions: {
+      temperature: temperaturePressure,
+      humidity: humidityPressure,
+      hygiene: hygienePressure,
+      decay,
+    },
+  } satisfies PestDiseaseRiskResult;
+}

--- a/packages/engine/src/backend/src/health/pestDiseaseSystem.ts
+++ b/packages/engine/src/backend/src/health/pestDiseaseSystem.ts
@@ -1,0 +1,293 @@
+import { DEFAULT_HEALTH_STATE, type HealthState, type PestDiseaseRiskLevel } from '../domain/health/pestDisease.js';
+import type {
+  Room,
+  SimulationWorld,
+  Structure,
+  WorkforceState,
+  WorkforceTaskInstance,
+  Zone,
+} from '../domain/world.js';
+import { evaluatePestDiseaseRisk, resolveRiskLevel } from './pestDiseaseRisk.js';
+import { deterministicUuid } from '../util/uuid.js';
+
+export const PEST_INSPECTION_TASK_CODE = 'task.pest.inspection';
+export const PEST_TREATMENT_TASK_CODE = 'task.pest.treatment';
+export const INSPECTION_COOLDOWN_HOURS = 24;
+export const TREATMENT_COOLDOWN_HOURS = 72;
+export const QUARANTINE_DURATION_HOURS = 72;
+export const INSPECTION_DUE_OFFSET_HOURS = 12;
+export const TREATMENT_DUE_OFFSET_HOURS = 6;
+export const DEFAULT_ROOM_HYGIENE_SCORE01 = 0.85;
+
+export interface PestDiseaseRiskWarning {
+  readonly structureId: Structure['id'];
+  readonly roomId: Room['id'];
+  readonly zoneId: Zone['id'];
+  readonly riskLevel: PestDiseaseRiskLevel;
+  readonly risk01: number;
+  readonly tick: number;
+}
+
+export interface PestDiseaseTaskEvent {
+  readonly taskId: WorkforceTaskInstance['id'];
+  readonly taskCode: WorkforceTaskInstance['taskCode'];
+  readonly structureId: Structure['id'];
+  readonly roomId: Room['id'];
+  readonly zoneId: Zone['id'];
+  readonly tick: number;
+  readonly riskLevel: PestDiseaseRiskLevel;
+  readonly risk01: number;
+}
+
+export interface PestDiseaseEvaluationResult {
+  readonly health: HealthState;
+  readonly scheduledTasks: readonly WorkforceTaskInstance[];
+  readonly warnings: readonly PestDiseaseRiskWarning[];
+  readonly taskEvents: readonly PestDiseaseTaskEvent[];
+}
+
+interface HygieneSignalLookup {
+  readonly hygieneScore01: number;
+  readonly updatedTick: number;
+}
+
+function collectHygieneSignals(world: SimulationWorld): Map<Room['id'], HygieneSignalLookup> {
+  const signals = new Map<Room['id'], HygieneSignalLookup>();
+  const health = world.health ?? DEFAULT_HEALTH_STATE;
+  for (const entry of health.pestDisease.hygieneSignals) {
+    signals.set(entry.roomId, { hygieneScore01: entry.hygieneScore01, updatedTick: entry.updatedTick });
+  }
+  return signals;
+}
+
+function resolveHygieneScore(
+  roomId: Room['id'],
+  hygieneSignals: Map<Room['id'], HygieneSignalLookup>,
+): number {
+  const signal = hygieneSignals.get(roomId);
+  if (!signal) {
+    return DEFAULT_ROOM_HYGIENE_SCORE01;
+  }
+  return signal.hygieneScore01;
+}
+
+function indexExistingTasks(tasks: readonly WorkforceTaskInstance[]): Set<WorkforceTaskInstance['id']> {
+  return new Set(tasks.map((task) => task.id));
+}
+
+function findDefinition(
+  workforce: WorkforceState | undefined,
+  taskCode: string,
+): WorkforceTaskInstance['taskCode'] | undefined {
+  const definition = workforce?.taskDefinitions.find((entry) => entry.taskCode === taskCode);
+  return definition?.taskCode;
+}
+
+function shouldSchedule(
+  lastTick: number | undefined,
+  currentTick: number,
+  cooldown: number,
+): boolean {
+  if (!Number.isFinite(currentTick)) {
+    return false;
+  }
+  if (lastTick === undefined) {
+    return true;
+  }
+  return currentTick - lastTick >= cooldown;
+}
+
+function isQuarantined(quarantineUntilTick: number | undefined, currentTick: number): boolean {
+  return quarantineUntilTick !== undefined && quarantineUntilTick > currentTick;
+}
+
+function createTaskId(
+  worldSeed: string,
+  taskCode: WorkforceTaskInstance['taskCode'],
+  zoneId: Zone['id'],
+  currentTick: number,
+): WorkforceTaskInstance['id'] {
+  return deterministicUuid(worldSeed, `pest:${taskCode}:${zoneId}:${currentTick}`);
+}
+
+function buildTask(
+  worldSeed: string,
+  taskCode: WorkforceTaskInstance['taskCode'],
+  zone: Zone,
+  room: Room,
+  structure: Structure,
+  currentTick: number,
+  riskLevel: PestDiseaseRiskLevel,
+  risk01: number,
+  dueOffset: number,
+): WorkforceTaskInstance {
+  const id = createTaskId(worldSeed, taskCode, zone.id, currentTick);
+  const dueTick = Math.max(currentTick, currentTick + dueOffset);
+  return {
+    id,
+    taskCode,
+    status: 'queued',
+    createdAtTick: currentTick,
+    dueTick,
+    context: {
+      structureId: structure.id,
+      roomId: room.id,
+      zoneId: zone.id,
+      riskLevel,
+      risk01,
+    },
+  } satisfies WorkforceTaskInstance;
+}
+
+export function evaluatePestDiseaseSystem(
+  world: SimulationWorld,
+  currentTick: number,
+): PestDiseaseEvaluationResult {
+  const health = world.health ?? DEFAULT_HEALTH_STATE;
+  const hygieneSignals = collectHygieneSignals(world);
+  const previousRiskStates = new Map(
+    health.pestDisease.zoneRisks.map((entry) => [entry.zoneId, entry]),
+  );
+  const existingTaskIds = indexExistingTasks(world.workforce?.taskQueue ?? []);
+  const supportsInspection = Boolean(findDefinition(world.workforce, PEST_INSPECTION_TASK_CODE));
+  const supportsTreatment = Boolean(findDefinition(world.workforce, PEST_TREATMENT_TASK_CODE));
+
+  const scheduledTasks: WorkforceTaskInstance[] = [];
+  const warnings: PestDiseaseRiskWarning[] = [];
+  const taskEvents: PestDiseaseTaskEvent[] = [];
+  const updatedRiskStates: typeof health.pestDisease.zoneRisks = [];
+
+  for (const structure of world.company.structures) {
+    for (const room of structure.rooms) {
+      for (const zone of room.zones) {
+        const previous = previousRiskStates.get(zone.id);
+        const previousRisk01 = previous?.risk01 ?? 0;
+        const quarantineUntilTick = previous?.quarantineUntilTick;
+        const zoneIsQuarantined = isQuarantined(quarantineUntilTick, currentTick);
+        const hygieneScore01 = resolveHygieneScore(room.id, hygieneSignals);
+
+        const evaluation = evaluatePestDiseaseRisk({
+          environment: zone.environment,
+          hygieneScore01,
+          previousRisk01,
+          isQuarantined: zoneIsQuarantined,
+        });
+
+        const riskLevel = resolveRiskLevel(evaluation.risk01);
+        let nextInspectionTick = previous?.lastInspectionTick;
+        let nextTreatmentTick = previous?.lastTreatmentTick;
+        let nextQuarantineUntilTick = quarantineUntilTick;
+
+        if (riskLevel !== 'low') {
+          warnings.push({
+            structureId: structure.id,
+            roomId: room.id,
+            zoneId: zone.id,
+            riskLevel,
+            risk01: evaluation.risk01,
+            tick: currentTick,
+          });
+        }
+
+        if (
+          supportsInspection &&
+          riskLevel !== 'low' &&
+          shouldSchedule(nextInspectionTick, currentTick, INSPECTION_COOLDOWN_HOURS)
+        ) {
+          const task = buildTask(
+            world.seed,
+            PEST_INSPECTION_TASK_CODE,
+            zone,
+            room,
+            structure,
+            currentTick,
+            riskLevel,
+            evaluation.risk01,
+            INSPECTION_DUE_OFFSET_HOURS,
+          );
+
+          if (!existingTaskIds.has(task.id)) {
+            scheduledTasks.push(task);
+            existingTaskIds.add(task.id);
+            taskEvents.push({
+              taskId: task.id,
+              taskCode: task.taskCode,
+              structureId: structure.id,
+              roomId: room.id,
+              zoneId: zone.id,
+              tick: currentTick,
+              riskLevel,
+              risk01: evaluation.risk01,
+            });
+          }
+
+          nextInspectionTick = currentTick;
+        }
+
+        if (
+          supportsTreatment &&
+          riskLevel === 'high' &&
+          !zoneIsQuarantined &&
+          shouldSchedule(nextTreatmentTick, currentTick, TREATMENT_COOLDOWN_HOURS)
+        ) {
+          const task = buildTask(
+            world.seed,
+            PEST_TREATMENT_TASK_CODE,
+            zone,
+            room,
+            structure,
+            currentTick,
+            riskLevel,
+            evaluation.risk01,
+            TREATMENT_DUE_OFFSET_HOURS,
+          );
+
+          if (!existingTaskIds.has(task.id)) {
+            scheduledTasks.push(task);
+            existingTaskIds.add(task.id);
+            taskEvents.push({
+              taskId: task.id,
+              taskCode: task.taskCode,
+              structureId: structure.id,
+              roomId: room.id,
+              zoneId: zone.id,
+              tick: currentTick,
+              riskLevel,
+              risk01: evaluation.risk01,
+            });
+          }
+
+          nextTreatmentTick = currentTick;
+          nextQuarantineUntilTick = currentTick + QUARANTINE_DURATION_HOURS;
+        }
+
+        updatedRiskStates.push({
+          zoneId: zone.id,
+          roomId: room.id,
+          structureId: structure.id,
+          risk01: evaluation.risk01,
+          riskLevel,
+          hygieneScore01,
+          updatedTick: currentTick,
+          lastInspectionTick: nextInspectionTick,
+          lastTreatmentTick: nextTreatmentTick,
+          quarantineUntilTick: nextQuarantineUntilTick,
+        });
+      }
+    }
+  }
+
+  const nextHealth: HealthState = {
+    pestDisease: {
+      zoneRisks: updatedRiskStates,
+      hygieneSignals: health.pestDisease.hygieneSignals,
+    },
+  };
+
+  return {
+    health: nextHealth,
+    scheduledTasks,
+    warnings,
+    taskEvents,
+  } satisfies PestDiseaseEvaluationResult;
+}

--- a/packages/engine/src/backend/src/telemetry/health.ts
+++ b/packages/engine/src/backend/src/telemetry/health.ts
@@ -1,0 +1,39 @@
+import type { TelemetryBus } from '../engine/Engine.js';
+import type {
+  PestDiseaseRiskWarning,
+  PestDiseaseTaskEvent,
+} from '../health/pestDiseaseSystem.js';
+import {
+  TELEMETRY_HEALTH_PEST_DISEASE_RISK_V1,
+  TELEMETRY_HEALTH_PEST_DISEASE_TASK_V1,
+} from './topics.js';
+
+function emitEvent(
+  bus: TelemetryBus | undefined,
+  topic: string,
+  payload: Record<string, unknown>,
+): void {
+  bus?.emit(topic, payload);
+}
+
+export function emitPestDiseaseRiskWarnings(
+  bus: TelemetryBus | undefined,
+  warnings: readonly PestDiseaseRiskWarning[],
+): void {
+  if (!bus || warnings.length === 0) {
+    return;
+  }
+
+  emitEvent(bus, TELEMETRY_HEALTH_PEST_DISEASE_RISK_V1, { warnings });
+}
+
+export function emitPestDiseaseTaskEvents(
+  bus: TelemetryBus | undefined,
+  events: readonly PestDiseaseTaskEvent[],
+): void {
+  if (!bus || events.length === 0) {
+    return;
+  }
+
+  emitEvent(bus, TELEMETRY_HEALTH_PEST_DISEASE_TASK_V1, { events });
+}

--- a/packages/engine/src/backend/src/telemetry/topics.ts
+++ b/packages/engine/src/backend/src/telemetry/topics.ts
@@ -17,3 +17,7 @@ export const TELEMETRY_WORKFORCE_RAISE_IGNORED_V1 =
   'telemetry.workforce.raise.ignored.v1' as const;
 export const TELEMETRY_WORKFORCE_EMPLOYEE_TERMINATED_V1 =
   'telemetry.workforce.employee.terminated.v1' as const;
+export const TELEMETRY_HEALTH_PEST_DISEASE_RISK_V1 =
+  'telemetry.health.pest_disease.risk.v1' as const;
+export const TELEMETRY_HEALTH_PEST_DISEASE_TASK_V1 =
+  'telemetry.health.pest_disease.task_emitted.v1' as const;

--- a/packages/engine/tests/integration/pipeline/pestDiseaseMvp.integration.test.ts
+++ b/packages/engine/tests/integration/pipeline/pestDiseaseMvp.integration.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest';
+
+import { PIPELINE_ORDER, type EngineRunContext } from '@/backend/src/engine/Engine.js';
+import { createDemoWorld, runStages } from '@/backend/src/engine/testHarness.js';
+import {
+  PEST_INSPECTION_TASK_CODE,
+  PEST_TREATMENT_TASK_CODE,
+} from '@/backend/src/health/pestDiseaseSystem.js';
+import type {
+  EmployeeRole,
+  HealthState,
+  SimulationWorld,
+  WorkforceState,
+  WorkforceTaskDefinition,
+  WorkforceTaskInstance,
+  Zone,
+} from '@/backend/src/domain/world.js';
+
+function createRole(): EmployeeRole {
+  return {
+    id: '00000000-0000-0000-0000-00000000d001' as EmployeeRole['id'],
+    slug: 'biosecurity_specialist',
+    name: 'Biosecurity Specialist',
+    coreSkills: [{ skillKey: 'cleanliness', minSkill01: 0.5 }],
+  } satisfies EmployeeRole;
+}
+
+function createInspectionDefinition(): WorkforceTaskDefinition {
+  return {
+    taskCode: PEST_INSPECTION_TASK_CODE,
+    description: 'Inspect grow zone for pest activity',
+    requiredRoleSlug: 'biosecurity_specialist',
+    requiredSkills: [{ skillKey: 'cleanliness', minSkill01: 0.4 }],
+    priority: 85,
+    costModel: { basis: 'perSquareMeter', laborMinutes: 24 },
+  } satisfies WorkforceTaskDefinition;
+}
+
+function createTreatmentDefinition(): WorkforceTaskDefinition {
+  return {
+    taskCode: PEST_TREATMENT_TASK_CODE,
+    description: 'Apply integrated pest management treatment',
+    requiredRoleSlug: 'biosecurity_specialist',
+    requiredSkills: [{ skillKey: 'gardening', minSkill01: 0.5 }],
+    priority: 95,
+    costModel: { basis: 'perSquareMeter', laborMinutes: 36 },
+  } satisfies WorkforceTaskDefinition;
+}
+
+function rebuildWorldForScenario(baseWorld: SimulationWorld): SimulationWorld {
+  const structure = baseWorld.company.structures[0];
+  const room = structure.rooms[0];
+  const zone = room.zones[0];
+
+  const updatedZone: Zone = {
+    ...zone,
+    environment: {
+      ...zone.environment,
+      airTemperatureC: 31,
+      relativeHumidity_pct: 85,
+    },
+  };
+
+  const updatedRoom = {
+    ...room,
+    zones: room.zones.map((entry) => (entry.id === zone.id ? updatedZone : entry)),
+  } satisfies typeof room;
+
+  const updatedStructure = {
+    ...structure,
+    rooms: structure.rooms.map((entry) => (entry.id === room.id ? updatedRoom : entry)),
+  } satisfies typeof structure;
+
+  const updatedCompany = {
+    ...baseWorld.company,
+    structures: baseWorld.company.structures.map((entry) =>
+      entry.id === structure.id ? updatedStructure : entry,
+    ),
+  } satisfies typeof baseWorld.company;
+
+  const workforceRole = createRole();
+  const inspectionDefinition = createInspectionDefinition();
+  const treatmentDefinition = createTreatmentDefinition();
+
+  const baseWorkforce = baseWorld.workforce;
+  const workforce: WorkforceState = {
+    ...baseWorkforce,
+    roles: [workforceRole],
+    employees: [],
+    taskDefinitions: [inspectionDefinition, treatmentDefinition],
+    taskQueue: [],
+    kpis: [],
+    warnings: [],
+  } satisfies WorkforceState;
+
+  const health: HealthState = {
+    pestDisease: {
+      zoneRisks: [],
+      hygieneSignals: [
+        {
+          roomId: room.id,
+          hygieneScore01: 0.35,
+          updatedTick: baseWorld.simTimeHours,
+        },
+      ],
+    },
+  } satisfies HealthState;
+
+  return {
+    ...baseWorld,
+    company: updatedCompany,
+    workforce,
+    health,
+  } satisfies SimulationWorld;
+}
+
+describe('pest & disease system MVP integration', () => {
+  it('accumulates risk, emits tasks, and enforces quarantine windows', () => {
+    let world = rebuildWorldForScenario(createDemoWorld());
+    const maybeZoneId = world.company.structures[0]?.rooms[0]?.zones[0]?.id;
+    expect(maybeZoneId).toBeDefined();
+    const targetZoneId = maybeZoneId as Zone['id'];
+    const telemetryEvents: { topic: string; payload: any }[] = [];
+    const ctx: EngineRunContext = {
+      telemetry: {
+        emit(topic, payload) {
+          telemetryEvents.push({ topic, payload });
+        },
+      },
+    } satisfies EngineRunContext;
+
+    const queueSizes: number[] = [];
+    const riskLevels: string[] = [];
+    const riskValues: number[] = [];
+
+    for (let tick = 0; tick < 3; tick += 1) {
+      world = runStages(world, ctx, PIPELINE_ORDER);
+      queueSizes.push(world.workforce.taskQueue.length);
+
+      const riskState = world.health?.pestDisease.zoneRisks.find(
+        (entry) => entry.zoneId === targetZoneId,
+      );
+      expect(riskState).toBeDefined();
+      riskLevels.push(riskState?.riskLevel ?? 'low');
+      riskValues.push(riskState?.risk01 ?? 0);
+
+      if (tick === 1) {
+        expect(riskState?.quarantineUntilTick).toBeGreaterThan(world.simTimeHours);
+      }
+    }
+
+    expect(riskLevels[0]).toBe('moderate');
+    expect(riskLevels[1]).toBe('high');
+    expect(riskLevels[2]).toBe('high');
+    expect(queueSizes[0]).toBe(1);
+    expect(queueSizes[1]).toBe(2);
+    expect(queueSizes[2]).toBe(2);
+    expect(riskValues[1]).toBeGreaterThan(riskValues[0]);
+
+    const inspectionTask = world.workforce.taskQueue.find(
+      (task) => task.taskCode === PEST_INSPECTION_TASK_CODE,
+    ) as WorkforceTaskInstance | undefined;
+    const treatmentTask = world.workforce.taskQueue.find(
+      (task) => task.taskCode === PEST_TREATMENT_TASK_CODE,
+    ) as WorkforceTaskInstance | undefined;
+
+    expect(inspectionTask).toBeDefined();
+    expect(treatmentTask).toBeDefined();
+    expect(treatmentTask?.dueTick).toBeGreaterThanOrEqual(treatmentTask?.createdAtTick ?? 0);
+
+    const riskEvents = telemetryEvents.filter(
+      (entry) => entry.topic === 'telemetry.health.pest_disease.risk.v1',
+    );
+    const taskEvents = telemetryEvents.filter(
+      (entry) => entry.topic === 'telemetry.health.pest_disease.task_emitted.v1',
+    );
+
+    expect(riskEvents.length).toBeGreaterThanOrEqual(3);
+    expect(taskEvents.length).toBe(2);
+
+    const firstRiskLevel = riskEvents[0]?.payload.warnings[0]?.riskLevel;
+    const secondRiskLevel = riskEvents[1]?.payload.warnings[0]?.riskLevel;
+    expect(firstRiskLevel).toBe('moderate');
+    expect(secondRiskLevel).toBe('high');
+
+    const emittedTaskCodes = taskEvents.flatMap((entry) =>
+      entry.payload.events.map((event: any) => event.taskCode),
+    );
+    expect(emittedTaskCodes).toEqual([
+      PEST_INSPECTION_TASK_CODE,
+      PEST_TREATMENT_TASK_CODE,
+    ]);
+  });
+});

--- a/packages/engine/tests/unit/health/pestDiseaseRisk.spec.ts
+++ b/packages/engine/tests/unit/health/pestDiseaseRisk.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  evaluatePestDiseaseRisk,
+  resolveRiskLevel,
+  PEST_DISEASE_RISK_LEVEL_THRESHOLDS,
+} from '@/backend/src/health/pestDiseaseRisk.js';
+
+const IDEAL_ENVIRONMENT = {
+  airTemperatureC: 23,
+  relativeHumidity_pct: 55,
+  co2_ppm: 400,
+} as const;
+
+describe('pest & disease risk evaluation', () => {
+  it('returns zero risk when environment and hygiene are ideal', () => {
+    const result = evaluatePestDiseaseRisk({
+      environment: IDEAL_ENVIRONMENT,
+      hygieneScore01: 1,
+      previousRisk01: 0,
+      isQuarantined: false,
+    });
+
+    expect(result.risk01).toBe(0);
+    expect(resolveRiskLevel(result.risk01)).toBe('low');
+  });
+
+  it('escalates risk with poor humidity and hygiene signals', () => {
+    const result = evaluatePestDiseaseRisk({
+      environment: {
+        airTemperatureC: 30,
+        relativeHumidity_pct: 85,
+        co2_ppm: 400,
+      },
+      hygieneScore01: 0.3,
+      previousRisk01: 0.1,
+      isQuarantined: false,
+    });
+
+    expect(result.risk01).toBeGreaterThan(PEST_DISEASE_RISK_LEVEL_THRESHOLDS.moderate);
+    expect(resolveRiskLevel(result.risk01)).toBe('high');
+  });
+
+  it('applies additional decay when the zone is quarantined', () => {
+    const activeRisk = evaluatePestDiseaseRisk({
+      environment: {
+        airTemperatureC: 28,
+        relativeHumidity_pct: 75,
+        co2_ppm: 400,
+      },
+      hygieneScore01: 0.6,
+      previousRisk01: 0.8,
+      isQuarantined: false,
+    });
+
+    const quarantinedRisk = evaluatePestDiseaseRisk({
+      environment: {
+        airTemperatureC: 24,
+        relativeHumidity_pct: 50,
+        co2_ppm: 400,
+      },
+      hygieneScore01: 0.9,
+      previousRisk01: activeRisk.risk01,
+      isQuarantined: true,
+    });
+
+    expect(quarantinedRisk.risk01).toBeLessThan(activeRisk.risk01);
+    const levelRank = { low: 0, moderate: 1, high: 2 } as const;
+    const baselineLevel = resolveRiskLevel(activeRisk.risk01);
+    const quarantinedLevel = resolveRiskLevel(quarantinedRisk.risk01);
+    expect(levelRank[quarantinedLevel]).toBeLessThanOrEqual(levelRank[baselineLevel]);
+  });
+});


### PR DESCRIPTION
## Summary
- add pest & disease health state, deterministic risk scoring, and telemetry topics
- schedule inspection/treatment tasks with quarantine logic during applyWorkforce
- cover risk scoring and pipeline behaviour with new unit/integration tests and documentation updates

## SEC / TDD Sections
- SEC §8.5
- TDD §7

## Testing
- `pnpm --filter @wb/engine exec vitest run tests/unit/health/pestDiseaseRisk.spec.ts`
- `pnpm --filter @wb/engine exec vitest run tests/integration/pipeline/pestDiseaseMvp.integration.test.ts`
- `pnpm i`
- `pnpm -r lint` *(fails: existing lint backlog in repo)*
- `pnpm -r build` *(fails: facade tsconfig excludes engine outputs in current repo state)*
- `pnpm -r test` *(fails: missing golden fixtures & legacy stub expectations in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ddfe94808325a71082c0a7084914