### PR TITLE
feat(task:0008): add package audit reporting matrix CLI

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,7 +23,7 @@
 - Ratified the shadcn/ui + Tailwind + Radix UI stack (lucide icons, Framer Motion, Recharts/Tremor) for UI components (ADR-0016).
 - Added crash-safe save/load scaffolding with schema versioning, migration registry (v0→v1), canonical fixtures (`packages/engine/tests/fixtures/save/v*`), and `/data/savegames/` repository path documentation (Task 0005).
 - Added a deterministic conformance harness (`runDeterministic`) with committed golden fixtures (`packages/engine/tests/fixtures/golden/30d`, `.../200d`) and Vitest specs (`goldenMaster.30d.spec.ts`, `goldenMaster.200d.spec.ts`) wired to `pnpm --filter @wb/engine test:conf:30d`/`test:conf:200d`.
-- Added package audit report & deterministic scaffolds (no runtime behaviour change) to validate candidate dependencies.
+- Captured Task 0008 package audit matrix with `pnpm report:packages`, documenting the deterministic CLI + Markdown pairing without runtime behaviour changes.
 - Populated SEC Appendix B with a complete crosswalk of legacy `/docs/tasks/**` proposals and noted the contradictions log location.
 
 - Docs: standardized blueprint folders to max two levels under /data/blueprints (no deeper subfolders).

--- a/docs/DD.md
+++ b/docs/DD.md
@@ -21,6 +21,7 @@ Local version markers (`.nvmrc`, `.node-version`) pin Node.js 22 (LTS) for both 
 
 - Deterministic simulation with reproducible seeds and stream‑scoped RNG.
 - Test-only determinism scaffolds (`hashCanonicalJson`, `newV7`) live under `packages/engine/src/shared/determinism` until an ADR approves runtime adoption (see [docs/tasks/0007-determinism-helper-scaffolds.md](docs/tasks/0007-determinism-helper-scaffolds.md)).
+- Tooling CLI (`pnpm report:packages`) produces a deterministic package audit matrix stored in `docs/reports/PACKAGE_AUDIT.md` without introducing runtime imports.
 - Strict conformance to **per‑hour** economic units; tick derives from hours.
 - Clean separation of **engine** (no I/O) and **façade/transport**.
 - Enforce **roomPurpose**, **device placement**, and **zone cultivationMethod** rules.

--- a/docs/TDD.md
+++ b/docs/TDD.md
@@ -58,6 +58,7 @@ src/
 - **Coverage threshold:** 90% lines/branches in `engine/` and `facade/`; 80% overall.
 - **Snapshot location:** `__snapshots__` next to specs (only for low‑volatility payloads; prefer golden JSON files for world states).
 - **Blueprint fixtures:** Repository fixtures **MUST** live inside the domain folders that mirror their `class` (`device/climate/*.json`, `cultivation-method/*.json`, `room/purpose/*.json`, etc.). Specs walk `/data/blueprints/**` to assert the folder-derived taxonomy matches the JSON declaration and fail fast when contributors park files elsewhere.
+- **Tooling audits:** `packages/tools/tests/packageAudit.test.ts` keeps `docs/reports/PACKAGE_AUDIT.md` in sync with the CLI generator so `pnpm report:packages` remains deterministic documentation-only tooling.
 
 Blueprint directory rule: All blueprints are auto-discovered under /data/blueprints/<domain>/<file>.json with a maximum depth of two segments (domain + file). Devices are /data/blueprints/device/<category>.json or /data/blueprints/device/<category>/<file>.json limited to two levels; no deeper subfolders are allowed.
 - **Save/load fixtures:** Legacy/current save snapshots live under `packages/engine/tests/fixtures/save/v*/`. Unit specs in `tests/unit/save/` exercise schema guards and crash-safe writes; integration specs in `tests/integration/saveLoad/` load fixtures, apply migrations, and assert canonical hashes stay stable across versions.

--- a/docs/reports/PACKAGE_AUDIT.md
+++ b/docs/reports/PACKAGE_AUDIT.md
@@ -1,62 +1,80 @@
-# Package Audit — Seed Tooling (AJV-free)
+# Package Audit & Reporting Matrix
 
-_Audit date: 2025-10-06T07:03:26Z_
+_Generated via `pnpm report:packages` — deterministic snapshot of candidate tooling dependencies._
 
 ## Scope & Inputs
 
 - Parsed `package.json` for the root workspace and `packages/*` (pnpm workspaces).
-- Parsed `pnpm-lock.yaml` to resolve the concrete versions per importer.
-- Parsed `package-lock.json` (no candidates present — legacy file only).
+- Parsed `pnpm-lock.yaml` to resolve locked versions per importer.
 - Searched `packages/*/src/**` for direct imports/requires of candidate packages.
+- Classified candidates into Greenlist / Review / Skip buckets with rationale.
 
 ## Findings
 
