### PR TITLE
Fix Employee RNG seed UUID branding

### DIFF
--- a/packages/engine/src/backend/src/domain/workforce/Employee.ts
+++ b/packages/engine/src/backend/src/domain/workforce/Employee.ts
@@ -1,3 +1,5 @@
+import type { BRAND } from 'zod';
+
 import type { DomainEntity, Uuid } from '../entities.js';
 import type { EmployeeSkillRequirement } from './EmployeeRole.js';
 import type { EmployeeTraitAssignment, TraitSubject } from './traits.js';
@@ -5,7 +7,7 @@ import type { EmployeeTraitAssignment, TraitSubject } from './traits.js';
 /**
  * Brand describing UUID v7 identifiers that seed RNG streams.
  */
-export type EmployeeRngSeedUuid = string & { readonly __brand: unique symbol };
+export type EmployeeRngSeedUuid = string & BRAND<'EmployeeRngSeedUuid'>;
 
 /**
  * Captures the proficiency of an employee for a specific skill key.

--- a/packages/engine/src/backend/src/util/uuid.ts
+++ b/packages/engine/src/backend/src/util/uuid.ts
@@ -1,8 +1,9 @@
 import { createHash } from 'node:crypto';
 
 import type { Uuid } from '../domain/entities.js';
+import type { EmployeeRngSeedUuid } from '../domain/workforce/Employee.js';
 
-function formatUuid(bytes: Uint8Array): Uuid {
+function formatUuid<T extends string>(bytes: Uint8Array): T {
   const hex = Buffer.from(bytes).toString('hex');
   const parts = [
     hex.slice(0, 8),
@@ -11,7 +12,7 @@ function formatUuid(bytes: Uint8Array): Uuid {
     hex.slice(16, 20),
     hex.slice(20, 32)
   ];
-  return parts.join('-') as Uuid;
+  return parts.join('-') as T;
 }
 
 export function deterministicUuid(seed: string, streamId: string): Uuid {
@@ -25,10 +26,13 @@ export function deterministicUuid(seed: string, streamId: string): Uuid {
   uuidBytes[6] = (uuidBytes[6] & 0x0f) | 0x40;
   uuidBytes[8] = (uuidBytes[8] & 0x3f) | 0x80;
 
-  return formatUuid(uuidBytes);
+  return formatUuid<Uuid>(uuidBytes);
 }
 
-export function deterministicUuidV7(seed: string, streamId: string): Uuid {
+export function deterministicUuidV7(
+  seed: string,
+  streamId: string,
+): EmployeeRngSeedUuid {
   const hash = createHash('sha256');
   hash.update(seed);
   hash.update(':');
@@ -39,5 +43,5 @@ export function deterministicUuidV7(seed: string, streamId: string): Uuid {
   uuidBytes[6] = (uuidBytes[6] & 0x0f) | 0x70;
   uuidBytes[8] = (uuidBytes[8] & 0x3f) | 0x80;
 
-  return formatUuid(uuidBytes);
+  return formatUuid<EmployeeRngSeedUuid>(uuidBytes);
 }


### PR DESCRIPTION
## Summary
- brand `EmployeeRngSeedUuid` using Zod's BRAND helper so it composes with other schema brands
- emit branded employee RNG seed values from `deterministicUuidV7` without manual casts by generalising the UUID formatter helper

## Testing
- pnpm --filter engine test -- --runInBand *(fails: requires @typescript-eslint/parser dev dependency and pre-existing harvest inventory schema issues)*

------
https://chatgpt.com/codex/tasks/task_e_68e6741e1ec88325b9b4929751d5336b