### PR TITLE
Add mock telemetry harness for terminal monitor

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Published ADR-0017–ADR-0020 to close SEC §14 open questions: locked the canonical irrigation method set, ratified the piecewise quadratic stress→growth curve, mandated hourly-ledger plus daily-rollup economy reporting, and fixed zone height defaults alongside launch cultivation presets.
 - Added a deterministic CI performance budget harness (`pnpm perf:ci`) that runs 10 k demo-world ticks, fails below 5 k ticks/min throughput or above the 64 MiB heap plateau, and emits guard-band warnings so regressions surface before breaching SEC §3 success criteria.
 - Added a tools-monitor Vitest alias for `@wb/transport-sio` so terminal monitor integration tests resolve the Socket.IO transport directly from source during workspace runs, preventing missing dist artifact failures.
+- Added a deterministic mock telemetry harness (`pnpm monitor:mock`) that exercises the terminal monitor without a running façade and documented the TTY/Socket.IO requirements in `docs/tools/terminal-monitor.md`.
 
 ### #79 Terminal monitor MVP (Task 0018)
 

--- a/docs/tools/terminal-monitor.md
+++ b/docs/tools/terminal-monitor.md
@@ -14,14 +14,36 @@ providing a quick-look operational view aligned with the experience pillar in
 
 ## Running the monitor
 
+The terminal dashboard expects an interactive TTY. When launched inside tools
+that buffer stdout (e.g. CI logs) the neo-blessed screen will not render.
+
+### 1. Start a telemetry source
+
+The monitor only subscribes to the read-only Socket.IO namespace. Point it at
+either a running façade/transport instance or the deterministic mock server
+shipped with this package:
+
 ```bash
-pnpm monitor:terminal [--base-url=http://host:port] [--refresh-ms=1000]
+pnpm monitor:mock [-- --host=127.0.0.1 --port=4000 --interval-ms=1000]
 ```
 
-- The CLI automatically appends `/telemetry` to the provided base URL and only
-  listens to the read-only namespace. No commands are sent upstream.
+- CLI flags mirror the env vars below. The defaults match the monitor CLI so
+  both tools align on `http://127.0.0.1:4000/telemetry`.
+- Environment overrides for the mock harness:
+  - `WB_MOCK_TELEMETRY_HOST`
+  - `WB_MOCK_TELEMETRY_PORT`
+  - `WB_MOCK_TELEMETRY_INTERVAL_MS`
+
+### 2. Launch the monitor
+
+```bash
+pnpm monitor:terminal -- --base-url=http://127.0.0.1:4000 --refresh-ms=1000
+```
+
+- The CLI automatically appends `/telemetry` to the base URL. No commands are
+  ever emitted upstream.
 - Environment overrides:
