### PR TITLE
feat(task:0010): add cultivation maintenance runtime

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Added test-only determinism helper scaffolds (`hashCanonicalJson`, `newV7`) for
   hashing canonical JSON payloads and generating UUIDv7 identifiers without
   impacting runtime flows (Task 0007).
+- Added cultivation maintenance runtime translating cultivation-method reuse policies
+  into deterministic repotting, sterilisation, and disposal tasks with unit and
+  integration coverage (Task 0010).
 - Added the psychrometric VPD helper (`computeVpd_kPa`) under
   `packages/engine/src/shared/psychro/psychro.ts`, initialising `psychrolib` in
   SI mode and documenting its test-only scope pending Task 0009 wiring.

--- a/docs/DD.md
+++ b/docs/DD.md
@@ -149,6 +149,12 @@ targets from the same factor to keep unit conversions deterministic.
 
 > **Irrigation compatibility note:** Cultivation methods no longer list irrigation method IDs directly. Instead, irrigation method blueprints enumerate the substrates they support via `compatibility.substrates`, and methods inherit compatibility from whichever substrate option a zone selects (ADR-0003).
 
+**Runtime enforcement:** The engine monitors harvest cycles per zone and enqueues
+repotting, substrate sterilisation, and disposal tasks based on the active
+cultivation method's container service life and substrate reuse policy. These
+tasks land in the workforce queue with deterministic identifiers so labour
+costing and scheduling remain aligned with SEC §7.5 and §10.
+
 ---
 
 ## 5) Economy & Tariffs (SEC §3.6)