-| Package | Wanted | Installed? | Version | Location(s) | Direct Usage?* | Notes |
-| --- | --- | --- | --- | --- | --- | --- |
-| `uuid` | `^9` | ✅ | `13.0.0` | `@wb/engine` (`dependencies`) | `@wb/engine: packages/engine/src/shared/determinism/ids.ts` | Existing sha256-based `deterministicUuid` helper under `packages/engine/src/backend/src/util/uuid.ts`; coordinate before replacing runtime code. v7 API required bumping to the `13.x` stream. |
-| `xxhash-wasm` | `^1` | ✅ | `1.1.0` | `@wb/engine` (`dependencies`) | `@wb/engine: packages/engine/src/shared/determinism/hash.ts` | Current npm release only exposes 64-bit helpers; stub composes 128-bit output via dual seeds. |
-| `safe-stable-stringify` | `^2` | ✅ | `2.5.0` | `@wb/engine` (`dependencies`) | `@wb/engine: packages/engine/src/shared/determinism/hash.ts` | |
-| `globby` | `^14` | ✅ | `14.1.0` | `@wb/tools` (`dependencies`) | `@wb/tools: packages/tools/src/lib/packageAudit.ts` | |
-| `psychrolib` | `^2` | ✅ | `1.1.0` | `@wb/engine` (`dependencies`) | `@wb/engine: packages/engine/src/shared/psychro/psychro.ts` | Upstream has not published the `^2` train yet; holding on `1.1.0`. Review before promoting beyond test scaffolds. |
-| `mathjs` | `^13` | ❌ | — | — | — | Tree-shake via named imports only when introduced. |
-| `@turf/turf` | `^7` | ❌ | — | — | — | |
-| `zod-to-json-schema` | `^3` | ❌ | — | — | — | |
-| `type-fest` | `^4` | ❌ | — | — | — | |
-| `rxjs` | `^7` | ❌ | — | — | — | |
-| `mitt` | `^3` | ❌ | — | — | — | |
-| `eventemitter3` | `^5` | ❌ | — | — | — | |
-| `commander` | `^12` | ✅ | `12.1.0` | `@wb/tools` (`dependencies`) | `@wb/tools: packages/tools/src/cli/report.ts` | |
-| `pino` | `^9` | ✅ | `9.13.1` | `@wb/tools` (`dependencies`) | `@wb/tools: packages/tools/src/lib/logger.ts` | Pretty transport disabled by default; opt-in via env. |
-| `pino-pretty` | `^11` | ✅ | `11.3.0` | `@wb/tools` (`dependencies`) | — | Wired as optional transport target only. |
-| `cli-table3` | `^0.6` | ✅ | `0.6.5` | `@wb/tools` (`dependencies`) | `@wb/tools: packages/tools/src/cli/report.ts` | |
-| `fast-check` | `^3` | ✅ | `3.23.2` | `@wb/engine` (`devDependencies`) | — | Tests-only; no production import. |
-| `vitest-fetch-mock` | `^0.4` | ❌ | — | — | — | |
-| `msw` | `^2` | ❌ | — | — | — | |
-| `neo-blessed` | `^0.2` | ❌ | — | — | — | Optional monitor tooling; defer until terminal UX sprint. |
-| `blessed-contrib` | `^5` | ❌ | — | — | — | Optional monitor tooling; defer until terminal UX sprint. |
+| Package | Wanted | Installed? | Version(s) | Location(s) | Direct Usage?* | Category | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `uuid` | `^9` | ✅ | `13.0.0` | @wb/engine (dependencies) | @wb/engine: packages/engine/src/shared/determinism/ids.ts | Greenlist | Existing sha256-based deterministicUuid helper lives under packages/engine/src/backend/src/util/uuid.ts.<br>Deterministic scaffolds only; keep parity with existing helpers before touching runtime flows.<br>Installed range diverges from prompt target; verify before rollout. |
+| `xxhash-wasm` | `^1` | ✅ | `1.1.0` | @wb/engine (dependencies) | @wb/engine: packages/engine/src/shared/determinism/hash.ts | Greenlist | Current release exposes 64-bit helpers only; 128-bit hash composed via dual seeds.<br>Test-only hashing helper; aligns with deterministic checksum scaffolds without runtime hooks yet. |
+| `safe-stable-stringify` | `^2` | ✅ | `2.5.0` | @wb/engine (dependencies) | @wb/engine: packages/engine/src/backend/src/engine/conformance/goldenScenario.ts<br>@wb/engine: packages/engine/src/backend/src/engine/conformance/runDeterministic.ts<br>@wb/engine: packages/engine/src/backend/src/saveLoad/saveManager.ts<br>@wb/engine: packages/engine/src/shared/determinism/hash.ts | Greenlist | Used for canonical JSON hashing in tests; no production wiring planned until determinism ADR. |
+| `globby` | `^14` | ✅ | `14.1.0` | @wb/tools (dependencies) | @wb/tools: packages/tools/src/lib/packageAudit.ts | Greenlist | Tooling helper only; drives report discovery without impacting runtime bundles. |
+| `psychrolib` | `^2` | ✅ | `1.1.0` | @wb/engine (dependencies) | @wb/engine: packages/engine/src/shared/psychro/psychro.ts | Review | Upstream npm only publishes v1.x today; monitor for v2 cut.<br>Hold for v2 upstream release (or vetted fork) before wiring psychrometrics into the pipeline.<br>Installed range diverges from prompt target; verify before rollout. |
+| `mathjs` | `^13` | ❌ | — | — | — | Skip | Defer until we formalise tree-shaking and bundle footprint guardrails. |
+| `@turf/turf` | `^7` | ❌ | — | — | — | Skip | Spatial tooling is future-facing; no geometry ADR approved yet. |
+| `zod-to-json-schema` | `^3` | ❌ | — | — | — | Skip | Schema export automation can wait until façade contracts stabilise. |
+| `type-fest` | `^4` | ❌ | — | — | — | Skip | Additional TS utility types not required for current contracts. |
+| `rxjs` | `^7` | ❌ | — | — | — | Skip | Reactive stream layer unscheduled; existing event emitters cover needs. |
+| `mitt` | `^3` | ❌ | — | — | — | Skip | Redundant to current event emitter options; leave out until event bus ADR. |
+| `eventemitter3` | `^5` | ❌ | — | — | — | Skip | Hold until we benchmark emitter stacking for the façade/transport boundary. |
+| `commander` | `^12` | ✅ | `12.1.0` | @wb/tools (dependencies) | @wb/tools: packages/tools/src/cli/report.ts | Greenlist | CLI framework limited to tooling scope; deterministic for reports. |
+| `pino` | `^9` | ✅ | `9.13.1` | @wb/tools (dependencies) | @wb/tools: packages/tools/src/lib/logger.ts | Greenlist | Structured logging for tooling only; production stack remains unchanged. |
+| `pino-pretty` | `^11` | ✅ | `11.3.0` | @wb/tools (dependencies) | — | Review | Keep pretty transport opt-in so CI logs stay terse. |
+| `cli-table3` | `^0.6` | ✅ | `0.6.5` | @wb/tools (dependencies) | @wb/tools: packages/tools/src/cli/report.ts | Greenlist | Console formatting helper scoped to reports only. |
+| `fast-check` | `^3` | ✅ | `3.23.2` | @wb/engine (devDependencies) | — | Greenlist | Property testing library stays confined to tests. |
+| `vitest-fetch-mock` | `^0.4` | ❌ | — | — | — | Skip | Facade tests do not require fetch mocking yet; evaluate alongside transport work. |
+| `msw` | `^2` | ❌ | — | — | — | Skip | Network mocking remains out-of-scope until UI transport harness matures. |
+| `neo-blessed` | `^0.2` | ❌ | — | — | — | Skip | Terminal monitor deferred; revisit during monitoring sprint.<br>Optional monitor tooling; defer until terminal UX sprint. |
+| `blessed-contrib` | `^5` | ❌ | — | — | — | Skip | Depends on the terminal monitor initiative; skip for now.<br>Optional monitor tooling; defer until terminal UX sprint. |
 
 > *Direct usage = imports/requires within `packages/*/src/**`.
 
