### PR TITLE
Fix facade Vitest alias for transport adapter

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ### Unreleased — Blueprint Taxonomy v2
 
+### #07 Transport Vitest alias reliability
+
+- Added a façade Vitest alias for `@wb/transport-sio` so integration suites
+  resolve the Socket.IO transport directly from source during workspace test
+  runs, preventing missing dist artifact failures.
+
 - Removed the `packages/tools/tests/packageAudit.test.ts` tooling audit; the
   report markdown is now maintained via `pnpm report:packages` without an
   automated sync assertion after repeated encoding failures in CI.

--- a/packages/facade/vitest.config.ts
+++ b/packages/facade/vitest.config.ts
@@ -20,6 +20,8 @@ export default defineConfig({
   resolve: {
     alias: {
       '@wb/engine': resolve(currentDir, '../engine/src/index.ts'),
+      '@wb/transport-sio': resolve(currentDir, '../transport-sio/src/index.ts'),
+      '@wb/transport-sio/': resolve(currentDir, '../transport-sio/src/'),
       '@/backend': resolve(currentDir, '../engine/src/backend'),
       '@': resolve(currentDir, 'src')
     }


### PR DESCRIPTION
## Summary
- add a Vitest alias in the façade package so @wb/transport-sio resolves to source during tests
- document the transport alias reliability fix in the changelog

## Testing
- pnpm --filter @wb/facade test *(fails: vitest binary unavailable in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4ef91ad148325b06e230e0eda334c