### PR TITLE
chore: migrate JSON imports to import attributes

### DIFF
--- a/docs/ADR/ADR-0022-json-import-attributes.md
+++ b/docs/ADR/ADR-0022-json-import-attributes.md
@@ -1,0 +1,15 @@
+# ADR-0022 — JSON Import Attributes for Node.js 22
+
+## Status
+Accepted — 2025-10-08
+
+## Context
+Node.js 22 promotes import attributes for JSON modules and TypeScript 5.5 removes support for the legacy `assert { type: 'json' }` syntax (TS2880). The engine and its test suites still referenced the deprecated form, which triggered compiler diagnostics and risked runtime incompatibilities with the SEC-mandated ESM baseline.
+
+## Decision
+- Replace every JSON import that used `assert { type: 'json' }` with the Node.js 22-compatible `with { type: 'json' }` attribute syntax across engine runtime modules and tests.
+- Document the migration so future JSON imports within the monorepo adopt import attributes by default.
+
+## Consequences
+- JSON imports now compile cleanly under the Node.js 22 + TypeScript toolchain and remain aligned with the SEC ESM requirements.
+- Contributors must use `with { type: 'json' }` for all new JSON modules; mixing legacy `assert` syntax will regress compiler compatibility and should be treated as a lint failure in future tooling updates.

--- a/docs/ADR/INDEX.md
+++ b/docs/ADR/INDEX.md
@@ -2,6 +2,7 @@
 
 | ADR-ID   | Title                                                                   | Status     | Supersedes | Affects                      | Binding? | Link                                                               |
 | -------- | ----------------------------------------------------------------------- | ---------- | ---------- | ---------------------------- | -------- | ------------------------------------------------------------------ |
+| ADR-0022 | JSON Import Attributes for Node.js 22                                   | Accepted   | —          | SEC, DD, TDD, AGENTS         | Yes      | [ADR-0022](./ADR-0022-json-import-attributes.md)                    |
 | ADR-0020 | Zone Height Baseline & Cultivation Presets                              | Accepted   | —          | SEC, DD, TDD, VISION         | Yes      | [ADR-0020](./ADR-0020-zone-height-and-cultivation-presets.md)      |
 | ADR-0019 | Economy Reporting Cadence                                               | Accepted   | —          | SEC, DD, TDD, VISION         | Yes      | [ADR-0019](./ADR-0019-economy-reporting-cadence.md)                |
 | ADR-0018 | Stress→Growth Curve Model                                              | Accepted   | —          | SEC, DD, TDD, VISION         | Yes      | [ADR-0018](./ADR-0018-stress-growth-curve-model.md)                |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased — Blueprint Taxonomy v2
 
+- Migrated JSON module imports to Node.js 22 import attributes (`with { type: 'json' }`) across engine runtime and test suites to resolve TS2880 and align with the ESM baseline.
 - Fixed CO₂ injector clamp reporting (Task 0019) and extended tariff bootstrap tests:
   - Corrected `clampedByTarget` so it only flips when the requested delta exceeds deliverable output, and added coverage to verify satisfied requests remain unclamped.
   - Exercised difficulty-specific tariff overrides and cache reuse in `createEngineBootstrapConfig` while syncing SEC/ADR typos with the Node.js 22 baseline.

--- a/packages/engine/src/backend/src/domain/workforce/traits.ts
+++ b/packages/engine/src/backend/src/domain/workforce/traits.ts
@@ -1,4 +1,4 @@
-import traitsJson from '../../../../../../../data/personnel/traits.json' assert { type: 'json' };
+import traitsJson from '../../../../../../../data/personnel/traits.json' with { type: 'json' };
 
 import { clamp01 } from '../../util/math.js';
 import type { RandomNumberGenerator } from '../../util/rng.js';

--- a/packages/engine/src/backend/src/engine/conformance/goldenScenario.ts
+++ b/packages/engine/src/backend/src/engine/conformance/goldenScenario.ts
@@ -2,26 +2,26 @@ import { createHash } from 'node:crypto';
 
 import safeStringify from 'safe-stable-stringify';
 
