### PR TITLE
Align cultivation and irrigation blueprint compatibility types

### DIFF
--- a/packages/engine/src/backend/src/domain/blueprints/cultivationMethodBlueprint.ts
+++ b/packages/engine/src/backend/src/domain/blueprints/cultivationMethodBlueprint.ts
@@ -14,6 +14,16 @@ export interface CultivationMethodMeta {
   readonly defaults?: CultivationMethodDefaults;
 }
 
+export interface CultivationMethodTraitCompatibilityRange {
+  readonly min?: number;
+  readonly max?: number;
+}
+
+export interface CultivationMethodTraitCompatibility {
+  readonly preferred?: Record<string, CultivationMethodTraitCompatibilityRange>;
+  readonly conflicting?: Record<string, CultivationMethodTraitCompatibilityRange>;
+}
+
 export interface CultivationMethodBlueprint {
   readonly id: string;
   readonly slug: string;
@@ -26,7 +36,7 @@ export interface CultivationMethodBlueprint {
   readonly maxCycles?: number;
   readonly substrates: readonly string[];
   readonly containers: readonly string[];
-  readonly strainTraitCompatibility?: Record<string, Record<string, number>>;
+  readonly strainTraitCompatibility?: CultivationMethodTraitCompatibility;
   readonly envBias?: Record<string, number>;
   readonly capacityHints?: { readonly plantsPer_m2?: number; readonly canopyHeight_m?: number };
   readonly idealConditions?: {

--- a/packages/engine/src/backend/src/domain/blueprints/irrigationBlueprint.ts
+++ b/packages/engine/src/backend/src/domain/blueprints/irrigationBlueprint.ts
@@ -46,11 +46,13 @@ const compatibilitySchema = z.object({
       required_error: 'compatibility.substrates is required.',
       invalid_type_error: 'compatibility.substrates must be an array of substrate slugs.'
     })
-    .min(1, 'compatibility.substrates must contain at least one substrate slug.'),
+    .min(1, 'compatibility.substrates must contain at least one substrate slug.')
+    .readonly(),
   methods: z
     .array(nonEmptyString, {
       invalid_type_error: 'compatibility.methods must be an array of strings.'
     })
+    .readonly()
     .default([])
 });
 


### PR DESCRIPTION
## Summary
- define explicit cultivation method trait compatibility range and mapping types so the blueprint interface mirrors the schema
- mark irrigation compatibility substrate and method arrays as readonly to match downstream expectations

## Testing
- pnpm --filter engine test -- --runInBand *(fails: missing @typescript-eslint/parser and schema evaluation errors in current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6728244bc8325bd3490d94ad42451