--- a/packages/engine/src/backend/src/cultivation/methodRuntime.ts
+++ b/packages/engine/src/backend/src/cultivation/methodRuntime.ts
@@ -1,0 +1,556 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { z } from 'zod';
+
+import type { EngineRunContext as EngineContext } from '../engine/Engine.js';
+import type {
+  Room,
+  SimulationWorld,
+  Structure,
+  Uuid,
+  WorkforceState,
+  WorkforceTaskDefinition,
+  WorkforceTaskInstance,
+  Zone,
+} from '../domain/world.js';
+import { parseSubstrateBlueprint, type SubstrateBlueprint } from '../domain/blueprints/substrateBlueprint.js';
+import { deterministicUuid } from '../util/uuid.js';
+
+const CURRENT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(CURRENT_DIR, '../../../../../../');
+const BLUEPRINTS_ROOT = path.join(REPO_ROOT, 'data', 'blueprints');
+const METHOD_BLUEPRINT_ROOT = path.join(BLUEPRINTS_ROOT, 'cultivation-method');
+const CONTAINER_BLUEPRINT_ROOT = path.join(BLUEPRINTS_ROOT, 'container');
+const SUBSTRATE_BLUEPRINT_ROOT = path.join(BLUEPRINTS_ROOT, 'substrate');
+
+const slugSchema = z
+  .string({ required_error: 'slug is required.' })
+  .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'Slug must be kebab-case (lowercase letters, digits, hyphen).');
+
+const containerBlueprintSchema = z
+  .object({
+    id: z.string().uuid('Container blueprint id must be a UUID v4.'),
+    slug: slugSchema,
+    class: z.literal('container', {
+      invalid_type_error: 'class must be the canonical "container" domain value.',
+    }),
+    name: z.string().min(1, 'Container blueprint name must not be empty.'),
+    volumeInLiters: z.number().finite().positive('volumeInLiters must be a positive number.'),
+    footprintArea: z.number().finite().positive('footprintArea must be a positive number.'),
+    reusableCycles: z.number().int().min(1).optional(),
+  })
+  .passthrough();
+
+export type ContainerBlueprintLite = z.infer<typeof containerBlueprintSchema>;
+
+const cultivationMethodBlueprintSchema = z
+  .object({
+    id: z.string().uuid('Cultivation method blueprint id must be a UUID v4.'),
+    slug: slugSchema,
+    class: z.literal('cultivation-method', {
+      invalid_type_error: 'class must be the canonical "cultivation-method" domain value.',
+    }),
+    name: z.string().min(1, 'Cultivation method name must not be empty.'),
+    containers: z.array(slugSchema).min(1, 'Cultivation method must list at least one container option.'),
+    substrates: z.array(slugSchema).min(1, 'Cultivation method must list at least one substrate option.'),
+    maxCycles: z.number().int().min(1).optional(),
+    meta: z
+      .object({
+        defaults: z
+          .object({
+            containerSlug: slugSchema.optional(),
+            substrateSlug: slugSchema.optional(),
+          })
+          .partial()
+          .optional(),
+      })
+      .partial()
+      .optional(),
+  })
+  .passthrough();
+
+export type CultivationMethodBlueprintLite = z.infer<typeof cultivationMethodBlueprintSchema>;
+
+interface ContainerRegistry {
+  readonly byId: Map<Uuid, ContainerBlueprintLite>;
+  readonly bySlug: Map<string, ContainerBlueprintLite>;
+}
+
+interface SubstrateRegistry {
+  readonly byId: Map<Uuid, SubstrateBlueprint>;
+  readonly bySlug: Map<string, SubstrateBlueprint>;
+}
+
+function readJsonFile(filePath: string): unknown {
+  const raw = readFileSync(filePath, 'utf8');
+  return JSON.parse(raw) as unknown;
+}
+
+function listJsonFiles(root: string): string[] {
+  const entries = readdirSync(root, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    if (entry.isFile() && entry.name.endsWith('.json')) {
+      files.push(path.join(root, entry.name));
+      continue;
+    }
+
+    if (entry.isDirectory()) {
+      const nestedRoot = path.join(root, entry.name);
+      const nestedEntries = readdirSync(nestedRoot, { withFileTypes: true });
+
+      for (const nestedEntry of nestedEntries) {
+        if (nestedEntry.isFile() && nestedEntry.name.endsWith('.json')) {
+          files.push(path.join(nestedRoot, nestedEntry.name));
+        }
+      }
+    }
+  }
+
+  return files;
+}
+
+let containerRegistryCache: ContainerRegistry | null = null;
+let substrateRegistryCache: SubstrateRegistry | null = null;
+
+function ensureContainerRegistry(): ContainerRegistry {
+  if (containerRegistryCache) {
+    return containerRegistryCache;
+  }
+
+  const byId = new Map<Uuid, ContainerBlueprintLite>();
+  const bySlug = new Map<string, ContainerBlueprintLite>();
+
+  for (const filePath of listJsonFiles(CONTAINER_BLUEPRINT_ROOT)) {
+    const blueprint = containerBlueprintSchema.parse(readJsonFile(filePath));
+    byId.set(blueprint.id as Uuid, blueprint);
+    bySlug.set(blueprint.slug, blueprint);
+  }
+
+  containerRegistryCache = { byId, bySlug } satisfies ContainerRegistry;
+  return containerRegistryCache;
+}
+
+function ensureSubstrateRegistry(): SubstrateRegistry {
+  if (substrateRegistryCache) {
+    return substrateRegistryCache;
+  }
+
+  const byId = new Map<Uuid, SubstrateBlueprint>();
+  const bySlug = new Map<string, SubstrateBlueprint>();
+
+  for (const filePath of listJsonFiles(SUBSTRATE_BLUEPRINT_ROOT)) {
+    const blueprint = parseSubstrateBlueprint(readJsonFile(filePath), { filePath });
+    byId.set(blueprint.id as Uuid, blueprint);
+    bySlug.set(blueprint.slug, blueprint);
+  }
+
+  substrateRegistryCache = { byId, bySlug } satisfies SubstrateRegistry;
+  return substrateRegistryCache;
+}
+
+function resolveContainerPolicyById(containerId: Uuid): ContainerPolicy | undefined {
+  const registry = ensureContainerRegistry();
+  const entry = registry.byId.get(containerId);
+
+  if (!entry) {
+    return undefined;
+  }
+
+  return toContainerPolicy(entry);
+}
+
+function resolveSubstratePolicyById(substrateId: Uuid): SubstratePolicy | undefined {
+  const registry = ensureSubstrateRegistry();
+  const entry = registry.byId.get(substrateId);
+
+  if (!entry) {
+    return undefined;
+  }
+
+  return toSubstratePolicy(entry);
+}
+
+export interface ContainerPolicy {
+  readonly id: Uuid;
+  readonly slug: string;
+  readonly serviceLife_cycles: number;
+  readonly volume_L: number;
+  readonly footprintArea_m2: number;
+}
+
+export interface SubstratePolicy {
+  readonly id: Uuid;
+  readonly slug: string;
+  readonly maxCycles: number;
+  readonly sterilizationTaskCode?: string;
+  readonly sterilizationInterval_cycles?: number;
+}
+
+export interface CultivationMethodDescriptor {
+  readonly id: Uuid;
+  readonly slug: string;
+  readonly containerOptions: readonly ContainerPolicy[];
+  readonly substrateOptions: readonly SubstratePolicy[];
+  readonly defaultContainerId?: Uuid;
+  readonly defaultSubstrateId?: Uuid;
+}
+
+let cultivationMethodCatalogCache: Map<Uuid, CultivationMethodDescriptor> | null = null;
+
+function toContainerPolicy(entry: ContainerBlueprintLite): ContainerPolicy {
+  const serviceLife = entry.reusableCycles && entry.reusableCycles > 0 ? entry.reusableCycles : 1;
+
+  return {
+    id: entry.id as Uuid,
+    slug: entry.slug,
+    serviceLife_cycles: serviceLife,
+    volume_L: entry.volumeInLiters,
+    footprintArea_m2: entry.footprintArea,
+  } satisfies ContainerPolicy;
+}
+
+function toSubstratePolicy(entry: SubstrateBlueprint): SubstratePolicy {
+  const reusePolicy = entry.reusePolicy;
+
+  return {
+    id: entry.id as Uuid,
+    slug: entry.slug,
+    maxCycles: Math.max(1, reusePolicy.maxCycles),
+    sterilizationTaskCode: reusePolicy.sterilizationTaskCode,
+    sterilizationInterval_cycles: reusePolicy.sterilizationInterval_cycles,
+  } satisfies SubstratePolicy;
+}
+
+function buildCultivationMethodCatalog(): Map<Uuid, CultivationMethodDescriptor> {
+  const { bySlug: containerBySlug } = ensureContainerRegistry();
+  const { bySlug: substrateBySlug } = ensureSubstrateRegistry();
+  const catalog = new Map<Uuid, CultivationMethodDescriptor>();
+
+  for (const filePath of listJsonFiles(METHOD_BLUEPRINT_ROOT)) {
+    const blueprint = cultivationMethodBlueprintSchema.parse(readJsonFile(filePath));
+    const containerOptions = blueprint.containers
+      .map((slug) => containerBySlug.get(slug))
+      .filter((entry): entry is ContainerBlueprintLite => Boolean(entry))
+      .map(toContainerPolicy);
+
+    const substrateOptions = blueprint.substrates
+      .map((slug) => substrateBySlug.get(slug))
+      .filter((entry): entry is SubstrateBlueprint => Boolean(entry))
+      .map(toSubstratePolicy);
+
+    const defaultContainerId = blueprint.meta?.defaults?.containerSlug
+      ? containerBySlug.get(blueprint.meta.defaults.containerSlug)?.id
+      : undefined;
+    const defaultSubstrateId = blueprint.meta?.defaults?.substrateSlug
+      ? substrateBySlug.get(blueprint.meta.defaults.substrateSlug)?.id
+      : undefined;
+
+    catalog.set(blueprint.id as Uuid, {
+      id: blueprint.id as Uuid,
+      slug: blueprint.slug,
+      containerOptions,
+      substrateOptions,
+      defaultContainerId: defaultContainerId as Uuid | undefined,
+      defaultSubstrateId: defaultSubstrateId as Uuid | undefined,
+    });
+  }
+
+  return catalog;
+}
+
+export function getCultivationMethodCatalog(): ReadonlyMap<Uuid, CultivationMethodDescriptor> {
+  if (!cultivationMethodCatalogCache) {
+    cultivationMethodCatalogCache = buildCultivationMethodCatalog();
+  }
+
+  return cultivationMethodCatalogCache;
+}
+
+export function getCultivationMethodDescriptor(id: Uuid): CultivationMethodDescriptor | undefined {
+  return getCultivationMethodCatalog().get(id);
+}
+
+export const CULTIVATION_REPOT_TASK_CODE = 'cultivation.repot';
+export const CULTIVATION_SUBSTRATE_STERILIZE_TASK_CODE = 'cultivation.substrate.sterilize';
+export const CULTIVATION_SUBSTRATE_DISPOSAL_TASK_CODE = 'cultivation.substrate.dispose';
+
+export interface ZoneCultivationRuntimeState {
+  lastHarvestTick?: number;
+  containerCyclesUsed: number;
+  substrateCyclesUsed: number;
+  lastSterilizedCycle?: number;
+  totalCyclesCompleted: number;
+}
+
+interface CultivationTaskRuntimeMutable {
+  readonly zones: Map<Zone['id'], ZoneCultivationRuntimeState>;
+}
+
+type Mutable<T> = { -readonly [K in keyof T]: T[K] };
+
+type CultivationRuntimeCarrier = Mutable<EngineContext> & {
+  [CULTIVATION_RUNTIME_CONTEXT_KEY]?: CultivationTaskRuntimeMutable;
+};
+
+const CULTIVATION_RUNTIME_CONTEXT_KEY = '__wb_cultivationTaskRuntime' as const;
+
+export function ensureCultivationTaskRuntime(ctx: EngineContext): CultivationTaskRuntimeMutable {
+  const carrier = ctx as CultivationRuntimeCarrier;
+  let runtime = carrier[CULTIVATION_RUNTIME_CONTEXT_KEY];
+
+  if (!runtime) {
+    runtime = { zones: new Map() };
+    carrier[CULTIVATION_RUNTIME_CONTEXT_KEY] = runtime;
+  }
+
+  return runtime;
+}
+
+export function clearCultivationTaskRuntime(ctx: EngineContext): void {
+  const carrier = ctx as CultivationRuntimeCarrier;
+  if (carrier[CULTIVATION_RUNTIME_CONTEXT_KEY]) {
+    delete carrier[CULTIVATION_RUNTIME_CONTEXT_KEY];
+  }
+}
+
+function resolveZoneRuntime(
+  runtime: CultivationTaskRuntimeMutable,
+  zoneId: Zone['id'],
+): ZoneCultivationRuntimeState {
+  let state = runtime.zones.get(zoneId);
+
+  if (!state) {
+    state = {
+      containerCyclesUsed: 0,
+      substrateCyclesUsed: 0,
+      totalCyclesCompleted: 0,
+    } satisfies ZoneCultivationRuntimeState;
+    runtime.zones.set(zoneId, state);
+  }
+
+  return state;
+}
+
+interface ScheduleZoneTasksOptions {
+  readonly world: SimulationWorld;
+  readonly structure: Structure;
+  readonly room: Room;
+  readonly zone: Zone;
+  readonly workforce?: WorkforceState;
+  readonly runtime: CultivationTaskRuntimeMutable;
+  readonly currentTick: number;
+  readonly methodCatalog: ReadonlyMap<Uuid, CultivationMethodDescriptor>;
+}
+
+function findTaskDefinition(
+  workforce: WorkforceState | undefined,
+  taskCode: string,
+): WorkforceTaskDefinition | undefined {
+  if (!workforce) {
+    return undefined;
+  }
+
+  return workforce.taskDefinitions.find((definition) => definition.taskCode === taskCode);
+}
+
+function createTask(
+  world: SimulationWorld,
+  zone: Zone,
+  taskCode: string,
+  definition: WorkforceTaskDefinition | undefined,
+  baseContext: Record<string, unknown>,
+  currentTick: number,
+  eventKey: string,
+): WorkforceTaskInstance | null {
+  if (!definition) {
+    return null;
+  }
+
+  const id = deterministicUuid(world.seed, `cultivation:${taskCode}:${zone.id}:${eventKey}`);
+
+  return {
+    id,
+    taskCode: definition.taskCode,
+    status: 'queued',
+    createdAtTick: currentTick,
+    context: baseContext,
+  } satisfies WorkforceTaskInstance;
+}
+
+function hasCompletedHarvest(zone: Zone): boolean {
+  if (zone.plants.length === 0) {
+    return false;
+  }
+
+  return zone.plants.every((plant) => plant.status === 'harvested' && typeof plant.harvestedAt_tick === 'number');
+}
+
+function resolveLatestHarvestTick(zone: Zone): number | null {
+  const harvestedTicks = zone.plants
+    .map((plant) => (typeof plant.harvestedAt_tick === 'number' ? Math.trunc(plant.harvestedAt_tick) : null))
+    .filter((tick): tick is number => tick !== null);
+
+  if (harvestedTicks.length === 0) {
+    return null;
+  }
+
+  return Math.max(...harvestedTicks);
+}
+
+export function scheduleCultivationTasksForZone(
+  options: ScheduleZoneTasksOptions,
+): readonly WorkforceTaskInstance[] {
+  const { world, structure, room, zone, workforce, runtime, currentTick, methodCatalog } = options;
+
+  if (!hasCompletedHarvest(zone)) {
+    return [];
+  }
+
+  const latestHarvestTick = resolveLatestHarvestTick(zone);
+
+  if (latestHarvestTick === null) {
+    return [];
+  }
+
+  const descriptor = methodCatalog.get(zone.cultivationMethodId);
+
+  const containerPolicy =
+    descriptor?.containerOptions.find((option) => option.id === zone.containerId) ??
+    resolveContainerPolicyById(zone.containerId as Uuid);
+  const substratePolicy =
+    descriptor?.substrateOptions.find((option) => option.id === zone.substrateId) ??
+    resolveSubstratePolicyById(zone.substrateId as Uuid);
+
+  if (!containerPolicy || !substratePolicy) {
+    return [];
+  }
+
+  const state = resolveZoneRuntime(runtime, zone.id);
+
+  state.lastHarvestTick = latestHarvestTick;
+  state.totalCyclesCompleted += 1;
+  const cycleSequence = state.totalCyclesCompleted;
+  state.containerCyclesUsed += 1;
+  state.substrateCyclesUsed += 1;
+
+  const baseContext = {
+    zoneId: zone.id,
+    roomId: room.id,
+    structureId: structure.id,
+    area_m2: zone.floorArea_m2,
+    plantCount: zone.plants.length,
+    cycleIndex: state.substrateCyclesUsed,
+    cycleSequence,
+  } satisfies Record<string, unknown>;
+
+  const tasks: WorkforceTaskInstance[] = [];
+
+  if (state.containerCyclesUsed >= containerPolicy.serviceLife_cycles) {
+    const definition = findTaskDefinition(workforce, CULTIVATION_REPOT_TASK_CODE);
+    const task = createTask(
+      world,
+      zone,
+      CULTIVATION_REPOT_TASK_CODE,
+      definition,
+      {
+        ...baseContext,
+        containerId: zone.containerId,
+        containerServiceLife: containerPolicy.serviceLife_cycles,
+        containerCycleCount: state.containerCyclesUsed,
+      },
+      currentTick,
+      `repot:${cycleSequence}:tick:${latestHarvestTick}`,
+    );
+
+    if (task) {
+      tasks.push(task);
+      state.containerCyclesUsed = 0;
+    }
+  }
+
+  const sterilizeTaskCode = substratePolicy.sterilizationTaskCode ?? CULTIVATION_SUBSTRATE_STERILIZE_TASK_CODE;
+  const definitionSterilize = findTaskDefinition(workforce, sterilizeTaskCode);
+  const definitionDispose = findTaskDefinition(workforce, CULTIVATION_SUBSTRATE_DISPOSAL_TASK_CODE);
+
+  const shouldDispose = state.substrateCyclesUsed >= substratePolicy.maxCycles;
+  const shouldSterilize = !shouldDispose && substratePolicy.sterilizationTaskCode;
+
+  if (shouldDispose && definitionDispose) {
+    const task = createTask(
+      world,
+      zone,
+      CULTIVATION_SUBSTRATE_DISPOSAL_TASK_CODE,
+      definitionDispose,
+      {
+        ...baseContext,
+        substrateId: zone.substrateId,
+        substrateMaxCycles: substratePolicy.maxCycles,
+        substrateCycleCount: state.substrateCyclesUsed,
+      },
+      currentTick,
+      `dispose:${cycleSequence}:tick:${latestHarvestTick}`,
+    );
+
+    if (task) {
+      tasks.push(task);
+      state.substrateCyclesUsed = 0;
+      state.lastSterilizedCycle = undefined;
+    }
+  } else if (shouldSterilize && definitionSterilize) {
+    const interval = substratePolicy.sterilizationInterval_cycles ?? 1;
+    const nextSterilization = (state.lastSterilizedCycle ?? 0) + interval;
+
+    if (state.substrateCyclesUsed >= nextSterilization) {
+      const task = createTask(
+        world,
+        zone,
+        sterilizeTaskCode,
+        definitionSterilize,
+        {
+          ...baseContext,
+          substrateId: zone.substrateId,
+          sterilizationInterval_cycles: interval,
+          substrateCycleCount: state.substrateCyclesUsed,
+        },
+        currentTick,
+        `sterilize:${cycleSequence}:tick:${latestHarvestTick}`,
+      );
+
+      if (task) {
+        tasks.push(task);
+        state.lastSterilizedCycle = state.substrateCyclesUsed;
+      }
+    }
+  }
+
+  return tasks;
+}
+
+export interface ScheduleCultivationTasksResult {
+  readonly newTasks: readonly WorkforceTaskInstance[];
+}
+
+export function scheduleCultivationTasks(
+  options: Omit<ScheduleZoneTasksOptions, 'zone'> & { readonly zones: readonly Zone[] },
+): ScheduleCultivationTasksResult {
+  const { zones, ...rest } = options;
+  const tasks: WorkforceTaskInstance[] = [];
+
+  for (const zone of zones) {
+    const zoneTasks = scheduleCultivationTasksForZone({
+      ...rest,
+      zone,
+    });
+
+    if (zoneTasks.length > 0) {
+      tasks.push(...zoneTasks);
+    }
+  }
+
+  return { newTasks: tasks } satisfies ScheduleCultivationTasksResult;
+}
+

