### PR TITLE
Use leaf harvest and inventory schemas in room validation

### DIFF
--- a/packages/engine/src/backend/src/domain/schemas/InventorySchema.ts
+++ b/packages/engine/src/backend/src/domain/schemas/InventorySchema.ts
@@ -4,7 +4,7 @@ import { HarvestLotSchema } from './HarvestLotSchema.js';
 
 export const InventorySchema = z
   .object({
-    lots: z.readonly(z.array(HarvestLotSchema)).default([])
+    lots: z.array(HarvestLotSchema).readonly().default([])
   })
   .strip();
 


### PR DESCRIPTION
## Summary
- narrow room inventory validation using the leaf HarvestLot and Inventory schemas via safeParse so checks operate on parsed data
- switch InventorySchema to use the array readonly helper to avoid accessing an undefined z.readonly shim

## Testing
- `pnpm --filter @wb/engine exec vitest run tests/unit/domain/validateCompanyWorld.test.ts` *(fails: Cannot find module '../constants/simConstants.js' imported from src/backend/src/domain/schemas/coreSchemas.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e68129d9948325a988af950661af68