### PR TITLE
Align UUID schema branding across backend domain

### DIFF
--- a/packages/engine/src/backend/src/domain/entities.ts
+++ b/packages/engine/src/backend/src/domain/entities.ts
@@ -1,3 +1,5 @@
+import type { BRAND } from 'zod';
+
 import type { Inventory } from './types/Inventory.js';
 import type { HealthState } from './health/pestDisease.js';
 import type { WorkforceState } from './workforce/WorkforceState.js';
@@ -5,7 +7,7 @@ import type { WorkforceState } from './workforce/WorkforceState.js';
 /**
  * Branded string type representing a UUID v4 identifier.
  */
-export type Uuid = string & { readonly __brand: unique symbol };
+export type Uuid = string & BRAND<'Uuid'>;
 
 /**
  * Canonical list of supported room purposes as mandated by SEC §2.1.

--- a/packages/engine/src/backend/src/domain/schemas.ts
+++ b/packages/engine/src/backend/src/domain/schemas.ts
@@ -27,6 +27,7 @@ import {
   type Structure,
   type StructureDeviceInstance,
   type Zone,
+  type Uuid,
   type ZoneDeviceInstance,
   type ZoneEnvironment
 } from './entities.js';
@@ -60,7 +61,10 @@ import type {
 
 const [STRUCTURE_SCOPE, ROOM_SCOPE, ZONE_SCOPE] = DEVICE_PLACEMENT_SCOPES;
 
-const uuidSchema = z.string().uuid('Expected a UUID v4 identifier.').brand<'Uuid'>();
+export const uuidSchema: z.ZodType<Uuid> = z
+  .string()
+  .uuid('Expected a UUID v4 identifier.')
+  .brand<'Uuid'>();
 const uuidV7Pattern = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const uuidV7Schema: z.ZodBranded<string, EmployeeRngSeedUuid> = z
   .string()

--- a/packages/engine/src/backend/src/domain/schemas/HarvestLotSchema.ts
+++ b/packages/engine/src/backend/src/domain/schemas/HarvestLotSchema.ts
@@ -1,9 +1,7 @@
 import { z } from 'zod';
 
+import { uuidSchema } from '../schemas.js';
 import type { HarvestLot } from '../types/HarvestLot.js';
-import type { Uuid } from '../entities.js';
-
-const uuidSchema: z.ZodType<Uuid> = z.string().uuid().brand<'Uuid'>();
 
 const finiteNumber = z
   .number({ invalid_type_error: 'Expected a number.' })


### PR DESCRIPTION
## Summary
- align the backend `Uuid` brand with Zod's branding helper so schema outputs match domain types
- export the canonical `uuidSchema` from the domain schema module for reuse
- reuse the shared UUID schema inside the harvest lot schema to remove local duplicates

## Testing
- pnpm --filter @wb/engine build *(fails: existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e66a694a948325a08391315cf5842f