-  - `WB_MONITOR_BASE_URL` — default telemetry host (defaults to
+  - `WB_MONITOR_BASE_URL` — telemetry host (defaults to
     `http://127.0.0.1:4000`).
   - `WB_MONITOR_REFRESH_MS` — deterministic refresh cadence in milliseconds
     (defaults to `1000`).

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "migrate:classes": "node scripts/normalize-blueprint-classes.mjs",
     "migrate:blueprints": "npm run migrate:folders && npm run migrate:classes",
     "monitor:terminal": "pnpm --filter @wb/tools-monitor run start",
+    "monitor:mock": "pnpm --filter @wb/tools-monitor run mock-server",
     "preinstall": "node ./tools/scripts/ensure-pnpm.mjs",
     "verify-pnpm": "node ./tools/scripts/ensure-pnpm.mjs",
     "report:packages": "pnpm --filter ./packages/tools run report:packages",

--- a/packages/tools-monitor/package.json
+++ b/packages/tools-monitor/package.json
@@ -11,7 +11,8 @@
     "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\"",
     "format": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\"",
     "dev": "tsx watch src/index.ts",
-    "start": "tsx src/index.ts"
+    "start": "tsx src/index.ts",
+    "mock-server": "tsx scripts/mockTelemetryServer.mts"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/packages/tools-monitor/scripts/mockTelemetryServer.mts
+++ b/packages/tools-monitor/scripts/mockTelemetryServer.mts
@@ -1,0 +1,318 @@
+import { createServer } from 'node:http';
+import process from 'node:process';
+import {
+  createSocketTransportAdapter,
+  type SocketTransportAdapter,
+  type TelemetryEvent,
+} from '@wb/transport-sio';
+
+interface MockServerOptions {
+  readonly host: string;
+  readonly port: number;
+  readonly intervalMs: number;
+}
+
+function parsePositiveInteger(value: string | undefined, fallback: number): number {
+  if (!value) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseOptions(argv: readonly string[], env: NodeJS.ProcessEnv): MockServerOptions {
+  let host = env.WB_MOCK_TELEMETRY_HOST?.trim() || '127.0.0.1';
+  let port = parsePositiveInteger(env.WB_MOCK_TELEMETRY_PORT, 4000);
+  let intervalMs = parsePositiveInteger(env.WB_MOCK_TELEMETRY_INTERVAL_MS, 1000);
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index] ?? '';
+
+    if (argument === '--host') {
+      host = argv[index + 1]?.trim() || host;
+      index += 1;
+      continue;
+    }
+
+    if (argument.startsWith('--host=')) {
+      const [, value] = argument.split('=', 2);
+      host = value?.trim() || host;
+      continue;
+    }
+
+    if (argument === '--port') {
+      port = parsePositiveInteger(argv[index + 1], port);
+      index += 1;
+      continue;
+    }
+
+    if (argument.startsWith('--port=')) {
+      const [, value] = argument.split('=', 2);
+      port = parsePositiveInteger(value, port);
+      continue;
+    }
+
+    if (argument === '--interval-ms') {
+      intervalMs = parsePositiveInteger(argv[index + 1], intervalMs);
+      index += 1;
+      continue;
+    }
+
+    if (argument.startsWith('--interval-ms=')) {
+      const [, value] = argument.split('=', 2);
+      intervalMs = parsePositiveInteger(value, intervalMs);
+    }
+  }
+
+  return { host, port, intervalMs } satisfies MockServerOptions;
+}
+
+function createMockPayloads(tick: number): TelemetryEvent[] {
+  const simTimeHours = tick;
+  const queueDepth = tick % 6;
+  const overtimeMinutes = (tick % 4) * 30;
+
+  const workforceEvent: TelemetryEvent = {
+    topic: 'telemetry.workforce.kpi.v1',
+    payload: {
+      snapshot: {
+        simTimeHours,
+        tasksCompleted: tick * 3,
+        queueDepth,
+        laborHoursCommitted: 8 + (tick % 4),
+        overtimeHoursCommitted: overtimeMinutes / 60,
+        overtimeMinutes,
+        utilization01: ((tick % 10) + 2) / 12,
+        p95WaitTimeHours: 0.5 + (tick % 5) * 0.25,
+        maintenanceBacklog: tick % 4,
+        averageMorale01: 0.55 + ((tick % 3) * 0.05),
+        averageFatigue01: 0.35 + ((tick % 4) * 0.08),
+      },
+    },
+  } satisfies TelemetryEvent;
+
+  const workforceWarningsEvent: TelemetryEvent = {
+    topic: 'telemetry.workforce.warning.v1',
+    payload: {
+      warnings:
+        queueDepth > 3
+          ? [
+              {
+                simTimeHours,
+                code: 'queue_depth_high',
+                message: `Queue depth ${queueDepth} waiting tasks`,
+                severity: queueDepth >= 5 ? 'critical' : 'warning',
+                metadata: { queueDepth },
+              },
+            ]
+          : [],
+    },
+  } satisfies TelemetryEvent;
+
+  const events: TelemetryEvent[] = [workforceEvent, workforceWarningsEvent];
+
+  if (tick % 3 === 0) {
+    events.push({
+      topic: 'telemetry.health.pest_disease.risk.v1',
+      payload: {
+        warnings: [
+          {
+            structureId: 'structure-1',
+            roomId: 'room-1',
+            zoneId: `zone-${(tick % 3) + 1}`,
+            riskLevel: tick % 6 === 0 ? 'severe' : 'elevated',
+            risk01: 0.3 + (tick % 5) * 0.1,
+            tick: simTimeHours,
+          },
+        ],
+      },
+    });
+  }
+
+  if (tick % 4 === 0) {
+    events.push({
+      topic: 'telemetry.health.pest_disease.task_emitted.v1',
+      payload: {
+        events: [
+          {
+            taskId: `task-${tick}`,
+            taskCode: 'inspect_zone',
+            structureId: 'structure-1',
+            roomId: 'room-1',
+            zoneId: `zone-${(tick % 3) + 1}`,
+            tick: simTimeHours,
+            riskLevel: 'follow_up',
+            risk01: 0.2 + (tick % 4) * 0.1,
+          },
+        ],
+      },
+    });
+  }
+
+  if (tick % 8 === 0) {
+    events.push({
+      topic: 'telemetry.device.maintenance.scheduled.v1',
+      payload: {
+        taskId: `maint-${tick}`,
+        deviceId: `device-${(tick % 5) + 1}`,
+        structureId: 'structure-1',
+        roomId: 'room-1',
+        zoneId: `zone-${(tick % 3) + 1}`,
+        startTick: simTimeHours,
+        endTick: simTimeHours + 4,
+        serviceHours: 1 + (tick % 3) * 0.5,
+        reason: tick % 16 === 0 ? 'Filter replacement' : 'Routine inspection',
+        serviceVisitCostCc: 85 + (tick % 4) * 15,
+      },
+    });
+  }
+
+  if (tick % 12 === 0) {
+    events.push({
+      topic: 'telemetry.device.replacement.recommended.v1',
+      payload: {
+        deviceId: `device-${(tick % 5) + 1}`,
+        structureId: 'structure-1',
+        roomId: 'room-1',
+        zoneId: `zone-${(tick % 3) + 1}`,
+        recommendedSinceTick: simTimeHours - 6,
+        totalMaintenanceCostCc: 320 + tick * 4,
+        replacementCostCc: 540 + tick * 8,
+      },
+    });
+  }
+
+  if (tick % 6 === 0) {
+    const dayIndex = tick / 6;
+    const baseMinutes = 480 + (dayIndex % 3) * 30;
+    const otMinutes = 60 + (dayIndex % 2) * 30;
+    const baseCost = baseMinutes * 1.2;
+    const otCost = otMinutes * 1.8;
+    const totalLaborCost = baseCost + otCost;
+
+    events.push({
+      topic: 'telemetry.workforce.payroll_snapshot.v1',
+      payload: {
+        snapshot: {
+          dayIndex,
+          totals: {
+            baseMinutes,
+            otMinutes,
+            baseCost,
+            otCost,
+            totalLaborCost,
+          },
+          byStructure: [
+            {
+              structureId: 'structure-1',
+              baseMinutes: baseMinutes * 0.6,
+              otMinutes: otMinutes * 0.5,
+              baseCost: baseCost * 0.6,
+              otCost: otCost * 0.5,
+              totalLaborCost: totalLaborCost * 0.55,
+            },
+            {
+              structureId: 'structure-2',
+              baseMinutes: baseMinutes * 0.4,
+              otMinutes: otMinutes * 0.5,
+              baseCost: baseCost * 0.4,
+              otCost: otCost * 0.5,
+              totalLaborCost: totalLaborCost * 0.45,
+            },
+          ],
+        },
+      },
+    });
+  }
+
+  return events;
+}
+
+async function startServer(options: MockServerOptions): Promise<{
+  readonly adapter: SocketTransportAdapter;
+  stop(): Promise<void>;
+}> {
+  const httpServer = createServer();
+
+  await new Promise<void>((resolve) => {
+    httpServer.listen(options.port, options.host, () => {
+      resolve();
+    });
+  });
+
+  console.log(
+    `[mock-telemetry] Listening on http://${options.host}:${String(options.port)}/telemetry`
+  );
+
+  const adapter = createSocketTransportAdapter({
+    httpServer,
+    onIntent: () => {
+      console.warn('[mock-telemetry] Ignoring intent on read-only mock server.');
+    },
+  });
+
+  adapter.namespaces.telemetry.on('connection', (socket) => {
+    console.log('[mock-telemetry] Telemetry subscriber connected.');
+    socket.on('disconnect', (reason) => {
+      console.log(`[mock-telemetry] Telemetry subscriber disconnected (${reason}).`);
+    });
+  });
+
+  return {
+    adapter,
+    async stop() {
+      await adapter.close();
+      await new Promise<void>((resolve) => {
+        httpServer.close(() => {
+          resolve();
+        });
+      });
+    },
+  };
+}
+
+async function main(): Promise<void> {
+  const options = parseOptions(process.argv.slice(2), process.env);
+  const server = await startServer(options);
+
+  let tick = 0;
+  const interval = setInterval(() => {
+    tick += 1;
+    const payloads = createMockPayloads(tick);
+    for (const event of payloads) {
+      server.adapter.publishTelemetry(event);
+    }
+  }, options.intervalMs);
+
+  let shuttingDown = false;
+
+  const shutdown = async () => {
+    if (shuttingDown) {
+      return;
+    }
+
+    shuttingDown = true;
+    clearInterval(interval);
+
+    try {
+      await server.stop();
+    } catch (error) {
+      console.error('[mock-telemetry] Failed to close server cleanly.', error);
+    }
+
+    process.exit(0);
+  };
+
+  process.on('SIGINT', () => {
+    void shutdown();
+  });
+  process.on('SIGTERM', () => {
+    void shutdown();
+  });
+}
+
+main().catch((error) => {
+  console.error('[mock-telemetry] Fatal error starting mock telemetry server.', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a deterministic mock Socket.IO telemetry server for the terminal monitor and expose it via `pnpm monitor:mock`
- document the monitor's TTY requirement and how to run it against the mock harness
- record the change in the changelog

## Testing
- pnpm --filter @wb/tools-monitor test

------
https://chatgpt.com/codex/tasks/task_e_68e62c905c488325935056f44d271d6a