### PR TITLE
Centralize schema primitives for blueprint validators

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 - applyHarvestAndInventory: immutable write-back, direct leaf schemas.
 - simConstants: alias sync; string vs numeric env parsing fixed.
 - Migrated JSON module imports to Node.js 22 import attributes (`with { type: 'json' }`) across engine runtime and test suites to resolve TS2880 and align with the ESM baseline.
+- Centralised Zod scalar factories in `schemas/primitives.ts`, exposing helpers for string/number variants and updating blueprint/pipeline modules to import those primitives instead of redefining local copies, eliminating residual circular schema edges.
 - Normalised workforce trait metadata conflict resolution to avoid mutating read-only maps and aligned identity RNG seeding with branded employee UUIDs for TS 5.4 compatibility.
 - Broke the domain schema circular dependency chain by introducing `schemas/primitives.ts` for shared Zod scalars, moving `InventorySchema` into its own module, and updating every `Uuid`/inventory/harvest import across the engine so inventory parsing no longer dereferences undefined schemas at runtime.
 - Fixed CO₂ injector clamp reporting (Task 0019) and extended tariff bootstrap tests:

--- a/packages/engine/src/backend/src/domain/blueprints/containerBlueprint.ts
+++ b/packages/engine/src/backend/src/domain/blueprints/containerBlueprint.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { createFiniteNumber } from '../schemas/primitives.ts';
 import { assertBlueprintClassMatchesPath, type BlueprintPathOptions } from './taxonomy.ts';
 
 export interface ContainerBlueprintMeta {
@@ -29,6 +30,8 @@ const containerBlueprintMetaSchema = z
   })
   .partial();
 
+const finiteContainerNumber = createFiniteNumber({ message: 'Number must be finite.' });
+
 const containerBlueprintSchema = z
   .object({
     id: z.string().uuid('Container blueprint id must be a UUID v4.'),
@@ -39,10 +42,10 @@ const containerBlueprintSchema = z
       invalid_type_error: 'class must be the canonical "container" domain value.'
     }),
     name: z.string().min(1, 'Container blueprint name must not be empty.'),
-    volumeInLiters: z.number().finite().positive('volumeInLiters must be a positive number.'),
-    footprintArea: z.number().finite().positive('footprintArea must be a positive number.'),
+    volumeInLiters: finiteContainerNumber.positive('volumeInLiters must be a positive number.'),
+    footprintArea: finiteContainerNumber.positive('footprintArea must be a positive number.'),
     reusableCycles: z.number().int().min(1).optional(),
-    packingDensity: z.number().finite().positive('packingDensity must be positive.').optional(),
+    packingDensity: finiteContainerNumber.positive('packingDensity must be positive.').optional(),
     meta: containerBlueprintMetaSchema.optional(),
     containerType: z.string().optional()
   })

--- a/packages/engine/src/backend/src/domain/blueprints/deviceBlueprint.ts
+++ b/packages/engine/src/backend/src/domain/blueprints/deviceBlueprint.ts
@@ -1,14 +1,12 @@
 import { z } from 'zod';
 
 import { DEVICE_PLACEMENT_SCOPES, ROOM_PURPOSES } from '../entities.ts';
+import { finiteNumber, nonEmptyString } from '../schemas/primitives.ts';
 import {
   assertBlueprintClassMatchesPath,
   type BlueprintPathOptions,
   deriveBlueprintClassFromPath
 } from './taxonomy.ts';
-
-const nonEmptyString = z.string().trim().min(1, 'String fields must not be empty.');
-const finiteNumber = z.number().finite('Value must be a finite number.');
 const slugString = z
   .string({ required_error: 'slug is required.' })
   .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'Slug must be kebab-case (lowercase, digits, hyphen).');

--- a/packages/engine/src/backend/src/domain/blueprints/diseaseBlueprint.ts
+++ b/packages/engine/src/backend/src/domain/blueprints/diseaseBlueprint.ts
@@ -1,20 +1,22 @@
 import { z } from 'zod';
 