-## Greenlist (Safe to Continue)
+## Greenlist
 
-- `uuid`, `xxhash-wasm`, `safe-stable-stringify` — deterministic scaffolds only; no production wiring yet.
-- `globby`, `commander`, `cli-table3`, `pino`, `pino-pretty` — tooling/CLI scope only.
-- `fast-check` — tests-only, improves property coverage.
+- `uuid` — Deterministic scaffolds only; keep parity with existing helpers before touching runtime flows.
+- `xxhash-wasm` — Test-only hashing helper; aligns with deterministic checksum scaffolds without runtime hooks yet.
+- `safe-stable-stringify` — Used for canonical JSON hashing in tests; no production wiring planned until determinism ADR.
+- `globby` — Tooling helper only; drives report discovery without impacting runtime bundles.
+- `commander` — CLI framework limited to tooling scope; deterministic for reports.
+- `pino` — Structured logging for tooling only; production stack remains unchanged.
+- `cli-table3` — Console formatting helper scoped to reports only.
+- `fast-check` — Property testing library stays confined to tests.
 
-## Review (Needs Design/Version Check)
+## Review
 
-- `psychrolib` — npm still on `1.1.0`; upgrading to the desired `^2` requires upstream release or vendor fork.
-- `pino-pretty` — keep transport opt-in to avoid noisy CI logs.
+- `psychrolib` — Hold for v2 upstream release (or vetted fork) before wiring psychrometrics into the pipeline.
+- `pino-pretty` — Keep pretty transport opt-in so CI logs stay terse.
 
-## Skip (Out-of-scope for this pass)
+## Skip
 
-- Geometry/pipeline/event helpers (`mathjs`, `@turf/turf`, `rxjs`, `mitt`, `eventemitter3`).
-- Schema/typing utilities (`zod-to-json-schema`, `type-fest`).
-- Mocking/terminal tooling (`vitest-fetch-mock`, `msw`, `neo-blessed`, `blessed-contrib`).
+- `mathjs` — Defer until we formalise tree-shaking and bundle footprint guardrails.
+- `@turf/turf` — Spatial tooling is future-facing; no geometry ADR approved yet.
+- `zod-to-json-schema` — Schema export automation can wait until façade contracts stabilise.
+- `type-fest` — Additional TS utility types not required for current contracts.
+- `rxjs` — Reactive stream layer unscheduled; existing event emitters cover needs.
+- `mitt` — Redundant to current event emitter options; leave out until event bus ADR.
+- `eventemitter3` — Hold until we benchmark emitter stacking for the façade/transport boundary.
+- `vitest-fetch-mock` — Facade tests do not require fetch mocking yet; evaluate alongside transport work.
+- `msw` — Network mocking remains out-of-scope until UI transport harness matures.
+- `neo-blessed` — Terminal monitor deferred; revisit during monitoring sprint.
+- `blessed-contrib` — Depends on the terminal monitor initiative; skip for now.
+
+## Follow-up Tasks
+
+- Task 0007 keeps determinism helpers test-only until an ADR approves runtime adoption.
+- Task 0009 will cover psychrometric wiring once psychrolib v2 (or alternative) is stable.
 
 ## No-Go Criteria
 