-import ledVegLightBlueprint from '../../../../../../../data/blueprints/device/lighting/led-veg-light-600.json' assert { type: 'json' };
-import coolAirSplitBlueprint from '../../../../../../../data/blueprints/device/climate/cool-air-split-3000.json' assert { type: 'json' };
-import dripInlineFertigationBlueprint from '../../../../../../../data/blueprints/irrigation/drip-inline-fertigation-basic.json' assert { type: 'json' };
-import ebbFlowTableBlueprint from '../../../../../../../data/blueprints/irrigation/ebb-flow-table-small.json' assert { type: 'json' };
-import manualWateringBlueprint from '../../../../../../../data/blueprints/irrigation/manual-watering-can.json' assert { type: 'json' };
-import topFeedPumpBlueprint from '../../../../../../../data/blueprints/irrigation/top-feed-pump-timer.json' assert { type: 'json' };
-import pot10LBlueprint from '../../../../../../../data/blueprints/container/pot-10l.json' assert { type: 'json' };
-import pot11LBlueprint from '../../../../../../../data/blueprints/container/pot-11l.json' assert { type: 'json' };
-import pot25LBlueprint from '../../../../../../../data/blueprints/container/pot-25l.json' assert { type: 'json' };
-import soilSingleCycleBlueprint from '../../../../../../../data/blueprints/substrate/soil-single-cycle.json' assert { type: 'json' };
-import soilMultiCycleBlueprint from '../../../../../../../data/blueprints/substrate/soil-multi-cycle.json' assert { type: 'json' };
-import cocoCoirBlueprint from '../../../../../../../data/blueprints/substrate/coco-coir.json' assert { type: 'json' };
-import seaOfGreenBlueprint from '../../../../../../../data/blueprints/cultivation-method/sea-of-green.json' assert { type: 'json' };
-import screenOfGreenBlueprint from '../../../../../../../data/blueprints/cultivation-method/screen-of-green.json' assert { type: 'json' };
-import basicSoilPotBlueprint from '../../../../../../../data/blueprints/cultivation-method/basic-soil-pot.json' assert { type: 'json' };
-import ak47Strain from '../../../../../../../data/blueprints/strain/ak47.json' assert { type: 'json' };
-import sourDieselStrain from '../../../../../../../data/blueprints/strain/sour-diesel.json' assert { type: 'json' };
-import whiteWidowStrain from '../../../../../../../data/blueprints/strain/white-widow.json' assert { type: 'json' };
-import northernLightsStrain from '../../../../../../../data/blueprints/strain/northern-lights.json' assert { type: 'json' };
-import skunk1Strain from '../../../../../../../data/blueprints/strain/skunk-1.json' assert { type: 'json' };
+import ledVegLightBlueprint from '../../../../../../../data/blueprints/device/lighting/led-veg-light-600.json' with { type: 'json' };
+import coolAirSplitBlueprint from '../../../../../../../data/blueprints/device/climate/cool-air-split-3000.json' with { type: 'json' };
+import dripInlineFertigationBlueprint from '../../../../../../../data/blueprints/irrigation/drip-inline-fertigation-basic.json' with { type: 'json' };
+import ebbFlowTableBlueprint from '../../../../../../../data/blueprints/irrigation/ebb-flow-table-small.json' with { type: 'json' };
+import manualWateringBlueprint from '../../../../../../../data/blueprints/irrigation/manual-watering-can.json' with { type: 'json' };
+import topFeedPumpBlueprint from '../../../../../../../data/blueprints/irrigation/top-feed-pump-timer.json' with { type: 'json' };
+import pot10LBlueprint from '../../../../../../../data/blueprints/container/pot-10l.json' with { type: 'json' };
+import pot11LBlueprint from '../../../../../../../data/blueprints/container/pot-11l.json' with { type: 'json' };
+import pot25LBlueprint from '../../../../../../../data/blueprints/container/pot-25l.json' with { type: 'json' };
+import soilSingleCycleBlueprint from '../../../../../../../data/blueprints/substrate/soil-single-cycle.json' with { type: 'json' };
+import soilMultiCycleBlueprint from '../../../../../../../data/blueprints/substrate/soil-multi-cycle.json' with { type: 'json' };
+import cocoCoirBlueprint from '../../../../../../../data/blueprints/substrate/coco-coir.json' with { type: 'json' };
+import seaOfGreenBlueprint from '../../../../../../../data/blueprints/cultivation-method/sea-of-green.json' with { type: 'json' };
+import screenOfGreenBlueprint from '../../../../../../../data/blueprints/cultivation-method/screen-of-green.json' with { type: 'json' };
+import basicSoilPotBlueprint from '../../../../../../../data/blueprints/cultivation-method/basic-soil-pot.json' with { type: 'json' };
+import ak47Strain from '../../../../../../../data/blueprints/strain/ak47.json' with { type: 'json' };
+import sourDieselStrain from '../../../../../../../data/blueprints/strain/sour-diesel.json' with { type: 'json' };
+import whiteWidowStrain from '../../../../../../../data/blueprints/strain/white-widow.json' with { type: 'json' };
+import northernLightsStrain from '../../../../../../../data/blueprints/strain/northern-lights.json' with { type: 'json' };
+import skunk1Strain from '../../../../../../../data/blueprints/strain/skunk-1.json' with { type: 'json' };
 
 import { createRng } from '../../util/rng.js';
 

--- a/packages/engine/src/backend/src/engine/perf/perfScenarios.ts
+++ b/packages/engine/src/backend/src/engine/perf/perfScenarios.ts
@@ -8,11 +8,11 @@ import {
   type DeviceBlueprint
 } from '../../domain/blueprints/deviceBlueprint.js';
 import { clamp01 } from '../../util/math.js';
