### PR TITLE
Allow @wb/tools tests to pass without suites

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Removed the `packages/tools/tests/packageAudit.test.ts` tooling audit; the
   report markdown is now maintained via `pnpm report:packages` without an
   automated sync assertion after repeated encoding failures in CI.
+- Allowed the `@wb/tools` Vitest runner to pass when no test files are
+  present by forwarding `--passWithNoTests`, preventing workspace test runs
+  from failing on empty suites.
 - Hardened blueprint taxonomy loader guards (Task 0015): renamed the mismatch error to
   `BlueprintTaxonomyMismatchError`, added dedicated unit coverage for directory depth
   and class alignment, extended the repository layout spec to assert taxonomy guardrails,

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "build": "tsc --project tsconfig.json",
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "lint": "eslint \"src/**/*.ts\"",
     "format": "prettier --check \"src/**/*.ts\"",
     "dev": "tsx watch src/index.ts",


### PR DESCRIPTION
## Summary
- update the @wb/tools test script to forward --passWithNoTests so Vitest exits cleanly when the package has no suites
- document the change in the changelog

## Testing
- pnpm --filter @wb/tools test

------
https://chatgpt.com/codex/tasks/task_e_68e4e908d324832591492be2d7eab1a5