+import { createFiniteNumber, createNonEmptyString } from '../schemas/primitives.ts';
 import { assertBlueprintClassMatchesPath, type BlueprintPathOptions } from './taxonomy.ts';
 
 const slugSchema = z
   .string({ required_error: 'slug is required.' })
   .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'Slug must be kebab-case (lowercase letters, digits, hyphen).');
 
-const nonEmptyString = z.string().trim().min(1, 'String values must not be empty.');
-const probability01 = z
-  .number({ invalid_type_error: 'Probability values must be numbers.' })
-  .finite('Probability values must be finite.')
+const nonEmptyString = createNonEmptyString({ message: 'String values must not be empty.' });
+const probability01 = createFiniteNumber({
+  invalidTypeError: 'Probability values must be numbers.',
+  message: 'Probability values must be finite.'
+})
   .min(0, 'Probability values must be >= 0.')
   .max(1, 'Probability values must be <= 1.');
 
 const tupleRangeSchema = z
-  .array(z.number().finite('Range values must be finite numbers.'), {
+  .array(createFiniteNumber({ message: 'Range values must be finite numbers.' }), {
     invalid_type_error: 'Ranges must be numeric arrays.'
   })
   .length(2, 'Ranges must contain exactly two numeric bounds.');

--- a/packages/engine/src/backend/src/domain/blueprints/irrigationBlueprint.ts
+++ b/packages/engine/src/backend/src/domain/blueprints/irrigationBlueprint.ts
@@ -1,15 +1,16 @@
 import { z } from 'zod';
 
+import { createNonEmptyString } from '../schemas/primitives.ts';
 import { assertBlueprintClassMatchesPath, type BlueprintPathOptions } from './taxonomy.ts';
 
 const slugString = z
   .string({ required_error: 'slug is required.' })
   .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'Slug must be kebab-case (lowercase, digits, hyphen).');
 
-const nonEmptyString = z
-  .string({ required_error: 'value is required.' })
-  .trim()
-  .min(1, 'String fields must not be empty.');
+const nonEmptyString = createNonEmptyString({
+  requiredError: 'value is required.',
+  message: 'String fields must not be empty.'
+});
 
 const classSchema = z.literal('irrigation', {
   required_error: 'class is required.',

--- a/packages/engine/src/backend/src/domain/blueprints/personnelBlueprint.ts
+++ b/packages/engine/src/backend/src/domain/blueprints/personnelBlueprint.ts
@@ -1,46 +1,49 @@
 import { z } from 'zod';
 
+import { createFiniteNumber, createNonEmptyString } from '../schemas/primitives.ts';
 import { assertBlueprintClassMatchesPath, type BlueprintPathOptions } from './taxonomy.ts';
 
 const slugSchema = z
   .string({ required_error: 'slug is required.' })
   .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'Slug must be kebab-case (lowercase letters, digits, hyphen).');
 
-const nonEmptyString = z.string().trim().min(1, 'String values must not be empty.');
+const nonEmptyString = createNonEmptyString({ message: 'String values must not be empty.' });
 
-const probability01 = z
-  .number({ invalid_type_error: 'Probability values must be numbers.' })
-  .finite('Probability values must be finite.')
+const probability01 = createFiniteNumber({
+  invalidTypeError: 'Probability values must be numbers.',
+  message: 'Probability values must be finite.'
+})
   .min(0, 'Probability values must be >= 0.')
   .max(1, 'Probability values must be <= 1.');
 
 const numericRangeSchema = z
   .object({
-    min: z.number().finite('range.min must be finite.'),
-    max: z.number().finite('range.max must be finite.')
+    min: createFiniteNumber({ message: 'range.min must be finite.' }),
+    max: createFiniteNumber({ message: 'range.max must be finite.' })
   })
   .strict();
 
 const salarySchema = z
   .object({
-    basePerTick: z
-      .number({ required_error: 'salary.basePerTick is required.' })
-      .finite('salary.basePerTick must be finite.')
+    basePerTick: createFiniteNumber({
+      requiredError: 'salary.basePerTick is required.',
+      message: 'salary.basePerTick must be finite.'
+    })
       .min(0, 'salary.basePerTick must be >= 0.'),
     skillFactor: z
       .object({
-        base: z.number().finite('skillFactor.base must be finite.'),
-        perPoint: z.number().finite('skillFactor.perPoint must be finite.'),
-        min: z.number().finite('skillFactor.min must be finite.'),
-        max: z.number().finite('skillFactor.max must be finite.')
+        base: createFiniteNumber({ message: 'skillFactor.base must be finite.' }),
+        perPoint: createFiniteNumber({ message: 'skillFactor.perPoint must be finite.' }),
+        min: createFiniteNumber({ message: 'skillFactor.min must be finite.' }),
+        max: createFiniteNumber({ message: 'skillFactor.max must be finite.' })
       })
       .strict(),
     randomRange: numericRangeSchema,
     skillWeights: z
       .object({
-        primary: z.number().finite('skillWeights.primary must be finite.'),
-        secondary: z.number().finite('skillWeights.secondary must be finite.'),
-        tertiary: z.number().finite('skillWeights.tertiary must be finite.')
+        primary: createFiniteNumber({ message: 'skillWeights.primary must be finite.' }),
+        secondary: createFiniteNumber({ message: 'skillWeights.secondary must be finite.' }),
+        tertiary: createFiniteNumber({ message: 'skillWeights.tertiary must be finite.' })
       })
       .strict()
   })
@@ -48,23 +51,27 @@ const salarySchema = z
 
 const skillRollSchema = z
   .object({
-    min: z.number().finite('skillProfile.roll.min must be finite.'),
-    max: z.number().finite('skillProfile.roll.max must be finite.')
+    min: createFiniteNumber({ message: 'skillProfile.roll.min must be finite.' }),
+    max: createFiniteNumber({ message: 'skillProfile.roll.max must be finite.' })
   })
   .strict();
 
 const skillCandidateSchema = z
   .object({
     skill: nonEmptyString,
-    startingLevel: z.number().finite('skillProfile.candidate.startingLevel must be finite.'),
-    weight: z.number().finite('skillProfile.candidate.weight must be finite.').optional()
+    startingLevel: createFiniteNumber({
+      message: 'skillProfile.candidate.startingLevel must be finite.'
+    }),
+    weight: createFiniteNumber({
+      message: 'skillProfile.candidate.weight must be finite.'
+    }).optional()
   })
   .strict();
 
 const skillProfileEntrySchema = z
   .object({
     skill: nonEmptyString,
-    startingLevel: z.number().finite('skillProfile.startingLevel must be finite.'),
+    startingLevel: createFiniteNumber({ message: 'skillProfile.startingLevel must be finite.' }),
     roll: skillRollSchema
   })
   .strict();
@@ -99,13 +106,15 @@ const personnelRoleBlueprintSchema = z
     class: personnelRoleClassSchema,
     name: nonEmptyString,
     salary: salarySchema,
-    maxMinutesPerTick: z
-      .number({ required_error: 'maxMinutesPerTick is required.' })
-      .finite('maxMinutesPerTick must be finite.')
+    maxMinutesPerTick: createFiniteNumber({
+      requiredError: 'maxMinutesPerTick is required.',
+      message: 'maxMinutesPerTick must be finite.'
+    })
       .min(0, 'maxMinutesPerTick must be >= 0.'),
-    roleWeight: z
-      .number({ required_error: 'roleWeight is required.' })
-      .finite('roleWeight must be finite.')
+    roleWeight: createFiniteNumber({
+      requiredError: 'roleWeight is required.',
+      message: 'roleWeight must be finite.'
+    })
       .min(0, 'roleWeight must be >= 0.'),
     preferredShiftId: nonEmptyString.optional(),
     skillProfile: skillProfileSchema

--- a/packages/engine/src/backend/src/domain/blueprints/pestBlueprint.ts
+++ b/packages/engine/src/backend/src/domain/blueprints/pestBlueprint.ts
@@ -1,22 +1,24 @@
 import { z } from 'zod';
 
+import { createFiniteNumber, createNonEmptyString } from '../schemas/primitives.ts';
 import { assertBlueprintClassMatchesPath, type BlueprintPathOptions } from './taxonomy.ts';
 
 const slugSchema = z
   .string({ required_error: 'slug is required.' })
   .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'Slug must be kebab-case (lowercase letters, digits, hyphen).');
 
-const nonEmptyString = z.string().trim().min(1, 'String values must not be empty.');
+const nonEmptyString = createNonEmptyString({ message: 'String values must not be empty.' });
 
 const tupleRangeSchema = z
-  .array(z.number().finite('Ranges must contain finite numbers.'), {
+  .array(createFiniteNumber({ message: 'Ranges must contain finite numbers.' }), {
     invalid_type_error: 'Ranges must contain numeric bounds.'
   })
   .length(2, 'Ranges must contain exactly two numeric bounds.');
 
-const probability01 = z
-  .number({ invalid_type_error: 'Probability values must be numeric.' })
-  .finite('Probability values must be finite.')
+const probability01 = createFiniteNumber({
+  invalidTypeError: 'Probability values must be numeric.',
+  message: 'Probability values must be finite.'
+})
   .min(0, 'Probability values must be >= 0.')
   .max(1, 'Probability values must be <= 1.');
 
@@ -33,17 +35,20 @@ const environmentalRiskSchema = z
 
 const populationDynamicsSchema = z
   .object({
-    dailyReproductionRate: z
-      .number({ required_error: 'populationDynamics.dailyReproductionRate is required.' })
-      .finite('populationDynamics.dailyReproductionRate must be finite.')
+    dailyReproductionRate: createFiniteNumber({
+      requiredError: 'populationDynamics.dailyReproductionRate is required.',
+      message: 'populationDynamics.dailyReproductionRate must be finite.'
+    })
       .min(0, 'populationDynamics.dailyReproductionRate must be >= 0.'),
-    dailyMortalityRate: z
-      .number({ required_error: 'populationDynamics.dailyMortalityRate is required.' })
-      .finite('populationDynamics.dailyMortalityRate must be finite.')
+    dailyMortalityRate: createFiniteNumber({
+      requiredError: 'populationDynamics.dailyMortalityRate is required.',
+      message: 'populationDynamics.dailyMortalityRate must be finite.'
+    })
       .min(0, 'populationDynamics.dailyMortalityRate must be >= 0.'),
-    carryingCapacity: z
-      .number({ required_error: 'populationDynamics.carryingCapacity is required.' })
-      .finite('populationDynamics.carryingCapacity must be finite.')
+    carryingCapacity: createFiniteNumber({
+      requiredError: 'populationDynamics.carryingCapacity is required.',
+      message: 'populationDynamics.carryingCapacity must be finite.'
+    })
       .min(0, 'populationDynamics.carryingCapacity must be >= 0.')
   })
   .strict();

--- a/packages/engine/src/backend/src/domain/blueprints/roomBlueprint.ts
+++ b/packages/engine/src/backend/src/domain/blueprints/roomBlueprint.ts
@@ -1,17 +1,20 @@
 import { z } from 'zod';
 
+import { createFiniteNumber, createNonEmptyString } from '../schemas/primitives.ts';
 import { assertBlueprintClassMatchesPath, type BlueprintPathOptions } from './taxonomy.ts';
 
 const slugSchema = z
   .string({ required_error: 'slug is required.' })
   .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'Slug must be kebab-case (lowercase letters, digits, hyphen).');
 
+const economyAreaCost = createFiniteNumber({
+  requiredError: 'economy.areaCost is required.',
+  message: 'economy.areaCost must be a finite number.'
+});
+
 const economySchema = z
   .object({
-    areaCost: z
-      .number({ required_error: 'economy.areaCost is required.' })
-      .finite('economy.areaCost must be a finite number.')
-      .min(0, 'economy.areaCost must be >= 0.')
+    areaCost: economyAreaCost.min(0, 'economy.areaCost must be >= 0.')
   })
   .strict();
 
@@ -27,8 +30,8 @@ const roomPurposeBlueprintSchema = z
     id: z.string().uuid('Room blueprint id must be a UUID v4.'),
     slug: slugSchema,
     class: roomClassSchema,
-    name: z.string().trim().min(1, 'Room name must not be empty.'),
-    description: z.string().trim().min(1).optional(),
+    name: createNonEmptyString({ message: 'Room name must not be empty.' }),
+    description: createNonEmptyString({ message: 'Room description must not be empty.' }).optional(),
     economy: economySchema
   })
   .strict();

