### PR TITLE
Fix package audit manifest detection on Windows

### DIFF
--- a/packages/tools/src/lib/packageAudit.ts
+++ b/packages/tools/src/lib/packageAudit.ts
@@ -440,12 +440,13 @@ async function detectDirectUsage(
   const usage = new Map<string, Set<string>>();
 
   for (const filePath of files) {
+    const normalizedFilePath = path.normalize(filePath);
     const contents = await readFile(filePath, 'utf8');
 
     for (const candidate of CANDIDATES) {
       if (!containsImport(contents, candidate.name)) continue;
 
-      const manifest = manifestByDir.find((pkg) => filePath.startsWith(pkg.dirWithSep));
+      const manifest = manifestByDir.find((pkg) => normalizedFilePath.startsWith(pkg.dirWithSep));
       const relative = path.relative(repoRoot, filePath).replace(/\\/g, '/');
       const owner = manifest?.label ?? relative.split('/')[0];
       const list = ensureUsageSet(usage, candidate.name);


### PR DESCRIPTION
## Summary
- normalize file paths before matching them against manifest directories when building the package audit report
- restore package labels in the generated "Direct Usage" column so it matches the committed markdown snapshot

## Testing
- pnpm --filter @wb/tools test *(fails: vitest binary not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4e61d96188325a5175e9d33100879