### PR TITLE
Fix readonly room purpose typing for perf scenarios

### DIFF
--- a/packages/engine/src/backend/src/domain/blueprints/deviceBlueprint.ts
+++ b/packages/engine/src/backend/src/domain/blueprints/deviceBlueprint.ts
@@ -114,7 +114,8 @@ const deviceBlueprintObjectSchema = z
       .array(roomPurposeSchema, {
         invalid_type_error: 'allowedRoomPurposes must be an array of room purposes.'
       })
-      .nonempty('allowedRoomPurposes must contain at least one room purpose.'),
+      .nonempty('allowedRoomPurposes must contain at least one room purpose.')
+      .readonly(),
     power_W: finiteNumber.min(0, 'power_W must be non-negative.'),
     efficiency01: finiteNumber
       .min(0, 'efficiency01 must be >= 0.')

--- a/packages/engine/src/backend/src/engine/conformance/goldenScenario.ts
+++ b/packages/engine/src/backend/src/engine/conformance/goldenScenario.ts
@@ -24,6 +24,7 @@ import northernLightsStrain from '../../../../../../../data/blueprints/strain/no
 import skunk1Strain from '../../../../../../../data/blueprints/strain/skunk-1.json' with { type: 'json' };
 
 import { createRng } from '../../util/rng.js';
+import type { RoomPurpose } from '../../domain/entities.js';
 
 const HOURS_PER_DAY = 24;
 const BREAK_DURATION_MINUTES = 30;
@@ -44,14 +45,14 @@ interface BlueprintLite {
 
 interface LightingBlueprint extends BlueprintLite {
   readonly coverage_m2: number;
-  readonly allowedRoomPurposes: readonly string[];
+  readonly allowedRoomPurposes: ReadonlyArray<RoomPurpose>;
   readonly placementScope: string;
 }
 
 interface ClimateBlueprint extends BlueprintLite {
   readonly airflow_m3_per_h: number;
   readonly placementScope: string;
-  readonly allowedRoomPurposes: readonly string[];
+  readonly allowedRoomPurposes: ReadonlyArray<RoomPurpose>;
 }
 
 interface CultivationBlueprint extends BlueprintLite {


### PR DESCRIPTION
## Summary
- mark device blueprint allowedRoomPurposes as readonly to align with RoomPurpose arrays
- update perf and conformance fixture typings to consume RoomPurpose arrays without tuple assertions

## Testing
- `pnpm --filter @wb/engine build` *(fails: existing type errors in engine unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e66d1d44a483259cb9ba1e3fbc71f4