### PR TITLE
Normalize package audit usage path separators

### DIFF
--- a/packages/tools/src/lib/packageAudit.ts
+++ b/packages/tools/src/lib/packageAudit.ts
@@ -446,8 +446,8 @@ async function detectDirectUsage(
       if (!containsImport(contents, candidate.name)) continue;
 
       const manifest = manifestByDir.find((pkg) => filePath.startsWith(pkg.dirWithSep));
-      const relative = path.relative(repoRoot, filePath);
-      const owner = manifest?.label ?? relative.split(path.sep)[0];
+      const relative = path.relative(repoRoot, filePath).replace(/\\/g, '/');
+      const owner = manifest?.label ?? relative.split('/')[0];
       const list = ensureUsageSet(usage, candidate.name);
       list.add(`${owner}: ${relative}`);
     }


### PR DESCRIPTION
## Summary
- normalize package audit relative paths to forward slashes before reporting usage
- derive package owners by splitting on forward slashes for consistent output across platforms

## Testing
- pnpm --filter @wb/tools test *(fails: vitest not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4a7c288008325993d2de23bf1c7d4