### PR TITLE
feat(task:0004): clarify determinism scaffolds scope

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Unreleased — Blueprint Taxonomy v2
 
+- Added test-only determinism helper scaffolds (`hashCanonicalJson`, `newV7`) for
+  hashing canonical JSON payloads and generating UUIDv7 identifiers without
+  impacting runtime flows (Task 0007).
 - Rebuilt the Golden Master conformance suite (Task 0003): generated deterministic 30d/200d fixtures via `generateGoldenScenarioRun`, updated `runDeterministic` to validate fixtures or emit artifacts, expanded conformance specs to assert topology coverage/ACH, inventory transfer, workforce breaks/janitorial cadence, and documented artifact paths in SEC/TDD/task notes.
 - Locked canonical geometry, calendar, thermodynamic, and HQ defaults in `simConstants.ts` with documented precedence flow (ADR-0001).
 - Anchored irrigation/substrate compatibility to irrigation method blueprints and removed substrate-level lists (ADR-0003).

--- a/packages/engine/src/shared/determinism/hash.ts
+++ b/packages/engine/src/shared/determinism/hash.ts
@@ -17,6 +17,10 @@ async function getHashApi() {
  *
  * The current `xxhash-wasm` release exposes 64-bit helpers. To keep the footprint
  * deterministic we concatenate two 64-bit digests seeded with distinct constants.
+ *
+ * NOTE: This helper is intended for test scaffolding only. Production subsystems should
+ * continue to rely on the existing deterministic UUID services until an ADR approves
+ * runtime adoption.
  */
 export async function hashCanonicalJson(value: unknown): Promise<string> {
   const canonical = stringify(value);

--- a/packages/engine/src/shared/determinism/ids.ts
+++ b/packages/engine/src/shared/determinism/ids.ts
@@ -3,6 +3,8 @@ import { v7 as uuidv7 } from 'uuid';
 /**
  * Generate a UUIDv7 identifier. Wrapper exists so production code can swap
  * implementations after design review.
+ *
+ * NOTE: This helper is scoped to test scaffolding until an ADR unlocks runtime usage.
  */
 export function newV7(): string {
   return uuidv7();

--- a/packages/engine/tests/unit/shared/determinism/hash.test.ts
+++ b/packages/engine/tests/unit/shared/determinism/hash.test.ts
@@ -28,4 +28,10 @@ describe('hashCanonicalJson', () => {
 
     expect(hashA).not.toBe(hashB);
   });
+
+  it('rejects values that cannot be canonicalised', async () => {
+    await expect(hashCanonicalJson(() => undefined)).rejects.toThrow(
+      /could not be canonicalised/u
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- flag the shared `hashCanonicalJson` and `newV7` helpers as test-only scaffolds pending ADR approval
- extend the determinism unit spec suite with a rejection case for non-canonicalisable inputs
- document the availability of the scaffolds in the changelog for discoverability

## SEC/TDD Sections
- TDD §Shared determinism helpers

## Testing
- `pnpm i`
- `pnpm -r lint` *(fails: @wb/facade lint violations unrelated to this change)*
- `pnpm --reporter append-only -r build` *(fails: @wb/facade TypeScript rootDir/includes misalignment unrelated to this change)*
- `pnpm --reporter append-only -r test` *(fails: existing missing golden fixtures and Co2Injector stub expectations in @wb/engine plus @wb/tools lacking tests)*
- `pnpm --filter @wb/engine exec vitest run tests/unit/shared/determinism/hash.test.ts`

## Deviations
- Full workspace lint/build/test remain red due to pre-existing issues in @wb/facade, @wb/engine conformance fixtures, and @wb/tools. Focused engine unit coverage for the updated helpers is green.


------
https://chatgpt.com/codex/tasks/task_e_68e40803eec483259e5c030a3506b227