### PR TITLE
Fix tools-monitor Vitest alias for transport dependency

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Published ADR-0017–ADR-0020 to close SEC §14 open questions: locked the canonical irrigation method set, ratified the piecewise quadratic stress→growth curve, mandated hourly-ledger plus daily-rollup economy reporting, and fixed zone height defaults alongside launch cultivation presets.
 - Added a deterministic CI performance budget harness (`pnpm perf:ci`) that runs 10 k demo-world ticks, fails below 5 k ticks/min throughput or above the 64 MiB heap plateau, and emits guard-band warnings so regressions surface before breaching SEC §3 success criteria.
+- Added a tools-monitor Vitest alias for `@wb/transport-sio` so terminal monitor integration tests resolve the Socket.IO transport directly from source during workspace runs, preventing missing dist artifact failures.
 
 ### #79 Terminal monitor MVP (Task 0018)
 

--- a/packages/tools-monitor/vitest.config.ts
+++ b/packages/tools-monitor/vitest.config.ts
@@ -1,4 +1,8 @@
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   test: {
@@ -12,5 +16,11 @@ export default defineConfig({
   },
   esbuild: {
     target: 'es2022'
+  },
+  resolve: {
+    alias: {
+      '@wb/transport-sio': resolve(currentDir, '../transport-sio/src/index.ts'),
+      '@wb/transport-sio/': resolve(currentDir, '../transport-sio/src/')
+    }
   }
 });


### PR DESCRIPTION
## Summary
- add a Vitest alias in @wb/tools-monitor so @wb/transport-sio resolves from source during workspace tests
- document the alias fix in the changelog

## Testing
- pnpm --filter @wb/tools-monitor test *(fails: Vitest binary unavailable because workspace dependencies are not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e51305b87c83259536808260147088