### PR TITLE
Fix domain barrels to avoid duplicate exports

### DIFF
--- a/packages/engine/src/backend/src/domain/entities.ts
+++ b/packages/engine/src/backend/src/domain/entities.ts
@@ -1,7 +1,7 @@
 import type { BRAND } from 'zod';
 
-import type { Inventory } from './types/Inventory.js';
 import type { HealthState } from './health/pestDisease.js';
+import type { Inventory } from './types/Inventory.js';
 import type { WorkforceState } from './workforce/WorkforceState.js';
 
 /**
@@ -285,7 +285,6 @@ export type ZoneDeviceInstance = DeviceInstance & {
 /**
  * Canonical representation of a plant instance within a zone.
  */
-import type { Inventory } from './types/Inventory.js';
 
 export interface Plant extends DomainEntity, SluggedEntity {
   /** Identifier of the strain blueprint driving this plant. */

--- a/packages/engine/src/backend/src/domain/world.ts
+++ b/packages/engine/src/backend/src/domain/world.ts
@@ -1,7 +1,26 @@
 export * from './entities.js';
 export * from './schemas.js';
 export * from './validation.js';
-export * from './blueprints/deviceBlueprint.js';
+export {
+  deviceBlueprintSchema,
+  parseDeviceBlueprint,
+  toDeviceInstanceCapacity,
+  toDeviceInstanceEffectConfigs
+} from './blueprints/deviceBlueprint.js';
+export type {
+  AirflowConfig,
+  Co2Config,
+  DeviceBlueprint,
+  DeviceEffect,
+  DeviceInstanceCapacity,
+  DeviceInstanceEffectConfigProjection,
+  FiltrationConfig,
+  HumidityConfig,
+  LightingConfig,
+  ParseDeviceBlueprintOptions,
+  SensorConfig,
+  ThermalConfig
+} from './blueprints/deviceBlueprint.js';
 export * from './blueprints/strainBlueprint.js';
 export * from './blueprints/substrateBlueprint.js';
 export * from './blueprints/irrigationBlueprint.js';

--- a/packages/engine/src/backend/src/services/workforce/market.ts
+++ b/packages/engine/src/backend/src/services/workforce/market.ts
@@ -6,7 +6,7 @@ import type {
   WorkforceMarketCandidateTrait,
   WorkforceMarketState,
   WorkforceMarketStructureState,
-} from '../../domain/workforce/WorkforceState.js';
+} from '../../domain/world.js';
 import { HOURS_PER_DAY } from '../../constants/simConstants.js';
 import type { WorkforceMarketScanConfig } from '../../config/workforce.js';
 import { createRng, type RandomNumberGenerator } from '../../util/rng.js';

--- a/packages/engine/src/backend/src/util/harvest.ts
+++ b/packages/engine/src/backend/src/util/harvest.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto';
 
-import type { PlantLifecycleStage, HarvestLot, Uuid } from '../domain/entities.js';
+import type { HarvestLot, PlantLifecycleStage, Uuid } from '../domain/world.js';
 import type { StrainBlueprint } from '../domain/blueprints/strainBlueprint.js';
 import { clamp01 } from './math.js';
 import { getDryMatterFraction, getHarvestIndex } from './growth.js';


### PR DESCRIPTION
## Summary
- remove the stray duplicate `Inventory` import so the domain keeps a single definition
- narrow the world barrel exports for device blueprints to avoid re-exporting `DeviceEffectConfigs` twice
- point harvest utilities and workforce market service at the canonical world barrel for their shared types

## Testing
- pnpm --filter @wb/engine lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e670cbf3448325a6a1626120f1db4e