### PR TITLE
feat(task:0015): harden blueprint taxonomy guards

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Unreleased — Blueprint Taxonomy v2
 
+- Hardened blueprint taxonomy loader guards (Task 0015): renamed the mismatch error to
+  `BlueprintTaxonomyMismatchError`, added dedicated unit coverage for directory depth
+  and class alignment, extended the repository layout spec to assert taxonomy guardrails,
+  and documented the enforcement path in TDD.
 - Hardened the Socket.IO transport adapter (Task 0013): enforced read-only telemetry with
   deterministic `WB_TEL_READONLY` rejections, constrained intents to `intent:submit` with
   `{ type: string }` envelopes, added façade integration tests covering malformed payloads

--- a/docs/TDD.md
+++ b/docs/TDD.md
@@ -57,7 +57,7 @@ src/
 - **Runner:** `vitest` (node).
 - **Coverage threshold:** 90% lines/branches in `engine/` and `facade/`; 80% overall.
 - **Snapshot location:** `__snapshots__` next to specs (only for low‑volatility payloads; prefer golden JSON files for world states).
-- **Blueprint fixtures:** Repository fixtures **MUST** live inside the domain folders that mirror their `class` (`device/climate/*.json`, `cultivation-method/*.json`, `room/purpose/*.json`, etc.). Specs walk `/data/blueprints/**` to assert the folder-derived taxonomy matches the JSON declaration and fail fast when contributors park files elsewhere.
+- **Blueprint fixtures:** Repository fixtures **MUST** live inside the domain folders that mirror their `class` (`device/climate/*.json`, `cultivation-method/*.json`, `room/purpose/*.json`, etc.). Specs walk `/data/blueprints/**` (see `packages/engine/tests/unit/domain/blueprintTaxonomyLayout.test.ts`) to assert the folder-derived taxonomy matches the JSON declaration, validate depth guardrails, and fail fast when contributors park files elsewhere.
 - **Tooling audits:** `packages/tools/tests/packageAudit.test.ts` keeps `docs/reports/PACKAGE_AUDIT.md` in sync with the CLI generator so `pnpm report:packages` remains deterministic documentation-only tooling.
 
 Blueprint directory rule: All blueprints are auto-discovered under /data/blueprints/<domain>/<file>.json with a maximum depth of two segments (domain + file). Devices are /data/blueprints/device/<category>.json or /data/blueprints/device/<category>/<file>.json limited to two levels; no deeper subfolders are allowed.
@@ -77,7 +77,7 @@ Blueprint directory rule: All blueprints are auto-discovered under /data/bluepri
   - `packages/engine/tests/unit/physiology/vpd.spec.ts` asserts Magnus-based saturation, dew point clamps, and VPD determinism at humidity bounds.
   - `packages/engine/tests/unit/physiology/stressCurves.spec.ts` exercises the quadratic tolerance ramp across temperature, humidity/VPD, and PPFD bands; `tests/unit/shared/psychro/psychro.test.ts` keeps the property-based guard on `computeVpd_kPa`.
   - `packages/engine/tests/integration/pipeline/plantStress.integration.test.ts` runs a seed→flowering scenario confirming VPD excursions degrade health and biomass accumulation as mandated by SEC §8.
-- **Taxonomy validation:** Unit tests assert that any mismatch between a blueprint's directory taxonomy and its JSON `class` raises a `BlueprintTaxonomyMismatchError` (or equivalent). Misplaced files must fail the loader guard immediately.
+- **Taxonomy validation:** Unit tests (`packages/engine/tests/unit/data/blueprintTaxonomy.spec.ts`) assert that any mismatch between a blueprint's directory taxonomy and its JSON `class` raises a `BlueprintTaxonomyMismatchError`. The guard also rejects nested directories beyond the two-level allowance so misplacements fail immediately.
 
 - **Fixture layout check:** Repository-level specs enumerate blueprint folders and ensure no stray directories exist outside the sanctioned taxonomy tree. Tests fail if contributors invent ad-hoc folders.
 

