### PR TITLE
feat(task:0019): tighten CO₂ clamp reporting

### DIFF
--- a/docs/ADR/ADR-0012-node-version-tooling-alignment.md
+++ b/docs/ADR/ADR-0012-node-version-tooling-alignment.md
@@ -15,7 +15,7 @@
 
 ## Context
 
-The monorepo targets Node.js 23+ in production and CI, matching the Simulation Engine Contract (SEC) guidance captured in root tooling metadata. However, developers frequently rely on environment managers such as `nvm`, `fnm`, `nodenv`, or `asdf` to synchronise their local runtimes. Without explicit version files, onboarding engineers must manually inspect `package.json` to discover the expected Node release, leading to mismatches between local shells, editor integrations, and automated scripts. The upcoming migration workstream for Node.js 22 LTS requires a deterministic mechanism to coordinate contributor upgrades and smoke-test the toolchain before flipping the enforced `engines.node` constraint.
+The monorepo now targets **Node.js 22 LTS** for production and CI, in line with the Simulation Engine Contract (SEC) and the markers documented in `AGENTS.md` and workspace manifests. Historically, the runtime alignment effort aimed at Node.js 23+, which is why some legacy notes still reference that target. Regardless of that history, developers rely on environment managers such as `nvm`, `fnm`, `nodenv`, or `asdf` to synchronise their local runtimes. Without explicit version files, onboarding engineers must manually inspect `package.json` to discover the expected Node release, leading to mismatches between local shells, editor integrations, and automated scripts. The Node.js 22 LTS standard therefore requires a deterministic mechanism to coordinate contributor upgrades and smoke-test the toolchain before flipping the enforced `engines.node` constraint.
 
 ## Decision
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Unreleased — Blueprint Taxonomy v2
 
+- Fixed CO₂ injector clamp reporting (Task 0019) and extended tariff bootstrap tests:
+  - Corrected `clampedByTarget` so it only flips when the requested delta exceeds deliverable output, and added coverage to verify satisfied requests remain unclamped.
+  - Exercised difficulty-specific tariff overrides and cache reuse in `createEngineBootstrapConfig` while syncing SEC/ADR typos with the Node.js 22 baseline.
+
 - Added guardrails and coverage across the simulation engine:
   - Introduced ESLint rule `wb-sim/no-economy-per-tick` (with unit tests) to block monetary `*_per_tick` identifiers, documented the guardrail in TDD, and recorded ADR-0021.
   - Published `docs/engine/telemetry.md` describing every telemetry topic/payload with SEC §15 cross-linking.

--- a/docs/SEC.md
+++ b/docs/SEC.md
@@ -641,7 +641,7 @@ Validation occurs at load time; on failure, the engine must not start. Validatio
 - **Quality scale:** adopt **[0,1]** engine scale; façade/read-model maps to 0–100 where needed.
 - **Save schema:** save files carry `schemaVersion`; the engine ships a migration registry (`packages/engine/src/backend/src/saveLoad/migrations`) with deterministic fixtures validating legacy upgrades (current: v0 → v1 normalises `simTime`).
 
-- Water + **Electricity tariff:** ensure backend config exposes `price_electricity` for electricity in kWh and `price_water` for water per m^3; difficulty layer provides `energyPriceFactor` and/or `energyPriceOverride`aswell as `waterPriceFactor` and/or `waterPriceOverride`.
+- Water + **Electricity tariff:** ensure backend config exposes `price_electricity` for electricity in kWh and `price_water` for water per m^3; difficulty layer provides `energyPriceFactor` and/or `energyPriceOverride` as well as `waterPriceFactor` and/or `waterPriceOverride`.
 
 ---
 

--- a/packages/engine/src/backend/src/stubs/Co2InjectorStub.ts
+++ b/packages/engine/src/backend/src/stubs/Co2InjectorStub.ts
@@ -167,7 +167,8 @@ export function createCo2InjectorStub(): ICo2Injector {
           requestedDelta_ppm,
           energy_Wh: 0,
           effectiveDuty01: 0,
-          clampedByTarget: requestedDelta_ppm > FLOAT_TOLERANCE,
+          clampedByTarget:
+            requestedDelta_ppm > deliverable_ppm + FLOAT_TOLERANCE,
           clampedBySafety: safetyHeadroom_ppm <= FLOAT_TOLERANCE
         });
       }