-- Introduce runtime UUID/hash replacements without aligning with existing deterministic helpers (`packages/engine/src/backend/src/util/uuid.ts`).
-- Adopt `psychrolib` in production flows before we can target a maintained `^2` release (or validate `1.x` compatibility formally).
-- Pull `mathjs` without a clear tree-shaking plan; risk of large bundle footprint.
+- Introduce runtime UUID/hash replacements without aligning with packages/engine/src/backend/src/util/uuid.ts.
+- Adopt psychrolib in production flows before securing a maintained ^2 release or validating 1.x compatibility formally.
+- Pull mathjs (or similar heavy dependencies) without a documented tree-shaking plan and bundle budget.
 

--- a/packages/tools/src/cli/report.ts
+++ b/packages/tools/src/cli/report.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import Table from 'cli-table3';
 
-import { generatePackageAudit } from '../lib/packageAudit.js';
+import { generatePackageAudit, renderPackageAuditMarkdown } from '../lib/packageAudit.js';
 import { logger } from '../lib/logger.js';
 
 const program = new Command('wb');
@@ -14,45 +14,54 @@ report
   .command('packages')
   .description('Print the candidate package audit matrix')
   .option('--json', 'Emit raw JSON instead of a table')
-  .action(async (options: { json?: boolean }) => {
+  .option('--table', 'Emit an ASCII table instead of Markdown')
+  .action(async (options: { json?: boolean; table?: boolean }) => {
     try {
       const { entries } = await generatePackageAudit();
 
-      if (options?.json) {
+      if (options.json) {
         process.stdout.write(`${JSON.stringify(entries, null, 2)}\n`);
         return;
       }
 
-      const table = new Table({
-        head: [
-          'Package',
-          'Wanted',
-          'Installed?',
-          'Version',
-          'Location(s)',
-          'Direct Usage?',
-          'Notes'
-        ],
-        wordWrap: true
-      });
+      if (options.table) {
+        const table = new Table({
+          head: [
+            'Package',
+            'Wanted',
+            'Installed?',
+            'Version(s)',
+            'Location(s)',
+            'Direct Usage?',
+            'Category',
+            'Notes'
+          ],
+          wordWrap: true
+        });
 
-      for (const entry of entries) {
-        table.push([
-          entry.candidate.name,
-          entry.candidate.wanted,
-          entry.installed ? 'Yes' : 'No',
-          entry.versions.join(', '),
-          entry.locations.length > 0 ? entry.locations.join('\n') : '—',
-          entry.directUsages.length > 0 ? entry.directUsages.join('\n') : '—',
-          entry.notes.join('\n')
-        ]);
+        for (const entry of entries) {
+          table.push([
+            entry.candidate.name,
+            entry.candidate.wanted,
+            entry.installed ? 'Yes' : 'No',
+            entry.versions.join(', '),
+            entry.locations.length > 0 ? entry.locations.join('\n') : '—',
+            entry.directUsages.length > 0 ? entry.directUsages.join('\n') : '—',
+            entry.candidate.category,
+            entry.notes.join('\n')
+          ]);
+        }
+
+        process.stdout.write(`${table.toString()}\n`);
+        return;
       }
 
-      process.stdout.write(`${table.toString()}\n`);
+      const markdown = renderPackageAuditMarkdown({ entries });
+      process.stdout.write(`${markdown}\n`);
     } catch (error) {
       logger.error(error, 'Failed to generate package report');
       process.exitCode = 1;
     }
   });
 
-program.parseAsync(process.argv);
+void program.parseAsync(process.argv);

--- a/packages/tools/src/lib/logger.ts
+++ b/packages/tools/src/lib/logger.ts
@@ -1,4 +1,4 @@
-import pino, { type LoggerOptions } from 'pino';
+import pino, { type Logger, type LoggerOptions } from 'pino';
 
 const DEFAULT_LEVEL = process.env.WB_TOOLS_LOG_LEVEL ?? 'silent';
 
@@ -23,7 +23,7 @@ function buildOptions(): LoggerOptions {
   return options;
 }
 
-export function createToolsLogger() {
+export function createToolsLogger(): Logger {
   return pino(buildOptions());
 }
 

--- a/packages/tools/src/lib/packageAudit.ts
+++ b/packages/tools/src/lib/packageAudit.ts
@@ -7,58 +7,201 @@ import { parse as parseYaml } from 'yaml';
 
 const MODULE_DIR = fileURLToPath(new URL('.', import.meta.url));
 
+interface CandidateDefinition {
+  name: string;
+  wanted: string;
+  group: string;
+  category: CandidateCategory;
+  categoryReason: string;
+  note?: string;
+}
+
 const CANDIDATES = [
   {
     name: 'uuid',
     wanted: '^9',
     group: 'Engine & determinism',
+    category: 'greenlist',
+    categoryReason:
+      'Deterministic scaffolds only; keep parity with existing helpers before touching runtime flows.',
     note: 'Existing sha256-based deterministicUuid helper lives under packages/engine/src/backend/src/util/uuid.ts.'
   },
   {
     name: 'xxhash-wasm',
     wanted: '^1',
     group: 'Engine & determinism',
+    category: 'greenlist',
+    categoryReason:
+      'Test-only hashing helper; aligns with deterministic checksum scaffolds without runtime hooks yet.',
     note: 'Current release exposes 64-bit helpers only; 128-bit hash composed via dual seeds.'
   },
-  { name: 'safe-stable-stringify', wanted: '^2', group: 'Engine & determinism' },
-  { name: 'globby', wanted: '^14', group: 'Engine & determinism' },
+  {
+    name: 'safe-stable-stringify',
+    wanted: '^2',
+    group: 'Engine & determinism',
+    category: 'greenlist',
+    categoryReason: 'Used for canonical JSON hashing in tests; no production wiring planned until determinism ADR.'
+  },
+  {
+    name: 'globby',
+    wanted: '^14',
+    group: 'Engine & determinism',
+    category: 'greenlist',
+    categoryReason: 'Tooling helper only; drives report discovery without impacting runtime bundles.'
+  },
   {
     name: 'psychrolib',
     wanted: '^2',
     group: 'Physics & math',
+    category: 'review',
+    categoryReason: 'Hold for v2 upstream release (or vetted fork) before wiring psychrometrics into the pipeline.',
     note: 'Upstream npm only publishes v1.x today; monitor for v2 cut.'
   },
   {
     name: 'mathjs',
     wanted: '^13',
     group: 'Physics & math',
-    note: 'Tree-shake via named imports only when adopted.'
+    category: 'skip',
+    categoryReason: 'Defer until we formalise tree-shaking and bundle footprint guardrails.'
   },
-  { name: '@turf/turf', wanted: '^7', group: 'Geometry (optional / future)' },
-  { name: 'zod-to-json-schema', wanted: '^3', group: 'Schemas & typing' },
-  { name: 'type-fest', wanted: '^4', group: 'Schemas & typing' },
-  { name: 'rxjs', wanted: '^7', group: 'Pipelines & events' },
-  { name: 'mitt', wanted: '^3', group: 'Pipelines & events' },
-  { name: 'eventemitter3', wanted: '^5', group: 'Pipelines & events' },
-  { name: 'commander', wanted: '^12', group: 'CLI, logging & DX' },
-  { name: 'pino', wanted: '^9', group: 'CLI, logging & DX' },
-  { name: 'pino-pretty', wanted: '^11', group: 'CLI, logging & DX' },
-  { name: 'cli-table3', wanted: '^0.6', group: 'CLI, logging & DX' },
-  { name: 'fast-check', wanted: '^3', group: 'Tests & quality' },
-  { name: 'vitest-fetch-mock', wanted: '^0.4', group: 'Tests & quality' },
-  { name: 'msw', wanted: '^2', group: 'Tests & quality' },
-  { name: 'neo-blessed', wanted: '^0.2', group: 'Terminal monitor (optional)' },
-  { name: 'blessed-contrib', wanted: '^5', group: 'Terminal monitor (optional)' }
-] as const;
+  {
+    name: '@turf/turf',
+    wanted: '^7',
+    group: 'Geometry (optional / future)',
+    category: 'skip',
+    categoryReason: 'Spatial tooling is future-facing; no geometry ADR approved yet.'
+  },
+  {
+    name: 'zod-to-json-schema',
+    wanted: '^3',
+    group: 'Schemas & typing',
+    category: 'skip',
+    categoryReason: 'Schema export automation can wait until façade contracts stabilise.'
+  },
+  {
+    name: 'type-fest',
+    wanted: '^4',
+    group: 'Schemas & typing',
+    category: 'skip',
+    categoryReason: 'Additional TS utility types not required for current contracts.'
+  },
+  {
+    name: 'rxjs',
+    wanted: '^7',
+    group: 'Pipelines & events',
+    category: 'skip',
+    categoryReason: 'Reactive stream layer unscheduled; existing event emitters cover needs.'
+  },
+  {
+    name: 'mitt',
+    wanted: '^3',
+    group: 'Pipelines & events',
+    category: 'skip',
+    categoryReason: 'Redundant to current event emitter options; leave out until event bus ADR.'
+  },
+  {
+    name: 'eventemitter3',
+    wanted: '^5',
+    group: 'Pipelines & events',
+    category: 'skip',
+    categoryReason: 'Hold until we benchmark emitter stacking for the façade/transport boundary.'
+  },
+  {
+    name: 'commander',
+    wanted: '^12',
+    group: 'CLI, logging & DX',
+    category: 'greenlist',
+    categoryReason: 'CLI framework limited to tooling scope; deterministic for reports.'
+  },
+  {
+    name: 'pino',
+    wanted: '^9',
+    group: 'CLI, logging & DX',
+    category: 'greenlist',
+    categoryReason: 'Structured logging for tooling only; production stack remains unchanged.'
+  },
+  {
+    name: 'pino-pretty',
+    wanted: '^11',
+    group: 'CLI, logging & DX',
+    category: 'review',
+    categoryReason: 'Keep pretty transport opt-in so CI logs stay terse.'
+  },
+  {
+    name: 'cli-table3',
+    wanted: '^0.6',
+    group: 'CLI, logging & DX',
+    category: 'greenlist',
+    categoryReason: 'Console formatting helper scoped to reports only.'
+  },
+  {
+    name: 'fast-check',
+    wanted: '^3',
+    group: 'Tests & quality',
+    category: 'greenlist',
+    categoryReason: 'Property testing library stays confined to tests.'
+  },
+  {
+    name: 'vitest-fetch-mock',
+    wanted: '^0.4',
+    group: 'Tests & quality',
+    category: 'skip',
+    categoryReason: 'Facade tests do not require fetch mocking yet; evaluate alongside transport work.'
+  },
+  {
+    name: 'msw',
+    wanted: '^2',
+    group: 'Tests & quality',
+    category: 'skip',
+    categoryReason: 'Network mocking remains out-of-scope until UI transport harness matures.'
+  },
+  {
+    name: 'neo-blessed',
+    wanted: '^0.2',
+    group: 'Terminal monitor (optional)',
+    category: 'skip',
+    categoryReason: 'Terminal monitor deferred; revisit during monitoring sprint.'
+  },
+  {
+    name: 'blessed-contrib',
+    wanted: '^5',
+    group: 'Terminal monitor (optional)',
+    category: 'skip',
+    categoryReason: 'Depends on the terminal monitor initiative; skip for now.'
+  }
+] satisfies readonly CandidateDefinition[];
+
+type CandidateCategory = 'greenlist' | 'review' | 'skip';
 
 type Candidate = (typeof CANDIDATES)[number];
+
+type DependencyField =
+  | 'dependencies'
+  | 'devDependencies'
+  | 'optionalDependencies'
+  | 'peerDependencies';
+
+interface PackageManifest {
+  name?: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+}
 
 interface ManifestInfo {
   dir: string;
   relativeDir: string;
   label: string;
-  manifest: Record<string, any>;
+  manifest: PackageManifest;
 }
+
+const DEPENDENCY_FIELDS: DependencyField[] = [
+  'dependencies',
+  'devDependencies',
+  'optionalDependencies',
+  'peerDependencies'
+];
 
 interface DependencyRecord {
   location: string;
@@ -73,6 +216,27 @@ interface CandidateReport {
   directUsages: string[];
   notes: string[];
 }
+
+interface PackageAuditSummary {
+  entries: CandidateReport[];
+}
+
+const CATEGORY_LABEL: Record<CandidateCategory, string> = {
+  greenlist: 'Greenlist',
+  review: 'Review',
+  skip: 'Skip'
+};
+
+const NO_GO_CRITERIA = [
+  'Introduce runtime UUID/hash replacements without aligning with packages/engine/src/backend/src/util/uuid.ts.',
+  'Adopt psychrolib in production flows before securing a maintained ^2 release or validating 1.x compatibility formally.',
+  'Pull mathjs (or similar heavy dependencies) without a documented tree-shaking plan and bundle budget.'
+];
+
+const FOLLOW_UP_TASKS = [
+  'Task 0007 keeps determinism helpers test-only until an ADR approves runtime adoption.',
+  'Task 0009 will cover psychrometric wiring once psychrolib v2 (or alternative) is stable.'
+];
 
 interface LockDependencyEntry {
   version: string;
@@ -89,27 +253,21 @@ export async function generatePackageAudit(): Promise<{ entries: CandidateReport
   const lockMap = await loadPnpmLock(repoRoot);
   const directUsageMap = await detectDirectUsage(repoRoot, manifests);
 
-  const entries = await Promise.all(
-    CANDIDATES.map(async (candidate) => {
+  const entries = CANDIDATES.map((candidate) => {
       const dependencyRecords: DependencyRecord[] = [];
       const versionSet = new Set<string>();
 
       for (const manifest of manifests) {
-        for (const field of [
-          'dependencies',
-          'devDependencies',
-          'optionalDependencies',
-          'peerDependencies'
-        ]) {
+        for (const field of DEPENDENCY_FIELDS) {
           const deps = manifest.manifest[field];
           if (!deps) continue;
 
           const specifier = deps[candidate.name];
-          if (!specifier) continue;
+          if (typeof specifier !== 'string' || specifier.length === 0) continue;
 
           dependencyRecords.push({
             location: `${manifest.label} (${field})`,
-            specifier: String(specifier)
+            specifier
           });
 
           const importerKey = normaliseImporterKey(manifest.relativeDir);
@@ -117,15 +275,18 @@ export async function generatePackageAudit(): Promise<{ entries: CandidateReport
             .get(importerKey)
             ?.get(candidate.name)?.version;
           if (locked) {
-            versionSet.add(String(locked));
+            versionSet.add(locked);
           }
         }
       }
 
-      const notes: string[] = [];
-      if (candidate.note) {
-        notes.push(candidate.note);
-      }
+    const notes: string[] = [];
+    const candidateNote = candidate.note;
+    if (typeof candidateNote === 'string' && candidateNote.length > 0) {
+      notes.push(candidateNote);
+    }
+
+      notes.push(candidate.categoryReason);
 
       if (candidate.group.startsWith('Terminal') && dependencyRecords.length === 0) {
         notes.push('Optional monitor tooling; defer until terminal UX sprint.');
@@ -152,10 +313,88 @@ export async function generatePackageAudit(): Promise<{ entries: CandidateReport
         directUsages: directUsage,
         notes
       } satisfies CandidateReport;
-    })
-  );
+    });
 
   return { entries };
+}
+
+export function renderPackageAuditMarkdown(summary: PackageAuditSummary): string {
+  const lines: string[] = [];
+  const { entries } = summary;
+
+  lines.push('# Package Audit & Reporting Matrix');
+  lines.push('');
+  lines.push(
+    '_Generated via `pnpm report:packages` — deterministic snapshot of candidate tooling dependencies._'
+  );
+  lines.push('');
+  lines.push('## Scope & Inputs');
+  lines.push('');
+  lines.push('- Parsed `package.json` for the root workspace and `packages/*` (pnpm workspaces).');
+  lines.push('- Parsed `pnpm-lock.yaml` to resolve locked versions per importer.');
+  lines.push('- Searched `packages/*/src/**` for direct imports/requires of candidate packages.');
+  lines.push('- Classified candidates into Greenlist / Review / Skip buckets with rationale.');
+  lines.push('');
+  lines.push('## Findings');
+  lines.push('');
+  lines.push(
+    '| Package | Wanted | Installed? | Version(s) | Location(s) | Direct Usage?* | Category | Notes |'
+  );
+  lines.push('| --- | --- | --- | --- | --- | --- | --- | --- |');
+
+  for (const entry of entries) {
+    const versions =
+      entry.versions.length === 1 && entry.versions[0] === '—'
+        ? '—'
+        : entry.versions.map((version) => `\`${escapePipes(version)}\``).join('<br>');
+    const locations = formatList(entry.locations);
+    const directUsage = formatList(entry.directUsages);
+    const notes = formatList(entry.notes.map(escapePipes));
+    const installed = entry.installed ? '✅' : '❌';
+    const category = CATEGORY_LABEL[entry.candidate.category];
+
+    lines.push(
+      `| \`${entry.candidate.name}\` | \`${entry.candidate.wanted}\` | ${installed} | ${versions} | ${locations} | ${directUsage} | ${category} | ${notes} |`
+    );
+  }
+
+  lines.push('');
+  lines.push('> *Direct usage = imports/requires within `packages/*/src/**`.');
+  lines.push('');
+
+  for (const category of ['greenlist', 'review', 'skip'] as CandidateCategory[]) {
+    const label = CATEGORY_LABEL[category];
+    lines.push(`## ${label}`);
+    lines.push('');
+
+    const relevant = entries.filter((entry) => entry.candidate.category === category);
+
+    if (relevant.length === 0) {
+      lines.push('- _No entries._');
+    } else {
+      for (const entry of relevant) {
+        lines.push(`- \`${entry.candidate.name}\` — ${entry.candidate.categoryReason}`);
+      }
+    }
+
+    lines.push('');
+  }
+
+  lines.push('## Follow-up Tasks');
+  lines.push('');
+  for (const task of FOLLOW_UP_TASKS) {
+    lines.push(`- ${task}`);
+  }
+  lines.push('');
+
+  lines.push('## No-Go Criteria');
+  lines.push('');
+  for (const item of NO_GO_CRITERIA) {
+    lines.push(`- ${item}`);
+  }
+  lines.push('');
+
+  return lines.join('\n');
 }
 
 async function loadManifests(repoRoot: string): Promise<ManifestInfo[]> {
@@ -176,8 +415,8 @@ async function loadManifests(repoRoot: string): Promise<ManifestInfo[]> {
     manifestPaths.map(async (manifestPath) => {
       const dir = path.dirname(manifestPath);
       const relativeDir = path.relative(repoRoot, dir) || '.';
-      const manifestJson = JSON.parse(await readFile(manifestPath, 'utf8'));
-      const label = typeof manifestJson.name === 'string' ? manifestJson.name : relativeDir;
+      const manifestJson = JSON.parse(await readFile(manifestPath, 'utf8')) as PackageManifest;
+      const label = typeof manifestJson.name === 'string' && manifestJson.name.length > 0 ? manifestJson.name : relativeDir;
 
       return { dir, relativeDir, label, manifest: manifestJson } satisfies ManifestInfo;
     })
@@ -243,19 +482,17 @@ function ensureUsageSet(map: Map<string, Set<string>>, key: string) {
 }
 
 async function findRepoRoot(startDir: string): Promise<string> {
-  let current = startDir;
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    const candidate = path.join(current, 'pnpm-workspace.yaml');
-    if (await pathExists(candidate)) {
-      return current;
-    }
-    const parent = path.dirname(current);
-    if (parent === current) {
-      throw new Error('Unable to locate repository root');
-    }
-    current = parent;
+  const candidate = path.join(startDir, 'pnpm-workspace.yaml');
+  if (await pathExists(candidate)) {
+    return startDir;
   }
+
+  const parent = path.dirname(startDir);
+  if (parent === startDir) {
+    throw new Error('Unable to locate repository root');
+  }
+
+  return findRepoRoot(parent);
 }
 
 async function pathExists(candidate: string): Promise<boolean> {
@@ -267,6 +504,22 @@ async function pathExists(candidate: string): Promise<boolean> {
   }
 }
 
+interface PnpmLockDependencyInfo {
+  version?: string;
+  specifier?: string;
+}
+
+interface PnpmLockImporter {
+  dependencies?: Record<string, PnpmLockDependencyInfo>;
+  devDependencies?: Record<string, PnpmLockDependencyInfo>;
+  optionalDependencies?: Record<string, PnpmLockDependencyInfo>;
+  peerDependencies?: Record<string, PnpmLockDependencyInfo>;
+}
+
+interface PnpmLockFile {
+  importers?: Record<string, PnpmLockImporter>;
+}
+
 async function loadPnpmLock(repoRoot: string): Promise<LockDependencyMap> {
   const lockPath = path.join(repoRoot, 'pnpm-lock.yaml');
   const map: LockDependencyMap = new Map();
@@ -276,26 +529,19 @@ async function loadPnpmLock(repoRoot: string): Promise<LockDependencyMap> {
   }
 
   const raw = await readFile(lockPath, 'utf8');
-  const parsed = parseYaml(raw) as any;
-  const importers = parsed?.importers ?? {};
+  const parsed = parseYaml(raw) as PnpmLockFile;
+  const importers = parsed.importers ?? {};
 
   for (const [importerKey, importerValue] of Object.entries(importers)) {
     const depMap = new Map<string, LockDependencyEntry>();
-    for (const field of [
-      'dependencies',
-      'devDependencies',
-      'optionalDependencies',
-      'peerDependencies'
-    ]) {
-      const section = (importerValue as any)[field];
+    for (const field of DEPENDENCY_FIELDS) {
+      const section = importerValue[field];
       if (!section) continue;
 
-      for (const [depName, info] of Object.entries(section as Record<string, any>)) {
-        const entry = info as { version?: string; specifier?: string };
-        depMap.set(depName, {
-          version: entry.version ? String(entry.version) : '',
-          specifier: entry.specifier ? String(entry.specifier) : ''
-        });
+      for (const [depName, info] of Object.entries(section)) {
+        const version = typeof info.version === 'string' ? info.version : '';
+        const specifier = typeof info.specifier === 'string' ? info.specifier : '';
+        depMap.set(depName, { version, specifier });
       }
     }
     map.set(normaliseImporterKey(importerKey), depMap);
@@ -306,6 +552,17 @@ async function loadPnpmLock(repoRoot: string): Promise<LockDependencyMap> {
 
 function normaliseImporterKey(relativeDir: string): string {
   return relativeDir === '.' ? '.' : relativeDir.replace(/\\/g, '/');
+}
+
+function formatList(values: string[]): string {
+  if (values.length === 0) {
+    return '—';
+  }
+  return values.map(escapePipes).join('<br>');
+}
+
+function escapePipes(value: string): string {
+  return value.replace(/\|/g, '\\|');
 }
 
 export { CANDIDATES };

--- a/packages/tools/tests/packageAudit.test.ts
+++ b/packages/tools/tests/packageAudit.test.ts
@@ -1,0 +1,40 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { readFile } from 'node:fs/promises';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  CANDIDATES,
+  generatePackageAudit,
+  renderPackageAuditMarkdown
+} from '../src/lib/packageAudit.js';
+
+const TEST_DIR = fileURLToPath(new URL('.', import.meta.url));
+const REPO_ROOT = path.resolve(TEST_DIR, '..', '..', '..');
+
+describe('package audit reporting', () => {
+  it('reports installed metadata for known candidates', async () => {
+    const { entries } = await generatePackageAudit();
+    const names = entries.map((entry) => entry.candidate.name);
+
+    expect(names).toEqual(CANDIDATES.map((candidate) => candidate.name));
+
+    const globbyEntry = entries.find((entry) => entry.candidate.name === 'globby');
+    expect(globbyEntry?.installed).toBe(true);
+    expect(globbyEntry?.directUsages.some((usage) => usage.includes('packages/tools/src/lib/packageAudit.ts'))).toBe(true);
+
+    const psychrolibEntry = entries.find((entry) => entry.candidate.name === 'psychrolib');
+    expect(psychrolibEntry?.versions).toContain('1.1.0');
+    expect(psychrolibEntry?.notes.some((note) => note.includes('v2 upstream release'))).toBe(true);
+  });
+
+  it('keeps the committed markdown report in sync with the generator', async () => {
+    const { entries } = await generatePackageAudit();
+    const markdown = renderPackageAuditMarkdown({ entries }).trim();
+    const docPath = path.join(REPO_ROOT, 'docs/reports/PACKAGE_AUDIT.md');
+    const doc = (await readFile(docPath, 'utf8')).trim();
+
+    expect(markdown).toBe(doc);
+  });
+});

--- a/packages/tools/vitest.config.ts
+++ b/packages/tools/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.ts']
+  }
+});


### PR DESCRIPTION
## Summary
- refactor the package audit generator to categorise candidates, produce a shared Markdown report, and surface follow-up/no-go guidance alongside the matrix
- update the wb report packages CLI to emit the Markdown snapshot by default (with optional JSON/table modes) and ensure logger typing stays strict
- refresh docs (CHANGELOG, DD, TDD, PACKAGE_AUDIT.md) and add vitest coverage so `docs/reports/PACKAGE_AUDIT.md` stays in lockstep with the generator

## Touched SEC/TDD sections
- DD §1 Goals
- TDD §2 Test Taxonomy & Folder Layout

## Testing
- pnpm --filter @wb/tools lint
- pnpm --filter @wb/tools build
- pnpm --filter @wb/tools test
- pnpm -r lint *(fails: existing @wb/facade lint violations)*
- pnpm -r --reporter=append-only build *(fails: existing @wb/facade TS project boundary errors)*
- pnpm -r --reporter=append-only test *(fails: existing @wb/engine golden fixture + CO₂ injector regressions)*

------
https://chatgpt.com/codex/tasks/task_e_68e413b5b118832589e55e910ac4a6eb