--- a/packages/engine/src/backend/src/domain/blueprints/strainBlueprint.ts
+++ b/packages/engine/src/backend/src/domain/blueprints/strainBlueprint.ts
@@ -1,10 +1,9 @@
 import { z } from 'zod';
 
+import { finiteNumber, nonEmptyString } from '../schemas/primitives.ts';
 import { assertBlueprintClassMatchesPath, type BlueprintPathOptions, deriveBlueprintClassFromPath } from './taxonomy.ts';
 
-const finiteNumber = z.number().finite('Value must be a finite number.');
 const positiveNumber = finiteNumber.gt(0, 'Value must be greater than zero.');
-const nonEmptyString = z.string().trim().min(1, 'String fields must not be empty.');
 const slugString = z
   .string({ required_error: 'slug is required.' })
   .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'Slug must be kebab-case (lowercase, digits, hyphen).');

--- a/packages/engine/src/backend/src/domain/blueprints/structureBlueprint.ts
+++ b/packages/engine/src/backend/src/domain/blueprints/structureBlueprint.ts
@@ -1,16 +1,19 @@
 import { z } from 'zod';
 
+import { createFiniteNumber, createNonEmptyString } from '../schemas/primitives.ts';
 import { assertBlueprintClassMatchesPath, type BlueprintPathOptions } from './taxonomy.ts';
 
 const slugSchema = z
   .string({ required_error: 'slug is required.' })
   .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'Slug must be kebab-case (lowercase letters, digits, hyphen).');
 