@@ -177,7 +178,8 @@ export function createCo2InjectorStub(): ICo2Injector {
       );
       const power_W = Math.max(0, ensureFinite(inputs.power_W, 0));
       const energy_Wh = power_W * resolvedDt_h * effectiveDuty01;
-      const clampedByTarget = requestedDelta_ppm > FLOAT_TOLERANCE;
+      const clampedByTarget =
+        requestedDelta_ppm > deliverable_ppm + FLOAT_TOLERANCE;
       const clampedBySafety =
         Number.isFinite(safetyCeiling_ppm) && safetyHeadroom_ppm <= deliverable_ppm + FLOAT_TOLERANCE;
 

--- a/packages/engine/tests/unit/createEngineBootstrapConfig.test.ts
+++ b/packages/engine/tests/unit/createEngineBootstrapConfig.test.ts
@@ -27,4 +27,20 @@ describe('createEngineBootstrapConfig', () => {
       /scenarioId must be a non-empty string/
     );
   });
+
+  it('honours difficulty overrides when they exist', () => {
+    const config = createEngineBootstrapConfig('hard');
+
+    expect(config.tariffs).toEqual({
+      price_electricity: 0.35 * 1.25,
+      price_water: 2.5
+    });
+  });
+
+  it('reuses cached tariffs for repeated difficulty lookups', () => {
+    const first = createEngineBootstrapConfig('hard');
+    const second = createEngineBootstrapConfig('hard');
+
+    expect(second.tariffs).toBe(first.tariffs);
+  });
 });

--- a/packages/engine/tests/unit/stubs/Co2InjectorStub.test.ts
+++ b/packages/engine/tests/unit/stubs/Co2InjectorStub.test.ts
@@ -48,7 +48,7 @@ describe('Co2InjectorStub', () => {
     expect(result.delta_ppm).toBeCloseTo(50, 6);
     expect(result.effectiveDuty01).toBeCloseTo(0.25, 6);
     expect(result.energy_Wh).toBeCloseTo(150 * 0.25, 6);
-    expect(result.clampedByTarget).toBe(true);
+    expect(result.clampedByTarget).toBe(false);
   });
 
   it('respects the safety ceiling clamp', () => {
@@ -88,5 +88,25 @@ describe('Co2InjectorStub', () => {
     expect(result.delta_ppm).toBe(0);
     expect(result.energy_Wh).toBe(0);
     expect(result.clampedByTarget).toBe(true);
+  });
+
+  it('flags clamping only when the request cannot be met', () => {
+    const satisfied = stub.computeEffect(
+      inputs({ target_ppm: AMBIENT_CO2_PPM + 20 }),
+      BASE_ENVIRONMENT,
+      HOURS_PER_TICK
+    );
+
+    expect(satisfied.delta_ppm).toBeCloseTo(20, 6);
+    expect(satisfied.clampedByTarget).toBe(false);
+
+    const limited = stub.computeEffect(
+      inputs({ dutyCycle01: 0.25 }),
+      BASE_ENVIRONMENT,
+      HOURS_PER_TICK
+    );
+
+    expect(limited.delta_ppm).toBeLessThan(limited.requestedDelta_ppm);
+    expect(limited.clampedByTarget).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- fix `clampedByTarget` in the CO₂ injector stub so it only trips when delivery falls short of the request
- extend bootstrap and stub unit suites to cover tariff overrides, caching behaviour, and unclamped delivery cases
- align SEC migration guidance, ADR-0012 context, and CHANGELOG notes with the Node.js 22 baseline and the corrected clamp semantics

## SEC/TDD Sections
- SEC §13 (Migration Notes)

## Testing
- `pnpm i`
- `CI=1 pnpm -r lint` *(fails: repository has 480 pre-existing lint errors across @wb/engine)*
- `CI=1 pnpm -r build` *(fails: TypeScript compilation currently broken upstream for @wb/engine)*
- `CI=1 pnpm -r test` *(pass: 95 suites / 475 tests across workspaces)*

## Deviations
- Ran lint/build with `CI=1` to suppress interactive spinners; both commands fail because the baseline @wb/engine workspace has unresolved lint and TypeScript errors that predate this task.


------
https://chatgpt.com/codex/tasks/task_e_68e62a3343a88325aec5765e89a12dc0