-import devicePrices from '../../../../../../../data/prices/devicePrices.json' assert { type: 'json' };
-import coolAirSplitBlueprint from '../../../../../../../data/blueprints/device/climate/cool-air-split-3000.json' assert { type: 'json' };
-import ledVegLightBlueprint from '../../../../../../../data/blueprints/device/lighting/led-veg-light-600.json' assert { type: 'json' };
-import exhaustFanBlueprint from '../../../../../../../data/blueprints/device/airflow/exhaust-fan-4-inch.json' assert { type: 'json' };
-import carbonFilterBlueprint from '../../../../../../../data/blueprints/device/filtration/carbon-filter-6-inch.json' assert { type: 'json' };
+import devicePrices from '../../../../../../../data/prices/devicePrices.json' with { type: 'json' };
+import coolAirSplitBlueprint from '../../../../../../../data/blueprints/device/climate/cool-air-split-3000.json' with { type: 'json' };
+import ledVegLightBlueprint from '../../../../../../../data/blueprints/device/lighting/led-veg-light-600.json' with { type: 'json' };
+import exhaustFanBlueprint from '../../../../../../../data/blueprints/device/airflow/exhaust-fan-4-inch.json' with { type: 'json' };
+import carbonFilterBlueprint from '../../../../../../../data/blueprints/device/filtration/carbon-filter-6-inch.json' with { type: 'json' };
 
 interface DeviceBlueprintEntry {
   readonly blueprint: DeviceBlueprint;

--- a/packages/engine/src/backend/src/services/workforce/identitySource.ts
+++ b/packages/engine/src/backend/src/services/workforce/identitySource.ts
@@ -1,9 +1,9 @@
 import { createRng, type RandomNumberGenerator } from '../../util/rng.js';
 import type { EmployeeRngSeedUuid } from '../../domain/workforce/Employee.js';
 
-import firstNamesFemaleJson from '../../../../../../../data/personnel/names/firstNamesFemale.json' assert { type: 'json' };
-import firstNamesMaleJson from '../../../../../../../data/personnel/names/firstNamesMale.json' assert { type: 'json' };
-import lastNamesJson from '../../../../../../../data/personnel/names/lastNames.json' assert { type: 'json' };
+import firstNamesFemaleJson from '../../../../../../../data/personnel/names/firstNamesFemale.json' with { type: 'json' };
+import firstNamesMaleJson from '../../../../../../../data/personnel/names/firstNamesMale.json' with { type: 'json' };
+import lastNamesJson from '../../../../../../../data/personnel/names/lastNames.json' with { type: 'json' };
 import { sampleTraitSet } from '../../domain/workforce/traits.js';
 
 const RANDOM_USER_ENDPOINT = 'https://randomuser.me/api/';

--- a/packages/engine/tests/integration/pipeline/cultivationMethodTasks.integration.test.ts
+++ b/packages/engine/tests/integration/pipeline/cultivationMethodTasks.integration.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import basicSoilPot from '../../../../../data/blueprints/cultivation-method/basic-soil-pot.json' assert { type: 'json' };
-import pot10L from '../../../../../data/blueprints/container/pot-10l.json' assert { type: 'json' };
-import soilMultiCycle from '../../../../../data/blueprints/substrate/soil-multi-cycle.json' assert { type: 'json' };
+import basicSoilPot from '../../../../../data/blueprints/cultivation-method/basic-soil-pot.json' with { type: 'json' };
+import pot10L from '../../../../../data/blueprints/container/pot-10l.json' with { type: 'json' };
+import soilMultiCycle from '../../../../../data/blueprints/substrate/soil-multi-cycle.json' with { type: 'json' };
 
 import { PIPELINE_ORDER, type EngineRunContext } from '@/backend/src/engine/Engine.js';
 import { createDemoWorld, runStages } from '@/backend/src/engine/testHarness.js';

--- a/packages/engine/tests/unit/cultivation/methodRuntime.spec.ts
+++ b/packages/engine/tests/unit/cultivation/methodRuntime.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import basicSoilPot from '../../../../../data/blueprints/cultivation-method/basic-soil-pot.json' assert { type: 'json' };
-import pot10L from '../../../../../data/blueprints/container/pot-10l.json' assert { type: 'json' };
-import soilMultiCycle from '../../../../../data/blueprints/substrate/soil-multi-cycle.json' assert { type: 'json' };
+import basicSoilPot from '../../../../../data/blueprints/cultivation-method/basic-soil-pot.json' with { type: 'json' };
+import pot10L from '../../../../../data/blueprints/container/pot-10l.json' with { type: 'json' };
+import soilMultiCycle from '../../../../../data/blueprints/substrate/soil-multi-cycle.json' with { type: 'json' };
 
 import { createDemoWorld } from '@/backend/src/engine/testHarness.js';
 import {


### PR DESCRIPTION
## Summary
- replace legacy `assert { type: 'json' }` JSON imports with Node.js 22 import attributes across engine runtime and test sources
- document the migration in a new ADR and changelog entry to keep the SEC-aligned toolchain notes current

## Testing
- pnpm --filter @wb/engine exec -- vitest run tests/unit/cultivation/methodRuntime.spec.ts tests/integration/pipeline/cultivationMethodTasks.integration.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e66bc4bc908325a23759faa661774b