+const finiteFootprintNumber = createFiniteNumber({ message: 'Number must be finite.' });
+
 const footprintSchema = z
   .object({
-    length_m: z.number().finite().positive('footprint.length_m must be positive.'),
-    width_m: z.number().finite().positive('footprint.width_m must be positive.'),
-    height_m: z.number().finite().positive('footprint.height_m must be positive.')
+    length_m: finiteFootprintNumber.positive('footprint.length_m must be positive.'),
+    width_m: finiteFootprintNumber.positive('footprint.width_m must be positive.'),
+    height_m: finiteFootprintNumber.positive('footprint.height_m must be positive.')
   })
   .strict();
 
@@ -21,17 +24,19 @@ const structureBlueprintSchema = z
     class: z.literal('structure', {
       invalid_type_error: 'class must be the canonical "structure" domain value.'
     }),
-    name: z.string().trim().min(1, 'Structure name must not be empty.'),
+    name: createNonEmptyString({ message: 'Structure name must not be empty.' }),
     footprint: footprintSchema,
-    rentalCostPerSqmPerMonth: z
-      .number({ required_error: 'rentalCostPerSqmPerMonth is required.' })
-      .finite('rentalCostPerSqmPerMonth must be a finite number.')
+    rentalCostPerSqmPerMonth: createFiniteNumber({
+      requiredError: 'rentalCostPerSqmPerMonth is required.',
+      message: 'rentalCostPerSqmPerMonth must be a finite number.'
+    })
       .min(0, 'rentalCostPerSqmPerMonth must be >= 0.'),