--- a/packages/engine/tests/integration/pipeline/cultivationMethodTasks.integration.test.ts
+++ b/packages/engine/tests/integration/pipeline/cultivationMethodTasks.integration.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+
+import basicSoilPot from '../../../../../data/blueprints/cultivation-method/basic-soil-pot.json' assert { type: 'json' };
+import pot10L from '../../../../../data/blueprints/container/pot-10l.json' assert { type: 'json' };
+import soilMultiCycle from '../../../../../data/blueprints/substrate/soil-multi-cycle.json' assert { type: 'json' };
+
+import { PIPELINE_ORDER, type EngineRunContext } from '@/backend/src/engine/Engine.js';
+import { createDemoWorld, runStages } from '@/backend/src/engine/testHarness.js';
+import type {
+  Plant,
+  SimulationWorld,
+  Structure,
+  Room,
+  Zone,
+  WorkforceState,
+  WorkforceTaskDefinition,
+  WorkforceTaskInstance,
+  Uuid,
+} from '@/backend/src/domain/world.js';
+
+function createTaskDefinition(taskCode: string, priority = 60): WorkforceTaskDefinition {
+  return {
+    taskCode,
+    description: taskCode,
+    requiredRoleSlug: 'cultivator',
+    requiredSkills: [],
+    priority,
+    costModel: { basis: 'perPlant', laborMinutes: 10 },
+  } satisfies WorkforceTaskDefinition;
+}
+
+function updateZone(
+  world: SimulationWorld,
+  updater: (structure: Structure, room: Room, zone: Zone) => Zone,
+): SimulationWorld {
+  const structure = world.company.structures[0];
+  const room = structure.rooms[0];
+  const zone = room.zones[0];
+  const nextZone = updater(structure, room, zone);
+  const nextRoom = { ...room, zones: [nextZone] } satisfies typeof room;
+  const nextStructure = { ...structure, rooms: [nextRoom] } satisfies typeof structure;
+  const nextCompany = { ...world.company, structures: [nextStructure] } satisfies typeof world.company;
+
+  return {
+    ...world,
+    company: nextCompany,
+  } satisfies SimulationWorld;
+}
+
+describe('cultivation method task scheduling integration', () => {
+  it('queues deterministic maintenance tasks over successive harvest cycles', () => {
+    let world = createDemoWorld();
+    world = {
+      ...world,
+      simTimeHours: 24,
+    } satisfies SimulationWorld;
+
+    const workforceState: WorkforceState = {
+      roles: [],
+      employees: [],
+      taskDefinitions: [
+        createTaskDefinition('cultivation.repot', 80),
+        createTaskDefinition(soilMultiCycle.reusePolicy.sterilizationTaskCode ?? 'cultivation.substrate.sterilize', 70),
+        createTaskDefinition('cultivation.substrate.dispose', 90),
+      ],
+      taskQueue: [],
+      kpis: [],
+      warnings: [],
+      payroll: {
+        dayIndex: 0,
+        totals: { baseMinutes: 0, otMinutes: 0, baseCost: 0, otCost: 0, totalLaborCost: 0 },
+        byStructure: [],
+      },
+      market: { structures: [] },
+    } satisfies WorkforceState;
+
+    const basePlant: Omit<Plant, 'id'> = {
+      name: 'Integration Plant',
+      slug: 'integration-plant',
+      strainId: '00000000-0000-4000-8000-000000000111' as Uuid,
+      lifecycleStage: 'harvest-ready',
+      ageHours: 640,
+      health01: 0.92,
+      biomass_g: 420,
+      containerId: pot10L.id as Uuid,
+      substrateId: soilMultiCycle.id as Uuid,
+      readyForHarvest: false,
+      status: 'harvested',
+      harvestedAt_tick: 23,
+    } satisfies Omit<Plant, 'id'>;
+
+    world = updateZone(world, (_structure, _room, incomingZone) => ({
+      ...incomingZone,
+      cultivationMethodId: basicSoilPot.id as Uuid,
+      containerId: pot10L.id as Uuid,
+      substrateId: soilMultiCycle.id as Uuid,
+      plants: [
+        { ...basePlant, id: '00000000-0000-4000-8000-000000000201' as Uuid },
+        { ...basePlant, id: '00000000-0000-4000-8000-000000000202' as Uuid },
+      ],
+    } satisfies Zone));
+
+    world = {
+      ...world,
+      workforce: workforceState,
+    } satisfies SimulationWorld;
+
+    const ctx: EngineRunContext = { telemetry: { emit: () => {} } };
+    let previousQueueLength = 0;
+
+    function extractNewTasks(currentWorld: SimulationWorld): WorkforceTaskInstance[] {
+      const queue = currentWorld.workforce?.taskQueue ?? [];
+      const newEntries = queue.slice(previousQueueLength);
+      previousQueueLength = queue.length;
+      return newEntries;
+    }
+
+    // Cycle 1 - expect sterilisation task
+    world = runStages(world, ctx, PIPELINE_ORDER);
+    let newTasks = extractNewTasks(world);
+    const steriliseCode = soilMultiCycle.reusePolicy.sterilizationTaskCode ?? 'cultivation.substrate.sterilize';
+    expect(newTasks.map((task) => task.taskCode)).toEqual([steriliseCode]);
+
+    // Prepare Cycle 2 - update harvest tick to current cycle
+    world = updateZone(world, (_structure, _room, incomingZone) => {
+      const updatedPlants = incomingZone.plants.map((plant) => ({
+        ...plant,
+        harvestedAt_tick: Math.trunc(world.simTimeHours) - 1,
+      }));
+
+      return { ...incomingZone, plants: updatedPlants } satisfies Zone;
+    });
+
+    world = runStages(world, ctx, PIPELINE_ORDER);
+    newTasks = extractNewTasks(world);
+    expect(newTasks.map((task) => task.taskCode)).toEqual(['cultivation.substrate.dispose']);
+
+    // Prepare Cycle 3 - container service life reached, expect repot + sterilise
+    world = updateZone(world, (_structure, _room, incomingZone) => {
+      const updatedPlants = incomingZone.plants.map((plant) => ({
+        ...plant,
+        harvestedAt_tick: Math.trunc(world.simTimeHours) - 1,
+      }));
+
+      return { ...incomingZone, plants: updatedPlants } satisfies Zone;
+    });
+
+    world = runStages(world, ctx, PIPELINE_ORDER);
+    newTasks = extractNewTasks(world);
+    const sortedCodes = newTasks.map((task) => task.taskCode).sort();
+    expect(sortedCodes).toEqual(['cultivation.repot', steriliseCode].sort());
+
+    // Ensure contexts carry zone metadata for downstream scheduling
+    newTasks.forEach((task) => {
+      expect(task.context?.zoneId).toBe(world.company.structures[0]?.rooms[0]?.zones[0]?.id);
+      expect(task.context?.structureId).toBe(world.company.structures[0]?.id);
+    });
+  });
+});
+

