### PR TITLE
chore: enforce import hygiene guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Lint
-        run: pnpm lint
+        run: pnpm -r lint
+
+      - name: Import resolution guardrail
+        run: pnpm test:imports
 
       - name: Test
         run: pnpm test

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Unreleased — Blueprint Taxonomy v2
 
+- Added import hygiene guardrails: `simple-git-hooks` pre-commit runs lint + import resolution specs, ESLint now blocks local
+  `.js` suffixes in TypeScript, and a Vitest probe dynamically `import()`s engine schemas/pipeline stages to catch bad specifiers
+  before CI.
 - Audited simulation constant usage across the engine: replaced duplicated physics and
   calendar literals with imports from `simConstants`, updated tolerance handling to
   reuse the canonical `FLOAT_TOLERANCE`, and extended `simConstants.test.ts` with

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing
+
+## Import hygiene guardrails
+
+- TypeScript sources **must not** import local files with a trailing `.js` extension. Use extensionless specifiers (`import './foo'`) so the build output can append `.js` while source tooling resolves `.ts`.
+- JSON modules continue to use import attributes (`import data from './foo.json' with { type: 'json' }`). Those remain allowed by the ESLint rule `wb-sim/no-ts-import-js-extension`.
+- Run `pnpm lint:imports` to execute the ESLint rule across the workspace. The rule auto-fixes offending specifiers by removing the trailing `.js` segment.
+
+## Runtime import resolution spec
+
+- `pnpm test:imports` runs a focused Vitest suite (`packages/engine/tests/runtime/importResolution.test.ts`) that dynamically `import()`s engine schemas and pipeline stages. This catches runtime failures like `Failed to load url` that surface when `.ts` sources accidentally reference `.js` artifacts.
+- The suite is intentionally lightweight; keep it fast so it can gate pre-commit and CI.
+
+## Pre-commit hooks
+
+- The repo uses [`simple-git-hooks`](https://github.com/toplenboren/simple-git-hooks). `pnpm install` (or `pnpm prepare`) wires up a `pre-commit` hook that runs `pnpm lint:imports` and `pnpm test:imports` before every commit.
+- If you need to skip the hook temporarily (e.g. for WIP commits), pass `HUSKY=0`/`SKIP=...` environment overrides intentionally and rerun the checks before pushing.
+- Hook output mirrors CI, so fixes applied locally keep the pipeline green.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,7 +24,7 @@ export default tseslint.config(
   ...tseslint.configs.strictTypeChecked,
   ...tseslint.configs.stylisticTypeChecked,
   {
-    files: ["**/*.ts", "**/*.tsx"],
+    files: ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"],
     languageOptions: {
       parserOptions: {
         projectService: true,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "dev": "pnpm -r --parallel dev",
     "build": "pnpm -r build",
     "test": "pnpm -r test",
+    "test:imports": "pnpm --filter @wb/engine test:imports",
     "lint": "pnpm -r lint",
+    "lint:imports": "pnpm exec eslint --max-warnings=0 --config tools/eslint/import-guard.config.js packages tools",
     "perf:ci": "pnpm --filter @wb/engine perf:ci",
     "format": "pnpm -r format",
     "migrate:folders": "node scripts/migrate-blueprint-folders.mjs",
@@ -22,6 +24,7 @@
     "monitor:mock": "pnpm --filter @wb/tools-monitor run mock-server",
     "preinstall": "node ./tools/scripts/ensure-pnpm.mjs",
     "verify-pnpm": "node ./tools/scripts/ensure-pnpm.mjs",
+    "prepare": "simple-git-hooks",
     "report:packages": "pnpm --filter ./packages/tools run report:packages",
     "tasks:dry": "tsx tools/tasks/renumberTasks.mts --dry",
     "tasks:write": "tsx tools/tasks/renumberTasks.mts --write",
@@ -32,10 +35,14 @@
     "@types/node": "^20.12.7",
     "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.5.0",
+    "simple-git-hooks": "^2.11.0",
     "prettier": "^3.2.5",
     "tsx": "^4.7.0",
     "typescript": "^5.4.5",
     "typescript-eslint": "^8.12.2",
     "vitest": "^3.2.4"
+  },
+  "simple-git-hooks": {
+    "pre-commit": "pnpm lint:imports && pnpm test:imports"
   }
 }

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "tsc --project tsconfig.json",
     "test": "vitest run",
+    "test:imports": "vitest run tests/runtime/importResolution.test.ts",
     "test:economy": "vitest run tests/integration/pipeline/economyAccrual.integration.test.ts",
     "test:conf:30d": "vitest run -t golden-30d",
     "test:conf:200d": "vitest run -t golden-200d",

--- a/packages/engine/tests/runtime/importResolution.test.ts
+++ b/packages/engine/tests/runtime/importResolution.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const testModuleDir = path.dirname(fileURLToPath(import.meta.url));
+const engineSourceRoot = fileURLToPath(
+  new URL("../../src/backend/src/", import.meta.url)
+);
+
+const pipelineDir = fileURLToPath(
+  new URL("../../src/backend/src/engine/pipeline/", import.meta.url)
+);
+const domainSchemasDir = fileURLToPath(
+  new URL("../../src/backend/src/domain/schemas/", import.meta.url)
+);
+
+const EXTRA_FILES = [
+  path.join(engineSourceRoot, "domain", "schemas.ts")
+];
+
+const entrypoints = await collectEntrypoints();
+
+describe("import resolution guardrail", () => {
+  for (const entrypoint of entrypoints) {
+    it(`dynamically imports ${entrypoint.label}`, async () => {
+      await expect(import(entrypoint.specifier)).resolves.toBeDefined();
+    });
+  }
+});
+
+async function collectEntrypoints() {
+  const files = [
+    ...(await listImmediateTsFiles(pipelineDir)),
+    ...(await listImmediateTsFiles(domainSchemasDir)),
+    ...EXTRA_FILES
+  ];
+
+  const sorted = files
+    .filter((file) => file.endsWith(".ts") && !file.endsWith(".d.ts"))
+    .sort((a, b) => a.localeCompare(b));
+
+  return sorted.map((filePath) => ({
+    filePath,
+    label: path.relative(engineSourceRoot, filePath),
+    specifier: toImportSpecifier(filePath)
+  }));
+}
+
+async function listImmediateTsFiles(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".ts"))
+    .map((entry) => path.join(directory, entry.name));
+}
+
+function toImportSpecifier(absPath) {
+  const relativePath = path.relative(testModuleDir, absPath);
+  const normalized = relativePath.split(path.sep).join("/");
+  return normalized.startsWith(".") ? normalized : `./${normalized}`;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       prettier:
         specifier: ^3.2.5
         version: 3.6.2
+      simple-git-hooks:
+        specifier: ^2.11.0
+        version: 2.13.1
       tsx:
         specifier: ^4.7.0
         version: 4.20.6
@@ -1443,6 +1446,10 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  simple-git-hooks@2.13.1:
+    resolution: {integrity: sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==}
+    hasBin: true
 
   slash@5.1.0:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
@@ -2945,6 +2952,8 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
+
+  simple-git-hooks@2.13.1: {}
 
   slash@5.1.0: {}
 

--- a/tools/eslint/import-guard.config.js
+++ b/tools/eslint/import-guard.config.js
@@ -1,0 +1,42 @@
+import tseslint from "typescript-eslint";
+import { noDuplicateSimConstantsRule } from "./rules/no-duplicate-sim-constants.js";
+import { noEconomyPerTickRule } from "./rules/no-economy-per-tick.js";
+import { noEnginePercentIdentifiersRule } from "./rules/no-engine-percent-identifiers.js";
+import { noMathRandomRule } from "./rules/no-math-random.js";
+import { noTsImportJsExtensionRule } from "./rules/no-ts-import-js-extension.js";
+
+const wbSimPlugin = {
+  rules: {
+    "no-duplicate-sim-constants": noDuplicateSimConstantsRule,
+    "no-economy-per-tick": noEconomyPerTickRule,
+    "no-engine-percent-identifiers": noEnginePercentIdentifiersRule,
+    "no-math-random": noMathRandomRule,
+    "no-ts-import-js-extension": noTsImportJsExtensionRule
+  }
+};
+
+export default tseslint.config(
+  {
+    ignores: ["dist", "**/dist/**", "node_modules"]
+  },
+  {
+    files: ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        projectService: false,
+        tsconfigRootDir: process.cwd()
+      }
+    },
+    plugins: {
+      "@typescript-eslint": tseslint.plugin,
+      "wb-sim": wbSimPlugin
+    },
+    linterOptions: {
+      reportUnusedDisableDirectives: false
+    },
+    rules: {
+      "wb-sim/no-ts-import-js-extension": "error"
+    }
+  }
+);

