### PR TITLE
Harden simulation constant lookup and environment parsing

### DIFF
--- a/packages/engine/src/backend/src/constants/simConstants.ts
+++ b/packages/engine/src/backend/src/constants/simConstants.ts
@@ -299,8 +299,26 @@ export type SimulationConstantName = keyof SimulationConstants;
  * @param name - Identifier of the canonical simulation constant.
  * @returns The canonical value associated with {@link name}.
  */
+function coerceNumericConstant(
+  value: SimulationConstants[SimulationConstantName]
+): number {
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  const parsed = Number.parseFloat(value);
+
+  if (Number.isFinite(parsed)) {
+    return parsed;
+  }
+
+  return 0;
+}
+
 export function getSimulationConstant(
   name: SimulationConstantName
 ): number {
-  return SIM_CONSTANTS[name];
+  const value = SIM_CONSTANTS[name];
+
+  return coerceNumericConstant(value);
 }

--- a/packages/engine/src/backend/src/util/environment.ts
+++ b/packages/engine/src/backend/src/util/environment.ts
@@ -1,18 +1,45 @@
 /**
  * Environment-related numeric helpers.
  */
-export function resolveAirflow(value: number | undefined): number {
-  if (!Number.isFinite(value) || value <= 0) {
-    return 0;
+
+function coercePositiveFiniteNumber(candidate: unknown): number | null {
+  if (typeof candidate === 'number') {
+    return Number.isFinite(candidate) ? candidate : null;
   }
 
-  return value;
+  if (typeof candidate === 'string') {
+    const trimmed = candidate.trim();
+
+    if (trimmed.length === 0) {
+      return null;
+    }
+
+    const parsed = Number.parseFloat(trimmed);
+
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+
+    return null;
+  }
+
+  return null;
 }
 
-export function resolveAirMassKg(value: number | undefined): number {
-  if (!Number.isFinite(value) || value <= 0) {
+function resolvePositiveFinite(candidate: unknown): number {
+  const numericValue = coercePositiveFiniteNumber(candidate);
+
+  if (numericValue === null || numericValue <= 0) {
     return 0;
   }
 
-  return value;
+  return numericValue;
+}
+
+export function resolveAirflow(value: unknown): number {
+  return resolvePositiveFinite(value);
+}
+
+export function resolveAirMassKg(value: unknown): number {
+  return resolvePositiveFinite(value);
 }


### PR DESCRIPTION
## Summary
- coerce simulation constant lookups through a numeric parser so callers always receive a number
- harden environment airflow/air mass helpers to parse unknown inputs into positive finite numbers with a zero fallback

## Testing
- `pnpm --filter @wb/engine build` *(fails: existing repository type errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e66e14431c832590a00ad602f5c45c