--- a/packages/engine/tests/integration/pipeline/pestDiseaseMvp.integration.test.ts
+++ b/packages/engine/tests/integration/pipeline/pestDiseaseMvp.integration.test.ts
@@ -1,52 +1,3 @@
-<<<<<<< HEAD
-import { describe, it, expect } from 'vitest';
-import { Engine, type EngineRunContext } from '../../../../src/backend/src/engine/Engine.js';
-import { createDemoWorld } from '../../../../src/backend/src/engine/testHarness.js';
-import type { SimulationWorld, WorkforceTaskInstance, WorkforceTaskDefinition } from '../../../../src/backend/src/domain/world.js';
-
-const INSPECT_ZONE_TASK: WorkforceTaskDefinition = {
-  taskCode: 'inspect-zone',
-  description: 'Inspect a zone for pests and diseases.',
-  requiredRoleSlug: 'cultivator',
-  priority: 10,
-  costModel: {
-    basis: 'perAction',
-    laborMinutes: 30,
-  },
-  requiredSkills: [],
-};
-
-describe('Pest & Disease MVP', () => {
-  it('should accumulate risk and trigger inspection tasks', () => {
-    // 1. Create a world
-    let world = createDemoWorld();
-    world.workforce.taskDefinitions.push(INSPECT_ZONE_TASK);
-    
-    const engine = new Engine(world);
-
-    // 2. Run the simulation for a few days
-    const runContext: EngineRunContext = {
-      tickRate: 1,
-      ticks: 24 * 5, // 5 days
-      telemetry: {
-        emit: () => {},
-      },
-    };
-    world = engine.run(runContext);
-
-    // 3. Assertions
-    const zone = world.company.structures[0].rooms[0].zones[0];
-    const pestDiseaseState = zone.pestDisease;
-
-    // Risk should have accumulated
-    expect(pestDiseaseState.risk01).toBeGreaterThan(0);
-
-    // An inspection task should be in the queue
-    const taskQueue = world.workforce.taskQueue;
-    const inspectionTask = taskQueue.find(task => task.taskCode === 'inspect-zone');
-    expect(inspectionTask).toBeDefined();
-    expect(inspectionTask?.context?.zoneId).toBe(zone.id);
-=======
 import { describe, expect, it } from 'vitest';
 
 import { PIPELINE_ORDER, type EngineRunContext } from '@/backend/src/engine/Engine.js';
@@ -239,6 +190,5 @@ describe('pest & disease system MVP integration', () => {
       PEST_INSPECTION_TASK_CODE,
       PEST_TREATMENT_TASK_CODE,
     ]);
->>>>>>> c29286bdeb0b43866b7afa83a0df476a649aad08
   });
 });