-    upfrontFee: z
-      .number({ required_error: 'upfrontFee is required.' })
-      .finite('upfrontFee must be a finite number.')
+    upfrontFee: createFiniteNumber({
+      requiredError: 'upfrontFee is required.',
+      message: 'upfrontFee must be a finite number.'
+    })
       .min(0, 'upfrontFee must be >= 0.'),
-    structureType: z.string().trim().min(1, 'structureType must not be empty.')
+    structureType: createNonEmptyString({ message: 'structureType must not be empty.' })
   })
   .strict();
 

--- a/packages/engine/src/backend/src/domain/blueprints/substrateBlueprint.ts
+++ b/packages/engine/src/backend/src/domain/blueprints/substrateBlueprint.ts
@@ -1,9 +1,8 @@
 import { z } from 'zod';
 
+import { finiteNumber, nonEmptyString } from '../schemas/primitives.ts';
 import { assertBlueprintClassMatchesPath, type BlueprintPathOptions } from './taxonomy.ts';
 
-const nonEmptyString = z.string().trim().min(1, 'String fields must not be empty.');
-const finiteNumber = z.number().finite('Value must be a finite number.');
 const positiveNumber = finiteNumber.gt(0, 'Value must be greater than zero.');
 const nonNegativeNumber = finiteNumber.min(0, 'Value cannot be negative.');
 const slugString = z