--- a/tools/eslint/tests/no-ts-import-js-extension.test.js
+++ b/tools/eslint/tests/no-ts-import-js-extension.test.js
@@ -1,0 +1,81 @@
+import test from "node:test";
+import path from "node:path";
+import { RuleTester } from "eslint";
+import { noTsImportJsExtensionRule } from "../rules/no-ts-import-js-extension.js";
+
+RuleTester.describe = (text, method) => {
+  method();
+};
+RuleTester.it = (text, method) => {
+  method();
+};
+RuleTester.itOnly = (text, method) => {
+  method();
+};
+RuleTester.itSkip = () => {
+  // noop for compatibility
+};
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: "module"
+  }
+});
+
+test("no-ts-import-js-extension rule", () => {
+  const tsFile = path.resolve("packages/engine/src/example.ts");
+  const jsFile = path.resolve("packages/engine/src/example.js");
+  const mtsFile = path.resolve("packages/engine/src/example.mts");
+
+  ruleTester.run("no-ts-import-js-extension", noTsImportJsExtensionRule, {
+    valid: [
+      {
+        code: "import './foo';",
+        filename: tsFile
+      },
+      {
+        code: "import data from '../foo.json' with { type: 'json' };",
+        filename: tsFile
+      },
+      {
+        code: "import pkg from 'pkg/foo.js';",
+        filename: tsFile
+      },
+      {
+        code: "import './foo.js';",
+        filename: jsFile
+      },
+      {
+        code: "import './foo';",
+        filename: mtsFile
+      }
+    ],
+    invalid: [
+      {
+        code: "import value from './foo.js';",
+        filename: tsFile,
+        errors: [{ messageId: "removeJsExtension" }],
+        output: "import value from './foo';"
+      },
+      {
+        code: "import value from './foo.js';",
+        filename: mtsFile,
+        errors: [{ messageId: "removeJsExtension" }],
+        output: "import value from './foo';"
+      },
+      {
+        code: "export * from '../bar.js';",
+        filename: tsFile,
+        errors: [{ messageId: "removeJsExtension" }],
+        output: "export * from '../bar';"
+      },
+      {
+        code: "import('./baz.js');",
+        filename: tsFile,
+        errors: [{ messageId: "removeJsExtension" }],
+        output: "import('./baz');"
+      }
+    ]
+  });
+});


### PR DESCRIPTION
## Summary
- extend the no-ts-import-js-extension rule (plus tests) and add a dedicated import-guard eslint config + scripts/pre-commit wiring
- add a Vitest runtime import-resolution probe for engine schemas/pipeline entrypoints and expose convenience scripts
- document the guardrails, update CI to run pnpm -r lint and the new spec, and note the change in the changelog

## Testing
- pnpm lint:imports
- pnpm test:imports

------
https://chatgpt.com/codex/tasks/task_e_68e6aaf459608325957fde22568af223