### PR TITLE
feat(task:0017): enforce engine perf budget in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,27 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+  perf-budget:
+    runs-on: ubuntu-latest
+    needs:
+      - quality
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Enforce engine performance budget
+        run: pnpm perf:ci

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased — Blueprint Taxonomy v2
 
 - Published ADR-0017–ADR-0020 to close SEC §14 open questions: locked the canonical irrigation method set, ratified the piecewise quadratic stress→growth curve, mandated hourly-ledger plus daily-rollup economy reporting, and fixed zone height defaults alongside launch cultivation presets.
+- Added a deterministic CI performance budget harness (`pnpm perf:ci`) that runs 10 k demo-world ticks, fails below 5 k ticks/min throughput or above the 64 MiB heap plateau, and emits guard-band warnings so regressions surface before breaching SEC §3 success criteria.
 
 ### #07 Transport Vitest alias reliability
 

--- a/docs/TDD.md
+++ b/docs/TDD.md
@@ -209,9 +209,10 @@ it('rejects zone device in non-grow room', () => {
 - [ ] No extra or missing phases; names match public stage symbols
 - `runTick(world, ctx, { trace: true })` returns `{ world, trace }` where `world` is the immutable post-tick snapshot and `trace` is an optional {@link TickTrace} with monotonic `startedAtNs`, `durationNs`, `endedAtNs`, and heap metrics for every stage without feeding wall-clock time into simulation logic.
 - `runOneTickWithTrace()` (engine test harness) clones the deterministic demo world and returns `{ world, context, trace }` for integration/unit assertions.
-- `withPerfHarness({ ticks })` executes repeated traced ticks and reports `{ traces, totalDurationNs, averageDurationNs, maxHeapUsedBytes }` so perf tests can guard throughput (< 5 ms avg/tick) and heap (< 64 MiB).
+- `withPerfHarness({ ticks })` executes repeated traced ticks and reports `{ traces, totalDurationNs, averageDurationNs, maxHeapUsedBytes }` so perf tests and CI guard throughput (≥ 5 k ticks/min ≈ ≤ 12 ms avg/tick) and heap (< 64 MiB).
 - `generateSeedToHarvestReport({ ticks, scenario })` wraps the orchestrator and perf harness to emit JSON artifacts documenting lifecycle transitions + telemetry; see `docs/engine/simulation-reporting.md` for CLI usage and schema.
 - `createRecordingContext(buffer)` attaches the instrumentation hook so specs can assert that stage completions mirror the trace order.
+- `pnpm --filter @wb/engine perf:ci` runs the CI performance budget harness (10 k traced ticks, deterministic demo world) and fails when throughput falls below 5 k ticks/min or heap exceeds 64 MiB; a 5 % guard band emits warnings for near-regressions requiring manual review.
 
 ---
 

--- a/docs/engine/simulation-reporting.md
+++ b/docs/engine/simulation-reporting.md
@@ -46,6 +46,11 @@ absolute path of the generated file on success.
 
 If the command fails with `Cannot find module '@npmcli/config'`, npm handled the execution instead of pnpm/Corepack. Reinstall or repair npm so it respects the Corepack shim, or switch to pnpm with `corepack use pnpm@10.18.0` before running the CLI.
 
+## 6) CI performance budget harness
+
+- The same perf harness powers the CI gate: `pnpm --filter @wb/engine perf:ci` traces 10 k demo-world ticks, enforces ≥ 5 k ticks/min throughput and a 64 MiB heap ceiling, and surfaces 5 % guard-band warnings for near-regressions that demand manual investigation.
+- Override knobs for local experimentation are exposed via environment variables (`PERF_CI_TICK_COUNT`, `PERF_CI_MIN_TICKS_PER_MINUTE`, `PERF_CI_MAX_HEAP_MIB`, `PERF_CI_WARNING_GUARD_PERCENTAGE`). CI never relaxes the failure thresholds; guard-band warnings document the review window.
+
 ## 5) JSON schema
 
 TypeScript-flavoured pseudo schema describing the artifact shape:

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "pnpm -r build",
     "test": "pnpm -r test",
     "lint": "pnpm -r lint",
+    "perf:ci": "pnpm --filter @wb/engine perf:ci",
     "format": "pnpm -r format",
     "migrate:folders": "node scripts/migrate-blueprint-folders.mjs",
     "migrate:classes": "node scripts/normalize-blueprint-classes.mjs",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -13,6 +13,7 @@
     "test:economy": "vitest run tests/integration/pipeline/economyAccrual.integration.test.ts",
     "test:conf:30d": "vitest run -t golden-30d",
     "test:conf:200d": "vitest run -t golden-200d",
+    "perf:ci": "tsx scripts/perf/ciPerfCheck.ts",
     "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\"",
     "format": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\"",
     "dev": "tsx watch src/index.ts",

--- a/packages/engine/scripts/perf/ciPerfCheck.ts
+++ b/packages/engine/scripts/perf/ciPerfCheck.ts
@@ -1,0 +1,99 @@
+import process from 'node:process';
+
+import { withPerfHarness } from '../../src/backend/src/engine/testHarness.js';
+import {
+  evaluatePerfBudget,
+  PERF_CI_TICK_COUNT,
+  PERF_CI_THRESHOLDS,
+  type PerfBudgetThresholds
+} from '../../src/backend/src/engine/perf/perfBudget.js';
+
+function parseThresholdOverrides(): Partial<PerfBudgetThresholds> {
+  const overrides: Partial<PerfBudgetThresholds> = {};
+  const throughput = process.env.PERF_CI_MIN_TICKS_PER_MINUTE;
+  const heap = process.env.PERF_CI_MAX_HEAP_MIB;
+  const guard = process.env.PERF_CI_WARNING_GUARD_PERCENTAGE;
+
+  if (throughput) {
+    const value = Number.parseFloat(throughput);
+
+    if (Number.isFinite(value) && value > 0) {
+      overrides.minTicksPerMinute = value;
+    }
+  }
+
+  if (heap) {
+    const value = Number.parseFloat(heap);
+
+    if (Number.isFinite(value) && value > 0) {
+      overrides.maxHeapBytes = value * 1024 * 1024;
+    }
+  }
+
+  if (guard) {
+    const value = Number.parseFloat(guard);
+
+    if (Number.isFinite(value) && value >= 0 && value < 1) {
+      overrides.warningGuardPercentage = value;
+    }
+  }
+
+  return overrides;
+}
+
+const tickOverride = process.env.PERF_CI_TICK_COUNT;
+const tickCount = (() => {
+  if (!tickOverride) {
+    return PERF_CI_TICK_COUNT;
+  }
+
+  const parsed = Number.parseInt(tickOverride, 10);
+
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return parsed;
+  }
+
+  return PERF_CI_TICK_COUNT;
+})();
+
+const overrides = parseThresholdOverrides();
+const thresholds = {
+  ...PERF_CI_THRESHOLDS,
+  ...overrides
+} satisfies PerfBudgetThresholds;
+
+const result = withPerfHarness({ ticks: tickCount });
+const evaluation = evaluatePerfBudget(result, overrides);
+
+const lines = [
+  'WeedBreed Engine CI performance budget',
+  `Tick samples: ${evaluation.metrics.tickCount} (requested ${tickCount})`,
+  `Average duration: ${(evaluation.metrics.averageDurationNs / 1_000_000).toFixed(3)} ms`,
+  `Throughput: ${evaluation.metrics.ticksPerMinute.toFixed(2)} ticks/min (min ${thresholds.minTicksPerMinute.toFixed(0)})`,
+  `Heap peak: ${evaluation.metrics.maxHeapUsedMiB.toFixed(2)} MiB (max ${(thresholds.maxHeapBytes / (1024 * 1024)).toFixed(2)} MiB)`,
+  `Guard band: ${(thresholds.warningGuardPercentage * 100).toFixed(1)}%`
+];
+
+for (const line of lines) {
+  console.log(line);
+}
+
+if (evaluation.failures.length > 0) {
+  console.error('\nFailures:');
+  for (const message of evaluation.failures) {
+    console.error(`- ${message}`);
+  }
+}
+
+if (evaluation.warnings.length > 0) {
+  console.warn('\nWarnings:');
+  for (const message of evaluation.warnings) {
+    console.warn(`- ${message}`);
+  }
+}
+
+console.log(`\nResult: ${evaluation.status.toUpperCase()}`);
+
+if (evaluation.status === 'fail') {
+  process.exitCode = 1;
+}

--- a/packages/engine/src/backend/src/engine/perf/perfBudget.ts
+++ b/packages/engine/src/backend/src/engine/perf/perfBudget.ts
@@ -1,0 +1,126 @@
+import { type PerfHarnessResult } from '../testHarness.js';
+
+const NS_PER_SECOND = 1_000_000_000;
+const SECONDS_PER_MINUTE = 60;
+const BYTES_PER_MIB = 1024 * 1024;
+
+export const PERF_CI_TICK_COUNT = 10_000;
+export const PERF_MIN_TICKS_PER_MINUTE = 5_000;
+export const PERF_MAX_HEAP_BYTES = 64 * BYTES_PER_MIB;
+export const PERF_WARNING_GUARD_PERCENTAGE = 0.05;
+
+export interface PerfBudgetThresholds {
+  readonly minTicksPerMinute: number;
+  readonly maxHeapBytes: number;
+  readonly warningGuardPercentage: number;
+}
+
+export interface PerfBudgetMetrics {
+  readonly tickCount: number;
+  readonly totalDurationNs: number;
+  readonly averageDurationNs: number;
+  readonly ticksPerMinute: number;
+  readonly maxHeapUsedBytes: number;
+  readonly maxHeapUsedMiB: number;
+}
+
+export interface PerfBudgetEvaluation {
+  readonly status: 'pass' | 'warn' | 'fail';
+  readonly failures: readonly string[];
+  readonly warnings: readonly string[];
+  readonly metrics: PerfBudgetMetrics;
+  readonly thresholds: PerfBudgetThresholds;
+}
+
+export const PERF_CI_THRESHOLDS: PerfBudgetThresholds = {
+  minTicksPerMinute: PERF_MIN_TICKS_PER_MINUTE,
+  maxHeapBytes: PERF_MAX_HEAP_BYTES,
+  warningGuardPercentage: PERF_WARNING_GUARD_PERCENTAGE
+} as const;
+
+export function evaluatePerfBudget(
+  result: PerfHarnessResult,
+  overrides?: Partial<PerfBudgetThresholds>
+): PerfBudgetEvaluation {
+  const thresholds: PerfBudgetThresholds = {
+    ...PERF_CI_THRESHOLDS,
+    ...overrides
+  } satisfies PerfBudgetThresholds;
+
+  const tickCount = result.traces.length;
+  const totalDurationNs = result.totalDurationNs;
+  const averageDurationNs = result.averageDurationNs;
+  const totalDurationMinutes = totalDurationNs / NS_PER_SECOND / SECONDS_PER_MINUTE;
+  const ticksPerMinute =
+    totalDurationMinutes > 0 ? tickCount / totalDurationMinutes : Number.POSITIVE_INFINITY;
+  const maxHeapUsedBytes = result.maxHeapUsedBytes;
+  const maxHeapUsedMiB = maxHeapUsedBytes / BYTES_PER_MIB;
+
+  const failures: string[] = [];
+  const warnings: string[] = [];
+
+  if (!Number.isFinite(ticksPerMinute) || ticksPerMinute <= 0) {
+    failures.push('Perf harness duration produced a non-finite ticks/minute measurement.');
+  }
+
+  if (!Number.isFinite(maxHeapUsedBytes) || maxHeapUsedBytes <= 0) {
+    failures.push('Perf harness heap metrics must be finite and positive.');
+  }
+
+  if (ticksPerMinute < thresholds.minTicksPerMinute) {
+    failures.push(
+      `Throughput ${ticksPerMinute.toFixed(2)} ticks/min is below the ${thresholds.minTicksPerMinute.toFixed(
+        0
+      )} ticks/min requirement.`
+    );
+  } else {
+    const throughputWarningFloor = thresholds.minTicksPerMinute * (1 + thresholds.warningGuardPercentage);
+
+    if (ticksPerMinute < throughputWarningFloor) {
+      warnings.push(
+        `Throughput ${ticksPerMinute.toFixed(2)} ticks/min is within ${(
+          thresholds.warningGuardPercentage * 100
+        ).toFixed(1)}% of the failure threshold.`
+      );
+    }
+  }
+
+  if (maxHeapUsedBytes > thresholds.maxHeapBytes) {
+    failures.push(
+      `Heap peak ${(maxHeapUsedMiB).toFixed(2)} MiB exceeds ${(thresholds.maxHeapBytes / BYTES_PER_MIB).toFixed(
+        2
+      )} MiB budget.`
+    );
+  } else {
+    const heapWarningCeiling = thresholds.maxHeapBytes * (1 - thresholds.warningGuardPercentage);
+
+    if (maxHeapUsedBytes > heapWarningCeiling) {
+      warnings.push(
+        `Heap peak ${maxHeapUsedMiB.toFixed(2)} MiB is within ${(
+          thresholds.warningGuardPercentage * 100
+        ).toFixed(1)}% of the budget.`
+      );
+    }
+  }
+
+  const status: PerfBudgetEvaluation['status'] = failures.length
+    ? 'fail'
+    : warnings.length
+      ? 'warn'
+      : 'pass';
+
+  return {
+    status,
+    failures,
+    warnings,
+    metrics: {
+      tickCount,
+      totalDurationNs,
+      averageDurationNs,
+      ticksPerMinute,
+      maxHeapUsedBytes,
+      maxHeapUsedMiB
+    },
+    thresholds
+  } satisfies PerfBudgetEvaluation;
+}

--- a/packages/engine/tests/unit/perf/perfBudget.spec.ts
+++ b/packages/engine/tests/unit/perf/perfBudget.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  evaluatePerfBudget,
+  PERF_CI_THRESHOLDS,
+  type PerfBudgetEvaluation
+} from '@/backend/src/engine/perf/perfBudget.js';
+import { type PerfHarnessResult } from '@/backend/src/engine/testHarness.js';
+import { type TickTrace } from '@/backend/src/engine/trace.js';
+
+interface MockPerfInput {
+  readonly tickCount: number;
+  readonly averageDurationNs: number;
+  readonly maxHeapBytes: number;
+}
+
+function createTickTrace(durationNs: number, heapBytes: number): TickTrace {
+  return {
+    startedAtNs: 0,
+    endedAtNs: durationNs,
+    durationNs,
+    steps: [],
+    totalHeapUsedDeltaBytes: 0,
+    maxHeapUsedBytes: heapBytes
+  } satisfies TickTrace;
+}
+
+function createPerfHarnessResult(input: MockPerfInput): PerfHarnessResult {
+  const traces: TickTrace[] = [];
+
+  for (let index = 0; index < input.tickCount; index += 1) {
+    traces.push(createTickTrace(input.averageDurationNs, input.maxHeapBytes));
+  }
+
+  const totalDurationNs = input.averageDurationNs * input.tickCount;
+
+  return {
+    traces,
+    totalDurationNs,
+    averageDurationNs: input.averageDurationNs,
+    maxHeapUsedBytes: input.maxHeapBytes
+  } satisfies PerfHarnessResult;
+}
+
+describe('evaluatePerfBudget', () => {
+  it('passes when throughput and heap headroom exceed thresholds', () => {
+    const result = createPerfHarnessResult({
+      tickCount: 100,
+      averageDurationNs: 8_000_000,
+      maxHeapBytes: 40 * 1024 * 1024
+    });
+
+    const evaluation = evaluatePerfBudget(result);
+
+    expect(evaluation.status).toBe('pass');
+    expect(evaluation.failures).toHaveLength(0);
+    expect(evaluation.warnings).toHaveLength(0);
+  });
+
+  it('emits warnings when metrics are inside the guard band', () => {
+    const averageDurationNs = Math.round((60 * 1_000_000_000) / 5_100);
+    const result = createPerfHarnessResult({
+      tickCount: 100,
+      averageDurationNs,
+      maxHeapBytes: Math.trunc(PERF_CI_THRESHOLDS.maxHeapBytes * 0.975)
+    });
+
+    const evaluation = evaluatePerfBudget(result);
+
+    expect(evaluation.status).toBe('warn');
+    expect(evaluation.failures).toHaveLength(0);
+    expect(evaluation.warnings.length).toBeGreaterThan(0);
+  });
+
+  it('fails when throughput or heap exceed the budget', () => {
+    const slowResult = createPerfHarnessResult({
+      tickCount: 100,
+      averageDurationNs: 15_000_000,
+      maxHeapBytes: PERF_CI_THRESHOLDS.maxHeapBytes + 1024
+    });
+
+    const evaluation: PerfBudgetEvaluation = evaluatePerfBudget(slowResult);
+
+    expect(evaluation.status).toBe('fail');
+    expect(evaluation.failures.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add a deterministic perf budget evaluator and CLI (`pnpm --filter @wb/engine perf:ci`) that samples 10k demo ticks and flags failures below 5k ticks/min or above the 64 MiB heap ceiling
- surface the new perf harness through workspace scripts and a dedicated CI job so the gate runs on every PR
- document the perf guardrail and guard-band policy in TDD and simulation-reporting, and log the change in the changelog

## SEC/TDD sections
- TDD §7 Tick trace instrumentation & perf harness

## Testing
- pnpm i
- pnpm --reporter append-only -r lint *(fails: pre-existing lint violations in @wb/engine)*
- pnpm --reporter append-only -r build *(fails: pre-existing TypeScript errors in @wb/engine)*
- pnpm --reporter append-only -r test

------
https://chatgpt.com/codex/tasks/task_e_68e4f6e6fb3c8325bc7b5608ac62678f