--- a/packages/engine/src/backend/src/domain/schemas/primitives.ts
+++ b/packages/engine/src/backend/src/domain/schemas/primitives.ts
@@ -7,14 +7,59 @@ import { z } from 'zod';
  * reintroduces circular dependencies; always import other leaves directly.
  */
 
-export const nonEmptyString = z
-  .string({ invalid_type_error: 'Expected a string.' })
-  .trim()
-  .min(1, 'String fields must not be empty.');
+export interface NonEmptyStringOptions {
+  readonly message?: string;
+  readonly invalidTypeError?: string;
+  readonly requiredError?: string;
+}
 
-export const finiteNumber = z
-  .number({ invalid_type_error: 'Expected a number.' })
-  .finite({ message: 'Value must be a finite number.' });
+export function createNonEmptyString({
+  message = 'String fields must not be empty.',
+  invalidTypeError = 'Expected a string.',
+  requiredError
+}: NonEmptyStringOptions = {}): z.ZodString {
+  const params: {
+    invalid_type_error: string;
+    required_error?: string;
+  } = {
+    invalid_type_error: invalidTypeError,
+  };
+
+  if (requiredError) {
+    params.required_error = requiredError;
+  }
+
+  return z.string(params).trim().min(1, message);
+}
+
+export const nonEmptyString = createNonEmptyString();
+
+export interface FiniteNumberOptions {
+  readonly message?: string;
+  readonly invalidTypeError?: string;
+  readonly requiredError?: string;
+}
+
+export function createFiniteNumber({
+  message = 'Value must be a finite number.',
+  invalidTypeError = 'Expected a number.',
+  requiredError
+}: FiniteNumberOptions = {}): z.ZodNumber {
+  const params: {
+    invalid_type_error: string;
+    required_error?: string;
+  } = {
+    invalid_type_error: invalidTypeError,
+  };
+
+  if (requiredError) {
+    params.required_error = requiredError;
+  }
+
+  return z.number(params).finite({ message });
+}
+
+export const finiteNumber = createFiniteNumber();
 
 export const nonNegativeNumber = finiteNumber.min(
   0,

--- a/packages/engine/src/backend/src/engine/pipeline/sensorReadingSchema.ts
+++ b/packages/engine/src/backend/src/engine/pipeline/sensorReadingSchema.ts
@@ -1,9 +1,10 @@
 import { z } from 'zod';
 
+import { createFiniteNumber } from '../../domain/schemas/primitives.ts';
 import { SENSOR_MEASUREMENT_TYPES } from '../../domain/entities.ts';
 import type { SensorReading } from '../../domain/interfaces/ISensor.ts';
 
-const finiteNumber = z.number().finite();
+const finiteNumber = createFiniteNumber({ message: 'Number must be finite.' });
 
 const SENSOR_READING_BASE_SCHEMA = z.object({
   measurementType: z.enum(SENSOR_MEASUREMENT_TYPES),


### PR DESCRIPTION
## Summary
- expose configurable string and number factories in `schemas/primitives.ts` so schema modules share canonical Zod scalars without reintroducing circular imports
- refactor blueprint and pipeline validators to import the shared primitives instead of redefining local helpers, keeping behaviour consistent across devices, pests/diseases, workforce, rooms/structures, and substrates
- document the consolidation under the Unreleased changelog entry

## Testing
- pnpm -r build *(fails: TypeScript requires `allowImportingTsExtensions` to be paired with `noEmit`/`emitDeclarationOnly` during package builds)*
- pnpm -r test *(fails: Vitest cannot resolve `@typescript-eslint/parser` when executing `tests/unit/economy/noEconomyPerTickRule.test.ts`)*

------
https://chatgpt.com/codex/tasks/task_e_68e690aa9b408325a2d8551fc826c88a