--- a/packages/engine/src/backend/src/domain/blueprints/taxonomy.ts
+++ b/packages/engine/src/backend/src/domain/blueprints/taxonomy.ts
@@ -24,7 +24,7 @@ export class BlueprintPathError extends Error {
   }
 }
 
-export class BlueprintClassMismatchError extends Error {
+export class BlueprintTaxonomyMismatchError extends Error {
   constructor(
     readonly filePath: string,
     readonly expectedClass: string,
@@ -33,7 +33,7 @@ export class BlueprintClassMismatchError extends Error {
     super(
       `Blueprint class mismatch for "${filePath}": expected "${expectedClass}" derived from the folder taxonomy, received "${actualClass}".`
     );
-    this.name = 'BlueprintClassMismatchError';
+    this.name = 'BlueprintTaxonomyMismatchError';
   }
 }
 
@@ -140,12 +140,12 @@ export function assertBlueprintClassMatchesPath(
 
   if (derived.allowNamespaceSuffix) {
     if (declaredClass !== expected && !declaredClass.startsWith(`${expected}.`)) {
-      throw new BlueprintClassMismatchError(derived.relativePath, expected, declaredClass);
+      throw new BlueprintTaxonomyMismatchError(derived.relativePath, expected, declaredClass);
     }
     return;
   }
 
   if (declaredClass !== expected) {
-    throw new BlueprintClassMismatchError(derived.relativePath, expected, declaredClass);
+    throw new BlueprintTaxonomyMismatchError(derived.relativePath, expected, declaredClass);
   }
 }

--- a/packages/engine/tests/unit/data/blueprintTaxonomy.spec.ts
+++ b/packages/engine/tests/unit/data/blueprintTaxonomy.spec.ts
@@ -1,0 +1,65 @@
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertBlueprintClassMatchesPath,
+  BlueprintPathError,
+  BlueprintTaxonomyMismatchError,
+  deriveBlueprintClassFromPath
+} from '@/backend/src/domain/blueprints/taxonomy.js';
+import { resolveBlueprintPath } from '../../testUtils/paths.js';
+
+const blueprintsRoot = path.resolve(resolveBlueprintPath(''));
+
+describe('blueprint taxonomy guards', () => {
+  it('derives taxonomy metadata for top-level domain blueprints', () => {
+    const filePath = resolveBlueprintPath('strain/white-widow.json');
+
+    const derived = deriveBlueprintClassFromPath(filePath, { blueprintsRoot });
+
+    expect(derived).toMatchObject({
+      expectedClass: 'strain',
+      allowNamespaceSuffix: false,
+      relativePath: 'strain/white-widow.json'
+    });
+  });
+
+  it('derives taxonomy metadata for nested device blueprints', () => {
+    const filePath = resolveBlueprintPath('device/climate/cool-air-split-3000.json');
+
+    const derived = deriveBlueprintClassFromPath(filePath, { blueprintsRoot });
+
+    expect(derived).toMatchObject({
+      expectedClass: 'device.climate',
+      allowNamespaceSuffix: false,
+      relativePath: 'device/climate/cool-air-split-3000.json'
+    });
+  });
+
+  it('allows namespace suffixes for room blueprints', () => {
+    const filePath = resolveBlueprintPath('room/purpose/growroom.json');
+
+    const derived = deriveBlueprintClassFromPath(filePath, { blueprintsRoot });
+
+    expect(derived).toMatchObject({
+      expectedClass: 'room.purpose',
+      allowNamespaceSuffix: true,
+      relativePath: 'room/purpose/growroom.json'
+    });
+  });
+
+  it('rejects directory depth beyond two levels', () => {
+    const filePath = path.join(blueprintsRoot, 'device/climate/nested/invalid.json');
+
+    expect(() => deriveBlueprintClassFromPath(filePath, { blueprintsRoot })).toThrow(BlueprintPathError);
+  });
+
+  it('throws BlueprintTaxonomyMismatchError when declared class diverges from taxonomy', () => {
+    const filePath = resolveBlueprintPath('device/climate/cool-air-split-3000.json');
+
+    expect(() =>
+      assertBlueprintClassMatchesPath('device.lighting', filePath, { blueprintsRoot })
+    ).toThrow(BlueprintTaxonomyMismatchError);
+  });
+});

--- a/packages/engine/tests/unit/domain/blueprintTaxonomyLayout.test.ts
+++ b/packages/engine/tests/unit/domain/blueprintTaxonomyLayout.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { assertBlueprintClassMatchesPath } from '@/backend/src/domain/blueprints/taxonomy.js';
+import { assertBlueprintClassMatchesPath, deriveBlueprintClassFromPath } from '@/backend/src/domain/blueprints/taxonomy.js';
 import { resolveBlueprintPath } from '../../testUtils/paths.js';
 
 const blueprintsRoot = path.resolve(resolveBlueprintPath(''));
@@ -42,6 +42,22 @@ describe('blueprint taxonomy layout', () => {
         assertBlueprintClassMatchesPath(payload.class as string, filePath, { blueprintsRoot })
       ).not.toThrow();
     }
+  });
+
+  it('keeps blueprint directory depth within taxonomy v2 guardrails', () => {
+    const failures: string[] = [];
+
+    for (const filePath of blueprintFiles) {
+      try {
+        deriveBlueprintClassFromPath(filePath, { blueprintsRoot });
+      } catch (error) {
+        const relative = path.relative(blueprintsRoot, filePath);
+        const message = error instanceof Error ? error.message : String(error);
+        failures.push(`${relative}: ${message}`);
+      }
+    }
+
+    expect(failures).toHaveLength(0);
   });
 
   it('keeps slug identifiers unique per blueprint class', () => {

--- a/packages/engine/tests/unit/domain/strainBlueprintSchema.test.ts
+++ b/packages/engine/tests/unit/domain/strainBlueprintSchema.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import { parseStrainBlueprint } from '../../../src/backend/src/domain/blueprints/strainBlueprint.js';
-import { BlueprintClassMismatchError } from '../../../src/backend/src/domain/blueprints/taxonomy.js';
+import { BlueprintTaxonomyMismatchError } from '../../../src/backend/src/domain/blueprints/taxonomy.js';
 import { resolveBlueprintPath } from '../../testUtils/paths.js';
 
 const fixturePath = resolveBlueprintPath('strain/white-widow.json');
@@ -156,13 +156,13 @@ describe('strainBlueprintSchema', () => {
     ).not.toThrow();
   });
 
-  it('throws BlueprintClassMismatchError when path disagrees', () => {
+  it('throws BlueprintTaxonomyMismatchError when path disagrees', () => {
     expect(() =>
       parseStrainBlueprint(fixturePayload, {
         filePath: path.join(blueprintsRoot, 'device/climate/cool-air-split-3000.json'),
         blueprintsRoot
       })
-    ).toThrow(BlueprintClassMismatchError);
+    ).toThrow(BlueprintTaxonomyMismatchError);
   });
 
   it('detects duplicate slugs in registry', () => {


### PR DESCRIPTION
## Summary
- rename the loader mismatch error to `BlueprintTaxonomyMismatchError` and reuse it across the taxonomy guard
- add focused unit coverage for blueprint taxonomy depth/class behaviour and extend the layout audit to assert the v2 guardrails
- document the enforcement path in TDD and surface the task entry in the changelog

## SEC / TDD Sections
- TDD §2 (Test taxonomy & folder layout)

## Testing
- `pnpm i`
- `pnpm -r --workspace-concurrency=1 lint` *(fails: repository has extensive pre-existing lint errors across engine sources/tests)*
- `pnpm -r --workspace-concurrency=1 build` *(fails: repository TypeScript build currently red with >100 errors unrelated to this task)*
- `pnpm -r --workspace-concurrency=1 test` *(fails: existing missing golden fixtures and Co2InjectorStub expectations; suites unrelated to this change)*

## Deviations
- Could not deliver green lint/build/test runs because the baseline repository already fails lint (hundreds of ESLint violations), build (TypeScript errors in unrelated modules), and tests (missing golden fixtures and failing CO₂ stub assertions). Task 0015 changes are limited to taxonomy guards/tests and do not affect those failing areas.

------
https://chatgpt.com/codex/tasks/task_e_68e453806be48325b26946b130dbd8e2