### PR TITLE
docs: annotate domain schemas to avoid barrel cycles

### DIFF
--- a/packages/engine/src/backend/src/domain/schemas.ts
+++ b/packages/engine/src/backend/src/domain/schemas.ts
@@ -1,3 +1,9 @@
+/**
+ * Domain schema barrel.
+ *
+ * Export order is topologically sorted: leaves first, followed by higher-level
+ * schemas. Leaf modules must never import from this barrel to prevent cycles.
+ */
 export * from './schemas/primitives.js';
 export * from './schemas/HarvestLotSchema.js';
 export * from './schemas/InventorySchema.js';

--- a/packages/engine/src/backend/src/domain/schemas/HarvestLotSchema.ts
+++ b/packages/engine/src/backend/src/domain/schemas/HarvestLotSchema.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+// Leaf schema: never import from '../schemas.ts' to avoid barrel cycles.
 import { finiteNumber, nonNegativeNumber, unitIntervalNumber, uuidSchema } from './primitives.js';
 import type { HarvestLot } from '../types/HarvestLot.js';
 

--- a/packages/engine/src/backend/src/domain/schemas/InventorySchema.ts
+++ b/packages/engine/src/backend/src/domain/schemas/InventorySchema.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+// Leaf schema: always import sibling schemas directly to avoid barrel cycles.
 import { HarvestLotSchema } from './HarvestLotSchema.js';
 
 export const InventorySchema = z

--- a/packages/engine/src/backend/src/domain/schemas/primitives.ts
+++ b/packages/engine/src/backend/src/domain/schemas/primitives.ts
@@ -1,5 +1,12 @@
 import { z } from 'zod';
 
+/**
+ * Leaf schema primitives.
+ *
+ * NOTE: Leaf schemas must never import from the domain schemas barrel. Doing so
+ * reintroduces circular dependencies; always import other leaves directly.
+ */
+
 export const nonEmptyString = z
   .string({ invalid_type_error: 'Expected a string.' })
   .trim()


### PR DESCRIPTION
## Summary
- document the leaf-first dependency rule directly in primitives, HarvestLot, and Inventory schemas
- annotate the domain schemas barrel with its topological export order so leaves stay decoupled from the barrel

## Testing
- not run (requires long-running vitest suite)

------
https://chatgpt.com/codex/tasks/task_e_68e684c3a00c8325b3931a4802d0c1c3