### PR TITLE
Fix getSimulationConstant registry to preserve string defaults

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@
   - Shipped the `structureTariffs` read-model with override precedence tests plus DD/TDD documentation.
   - Added device-physics invariants: humidity clamps (0–100 %), CO₂ safety ceiling (`SAFETY_MAX_CO2_PPM`), and non-negative enthalpy backed by deterministic `fast-check` runs; updated `updateEnvironment` to honour the new clamp.
   - Audited workforce payroll accrual so hourly slices summed with banker’s rounding match finalized daily totals (integration test in `economyAccrual.integration.test.ts`).
+- Synced `getSimulationConstant` with the frozen registry shared by `@/backend` and `@wb/engine`, keeping string defaults like `DEFAULT_COMPANY_LOCATION_CITY` intact while satisfying the alias sync integration test.
 
 - Published ADR-0017–ADR-0020 to close SEC §14 open questions: locked the canonical irrigation method set, ratified the piecewise quadratic stress→growth curve, mandated hourly-ledger plus daily-rollup economy reporting, and fixed zone height defaults alongside launch cultivation presets.
 - Added a deterministic CI performance budget harness (`pnpm perf:ci`) that runs 10 k demo-world ticks, fails below 5 k ticks/min throughput or above the 64 MiB heap plateau, and emits guard-band warnings so regressions surface before breaching SEC §3 success criteria.

--- a/packages/engine/src/backend/src/constants/simConstants.ts
+++ b/packages/engine/src/backend/src/constants/simConstants.ts
@@ -258,10 +258,13 @@ export const DEFAULT_COMPANY_LOCATION_CITY = 'Hamburg' as const;
 export const DEFAULT_COMPANY_LOCATION_COUNTRY = 'Deutschland' as const;
 
 /**
- * Frozen object literal bundling all canonical simulation constants for
- * ergonomic bulk imports.
+ * Single source of truth that stores the canonical simulation constants.
+ *
+ * The registry is frozen once to guarantee immutability and shared between
+ * direct imports (`@/backend/src/constants/simConstants`) and the public
+ * engine entry point (`@wb/engine`).
  */
-export const SIM_CONSTANTS: Readonly<SimulationConstants> = Object.freeze({
+const SIMULATION_CONSTANT_REGISTRY = Object.freeze({
   AREA_QUANTUM_M2,
   LIGHT_SCHEDULE_GRID_HOURS,
   SECONDS_PER_HOUR,
@@ -286,12 +289,21 @@ export const SIM_CONSTANTS: Readonly<SimulationConstants> = Object.freeze({
   LATITUDE_MAX_DEG,
   DEFAULT_COMPANY_LOCATION_CITY,
   DEFAULT_COMPANY_LOCATION_COUNTRY
-});
+} satisfies Readonly<SimulationConstants>);
+
+/**
+ * Frozen object literal bundling all canonical simulation constants for
+ * ergonomic bulk imports.
+ */
+export const SIM_CONSTANTS: Readonly<SimulationConstants> =
+  SIMULATION_CONSTANT_REGISTRY;
 
 /**
  * Exhaustive list of valid simulation constant identifiers.
  */
-export type SimulationConstantName = keyof SimulationConstants;
+type SimulationConstantRegistry = typeof SIMULATION_CONSTANT_REGISTRY;
+
+export type SimulationConstantName = keyof SimulationConstantRegistry;
 
 /**
  * Returns the canonical value for a simulation constant by its identifier.
@@ -299,26 +311,8 @@ export type SimulationConstantName = keyof SimulationConstants;
  * @param name - Identifier of the canonical simulation constant.
  * @returns The canonical value associated with {@link name}.
  */
-function coerceNumericConstant(
-  value: SimulationConstants[SimulationConstantName]
-): number {
-  if (typeof value === 'number') {
-    return value;
-  }
-
-  const parsed = Number.parseFloat(value);
-
-  if (Number.isFinite(parsed)) {
-    return parsed;
-  }
-
-  return 0;
-}
-
-export function getSimulationConstant(
-  name: SimulationConstantName
-): number {
-  const value = SIM_CONSTANTS[name];
-
-  return coerceNumericConstant(value);
+export function getSimulationConstant<N extends SimulationConstantName>(
+  name: N
+): SimulationConstantRegistry[N] {
+  return SIMULATION_CONSTANT_REGISTRY[name];
 }

--- a/packages/engine/src/backend/src/index.ts
+++ b/packages/engine/src/backend/src/index.ts
@@ -1,0 +1,1 @@
+export * from './constants/simConstants.js';

--- a/packages/engine/tests/integration/simConstants.integration.test.ts
+++ b/packages/engine/tests/integration/simConstants.integration.test.ts
@@ -4,7 +4,8 @@ import {
   LIGHT_SCHEDULE_GRID_HOURS,
   SIM_CONSTANTS,
   getSimulationConstant,
-  type SimulationConstantName
+  type SimulationConstantName,
+  type SimulationConstants
 } from '@wb/engine';
 
 describe('engine exports', () => {
@@ -19,7 +20,7 @@ describe('engine exports', () => {
   it('ensures entry point and backend alias stay in sync', () => {
     for (const [name, value] of Object.entries(SIM_CONSTANTS) as [
       SimulationConstantName,
-      number
+      SimulationConstants[SimulationConstantName]
     ][]) {
       expect(getSimulationConstant(name)).toBe(value);
     }


### PR DESCRIPTION
## Summary
- share a frozen registry between the backend constants module and the public engine entry so `getSimulationConstant` yields canonical values, including string defaults
- export the constants bundle through the backend index for alias parity and tighten the integration test typing
- document the registry sync in the changelog

## Testing
- `pnpm --filter @wb/engine test` *(fails: TypeError: z.readonly is not a function in pre-existing Zod schema setup)*

------
https://chatgpt.com/codex/tasks/task_e_68e67f26d4e0832591e398277209aba9