--- a/packages/engine/tests/unit/cultivation/methodRuntime.spec.ts
+++ b/packages/engine/tests/unit/cultivation/methodRuntime.spec.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'vitest';
+
+import basicSoilPot from '../../../../../data/blueprints/cultivation-method/basic-soil-pot.json' assert { type: 'json' };
+import pot10L from '../../../../../data/blueprints/container/pot-10l.json' assert { type: 'json' };
+import soilMultiCycle from '../../../../../data/blueprints/substrate/soil-multi-cycle.json' assert { type: 'json' };
+
+import { createDemoWorld } from '@/backend/src/engine/testHarness.js';
+import {
+  ensureCultivationTaskRuntime,
+  getCultivationMethodCatalog,
+  scheduleCultivationTasksForZone,
+} from '@/backend/src/cultivation/methodRuntime.js';
+import type {
+  EngineRunContext as EngineContext,
+} from '@/backend/src/engine/Engine.js';
+import type {
+  Plant,
+  SimulationWorld,
+  WorkforceState,
+  WorkforceTaskDefinition,
+  Zone,
+  Structure,
+  Room,
+  Uuid,
+} from '@/backend/src/domain/world.js';
+
+function createTaskDefinition(taskCode: string): WorkforceTaskDefinition {
+  return {
+    taskCode,
+    description: taskCode,
+    requiredRoleSlug: 'cultivator',
+    requiredSkills: [],
+    priority: 50,
+    costModel: { basis: 'perPlant', laborMinutes: 12 },
+  } satisfies WorkforceTaskDefinition;
+}
+
+function cloneWorldWithZone(
+  world: SimulationWorld,
+  zoneUpdater: (zone: Zone) => Zone,
+): { world: SimulationWorld; structure: Structure; room: Room; zone: Zone } {
+  const structure = world.company.structures[0];
+  const room = structure.rooms[0];
+  const zone = room.zones[0];
+  const updatedZone = zoneUpdater(zone);
+  const updatedRoom = { ...room, zones: [updatedZone] } satisfies typeof room;
+  const updatedStructure = { ...structure, rooms: [updatedRoom] } satisfies typeof structure;
+  const updatedCompany = {
+    ...world.company,
+    structures: [updatedStructure],
+  } satisfies typeof world.company;
+  const updatedWorld = {
+    ...world,
+    company: updatedCompany,
+  } satisfies SimulationWorld;
+
+  return {
+    world: updatedWorld,
+    structure: updatedStructure,
+    room: updatedRoom,
+    zone: updatedZone,
+  };
+}
+
+describe('cultivation method runtime task scheduling', () => {
+  it('emits sterilisation, disposal, and repot tasks according to policy cycles', () => {
+    let baseWorld = createDemoWorld();
+    baseWorld = {
+      ...baseWorld,
+      simTimeHours: 48,
+    } satisfies SimulationWorld;
+
+    const { world, structure, room, zone } = cloneWorldWithZone(baseWorld, (incomingZone) => {
+      const containerId = pot10L.id as Uuid;
+      const substrateId = soilMultiCycle.id as Uuid;
+      const cultivationMethodId = basicSoilPot.id as Uuid;
+      const plantTemplate: Omit<Plant, 'id'> = {
+        name: 'Test plant',
+        slug: 'test-plant',
+        strainId: '00000000-0000-4000-8000-000000000011' as Uuid,
+        lifecycleStage: 'harvest-ready',
+        ageHours: 720,
+        health01: 0.9,
+        biomass_g: 450,
+        containerId,
+        substrateId,
+        readyForHarvest: false,
+        status: 'harvested',
+        harvestedAt_tick: 47,
+      } satisfies Omit<Plant, 'id'>;
+
+      const plants: Plant[] = [
+        { ...plantTemplate, id: ('00000000-0000-4000-8000-000000000101' as Uuid) },
+        { ...plantTemplate, id: ('00000000-0000-4000-8000-000000000102' as Uuid) },
+      ];
+
+      return {
+        ...incomingZone,
+        cultivationMethodId,
+        containerId,
+        substrateId,
+        plants,
+      } satisfies Zone;
+    });
+
+    const workforceState: WorkforceState = {
+      roles: [],
+      employees: [],
+      taskDefinitions: [
+        createTaskDefinition('cultivation.repot'),
+        createTaskDefinition(soilMultiCycle.reusePolicy.sterilizationTaskCode ?? 'cultivation.substrate.sterilize'),
+        createTaskDefinition('cultivation.substrate.dispose'),
+      ],
+      taskQueue: [],
+      kpis: [],
+      warnings: [],
+      payroll: {
+        dayIndex: 0,
+        totals: { baseMinutes: 0, otMinutes: 0, baseCost: 0, otCost: 0, totalLaborCost: 0 },
+        byStructure: [],
+      },
+      market: { structures: [] },
+    } satisfies WorkforceState;
+
+    const worldWithWorkforce = {
+      ...world,
+      workforce: workforceState,
+    } satisfies SimulationWorld;
+
+    const ctx: EngineContext = {};
+    const runtime = ensureCultivationTaskRuntime(ctx);
+    const catalog = getCultivationMethodCatalog();
+    const currentTick = Math.trunc(worldWithWorkforce.simTimeHours);
+
+    const firstPassTasks = scheduleCultivationTasksForZone({
+      world: worldWithWorkforce,
+      structure,
+      room,
+      zone,
+      workforce: workforceState,
+      runtime,
+      currentTick,
+      methodCatalog: catalog,
+    });
+
+    const steriliseCode = soilMultiCycle.reusePolicy.sterilizationTaskCode ?? 'cultivation.substrate.sterilize';
+    expect(firstPassTasks, 'first harvest schedules sterilisation').toHaveLength(1);
+    expect(firstPassTasks[0]?.taskCode).toBe(steriliseCode);
+
+    // Second cycle should trigger substrate disposal (maxCycles = 2)
+    const secondCyclePlants: Plant[] = zone.plants.map((plant) => ({
+      ...plant,
+      harvestedAt_tick: currentTick,
+    }));
+    const secondCycleZone: Zone = { ...zone, plants: secondCyclePlants } satisfies Zone;
+    const secondCycleWorld = {
+      ...worldWithWorkforce,
+      simTimeHours: worldWithWorkforce.simTimeHours + 1,
+    } satisfies SimulationWorld;
+
+    const secondPassTasks = scheduleCultivationTasksForZone({
+      world: secondCycleWorld,
+      structure,
+      room,
+      zone: secondCycleZone,
+      workforce: workforceState,
+      runtime,
+      currentTick: Math.trunc(secondCycleWorld.simTimeHours),
+      methodCatalog: catalog,
+    });
+
+    expect(secondPassTasks, 'second harvest schedules disposal').toHaveLength(1);
+    expect(secondPassTasks[0]?.taskCode).toBe('cultivation.substrate.dispose');
+
+    // Third cycle should trigger container repot (service life 3) and another sterilisation.
+    const thirdCyclePlants: Plant[] = zone.plants.map((plant) => ({
+      ...plant,
+      harvestedAt_tick: Math.trunc(secondCycleWorld.simTimeHours),
+    }));
+    const thirdCycleZone: Zone = { ...zone, plants: thirdCyclePlants } satisfies Zone;
+    const thirdCycleWorld = {
+      ...secondCycleWorld,
+      simTimeHours: secondCycleWorld.simTimeHours + 1,
+    } satisfies SimulationWorld;
+
+    const thirdPassTasks = scheduleCultivationTasksForZone({
+      world: thirdCycleWorld,
+      structure,
+      room,
+      zone: thirdCycleZone,
+      workforce: workforceState,
+      runtime,
+      currentTick: Math.trunc(thirdCycleWorld.simTimeHours),
+      methodCatalog: catalog,
+    });
+
+    const taskCodes = thirdPassTasks.map((task) => task.taskCode).sort();
+    expect(taskCodes).toEqual(['cultivation.repot', steriliseCode].sort());
+
+    const contexts = thirdPassTasks.map((task) => task.context ?? {}) as Record<string, unknown>[];
+    contexts.forEach((context) => {
+      expect(context.zoneId).toBe(zone.id);
+      expect(context.structureId).toBe(structure.id);
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add a cultivation method task runtime that reads container/substrate policies and tracks zone cycle state to emit deterministic repot/sterilise/disposal jobs
- hook the runtime into applyWorkforce so queued cultivation tasks are deduplicated alongside pest & disease emissions and respect quarantine lookups
- cover the scheduler with unit/integration specs and document the new behaviour in DD plus the changelog

## SEC/TDD
- SEC §7.5, §10
- TDD §7

## Testing
- `pnpm i`
- `pnpm -r lint` *(fails: pre-existing facade/engine lint violations)*
- `pnpm -r build` *(fails: pre-existing TypeScript errors in facade/engine)*
- `pnpm -r test` *(fails: pre-existing missing fixtures & legacy unit failures)*
- `pnpm --filter @wb/engine exec vitest run tests/unit/cultivation/methodRuntime.spec.ts`
- `pnpm --filter @wb/engine exec vitest run tests/integration/pipeline/cultivationMethodTasks.integration.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68e4248f4e488325a053f6fe222a8c21