### PR TITLE
Align codemod thresholds with constants

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## Summary
+- 
+
+## Testing
+- [ ] `pnpm -r lint`
+- [ ] `pnpm -r test`
+- [ ] `pnpm scan:magic`
+- [ ] Checked numeric literals and extracted to `constants/**` where applicable.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Lint
         run: pnpm -r lint
 
+      - name: Magic number scan
+        run: pnpm scan:magic
+
       - name: Import resolution guardrail
         run: pnpm test:imports
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,7 @@
   - Shipped the `structureTariffs` read-model with override precedence tests plus DD/TDD documentation.
   - Added device-physics invariants: humidity clamps (0–100 %), CO₂ safety ceiling (`SAFETY_MAX_CO2_PPM`), and non-negative enthalpy backed by deterministic `fast-check` runs; updated `updateEnvironment` to honour the new clamp.
   - Audited workforce payroll accrual so hourly slices summed with banker’s rounding match finalized daily totals (integration test in `economyAccrual.integration.test.ts`).
+  - Centralised production constants under `constants/**`, enabled the `@typescript-eslint/no-magic-numbers` ESLint rule with CI `--max-warnings=0`, added a ripgrep-based `pnpm scan:magic` guardrail, and published a codemod plus contributor docs to keep magic numbers out of the engine and façade pipelines.
 - Synced `getSimulationConstant` with the frozen registry shared by `@/backend` and `@wb/engine`, keeping string defaults like `DEFAULT_COMPANY_LOCATION_CITY` intact while satisfying the alias sync integration test.
 
 - Published ADR-0017–ADR-0020 to close SEC §14 open questions: locked the canonical irrigation method set, ratified the piecewise quadratic stress→growth curve, mandated hourly-ledger plus daily-rollup economy reporting, and fixed zone height defaults alongside launch cultivation presets.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -16,3 +16,10 @@
 - The repo uses [`simple-git-hooks`](https://github.com/toplenboren/simple-git-hooks). `pnpm install` (or `pnpm prepare`) wires up a `pre-commit` hook that runs `pnpm lint:imports` and `pnpm test:imports` before every commit.
 - If you need to skip the hook temporarily (e.g. for WIP commits), pass `HUSKY=0`/`SKIP=...` environment overrides intentionally and rerun the checks before pushing.
 - Hook output mirrors CI, so fixes applied locally keep the pipeline green.
+
+## Magic number guardrail
+
+- Numeric literals in production TypeScript must live in `packages/engine/src/backend/src/constants/**` (or re-export from `simConstants.ts`).
+- ESLint enforces the `@typescript-eslint/no-magic-numbers` rule with a narrow allowlist. Lint warnings fail CI because `pnpm -r lint` runs with `--max-warnings=0`.
+- Run `pnpm scan:magic` to execute the ripgrep audit locally. The scan ignores tests, schemas, and the constants directory and fails when new literals slip through.
+- When introducing a new threshold or default, document it in the appropriate constants module and update `/docs/constants/README.md`.

--- a/docs/constants/README.md
+++ b/docs/constants/README.md
@@ -1,0 +1,14 @@
+# Constants ownership
+
+All production defaults and SEC-aligned thresholds live under `packages/engine/src/backend/src/constants/`.
+
+- `simConstants.ts` remains the canonical registry for Simulation Engine Contract values. Domain modules may only re-export or derive from these values.
+- Domain shims (`time.ts`, `physics.ts`, `climate.ts`, `lighting.ts`, `workforce.ts`, `economy.ts`, `validation.ts`) group related thresholds to keep imports ergonomic.
+- Export names use `UPPER_SNAKE_CASE` and include units (`*_PER_H`, `*_M2`, …) to avoid ambiguity.
+- When adding a new constant:
+  - Define it in the relevant domain module (or `simConstants.ts` if SEC-level) and document the rationale inline.
+  - Reference it from calling code instead of embedding numeric literals.
+  - Update this README and any domain-specific docs with ownership details.
+- Tests, fixtures, and schemas may use literals for clarity, but production code must import from the constants directory.
+
+For quick audits run `pnpm scan:magic` to surface stray literals. The command backs the CI guardrail and fails if new production magic numbers are introduced.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -36,6 +36,16 @@ export default tseslint.config(
     },
     rules: {
       "@typescript-eslint/explicit-module-boundary-types": "error",
+      "@typescript-eslint/no-magic-numbers": [
+        "warn",
+        {
+          ignore: [-1, 0, 1, 2, 10, 60, 100, 1000],
+          ignoreArrayIndexes: true,
+          ignoreDefaultValues: true,
+          enforceConst: true,
+          detectObjects: true
+        }
+      ],
       "wb-sim/no-duplicate-sim-constants": "error",
       "wb-sim/no-math-random": "error",
       "wb-sim/no-ts-import-js-extension": "error"
@@ -49,6 +59,12 @@ export default tseslint.config(
     rules: {
       "wb-sim/no-economy-per-tick": "error",
       "wb-sim/no-engine-percent-identifiers": "error"
+    }
+  },
+  {
+    files: ["**/*.test.ts", "**/*.spec.ts"],
+    rules: {
+      "@typescript-eslint/no-magic-numbers": "off"
     }
   }
 );

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "report:packages": "pnpm --filter ./packages/tools run report:packages",
     "tasks:dry": "tsx tools/tasks/renumberTasks.mts --dry",
     "tasks:write": "tsx tools/tasks/renumberTasks.mts --write",
-    "tasks:check": "tsx tools/tasks/renumberTasks.mts --dry --verify"
+    "tasks:check": "tsx tools/tasks/renumberTasks.mts --dry --verify",
+    "scan:magic": "node ./tools/scripts/scan-magic-numbers.mjs"
   },
   "devDependencies": {
     "@eslint/js": "^9.5.0",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -15,7 +15,7 @@
     "test:conf:30d": "vitest run -t golden-30d",
     "test:conf:200d": "vitest run -t golden-200d",
     "perf:ci": "tsx scripts/perf/ciPerfCheck.ts",
-    "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\"",
+    "lint": "eslint --max-warnings=0 \"src/**/*.ts\" \"tests/**/*.ts\"",
     "format": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\"",
     "dev": "tsx watch src/index.ts",
     "report:seed-to-harvest": "tsx src/backend/src/engine/reporting/cli.ts"

--- a/packages/engine/src/backend/src/constants/climate.ts
+++ b/packages/engine/src/backend/src/constants/climate.ts
@@ -1,0 +1,48 @@
+import {
+  AMBIENT_CO2_PPM,
+  SAFETY_MAX_CO2_PPM
+} from './simConstants.ts';
+
+export const HUMIDITY_FACTOR_TABLE = [
+  { tempC: 15, factor: 0.12 },
+  { tempC: 20, factor: 0.14 },
+  { tempC: 25, factor: 0.15 },
+  { tempC: 30, factor: 0.16 }
+] as const;
+
+export const HUMIDITY_FACTOR_MIN = 0.1 as const;
+export const HUMIDITY_FACTOR_MAX = 0.18 as const;
+export const HUMIDITY_FACTOR_FALLBACK = 0.15 as const;
+
+export const RELATIVE_HUMIDITY_MIN_PCT = 0 as const;
+export const RELATIVE_HUMIDITY_MAX_PCT = 100 as const;
+
+export const TEMPERATURE_SENSOR_MIN_C = -50 as const;
+export const TEMPERATURE_SENSOR_MAX_C = 150 as const;
+
+export const HUMIDITY_SENSOR_MIN_PCT = 0 as const;
+export const HUMIDITY_SENSOR_MAX_PCT = 100 as const;
+
+export const MIN_AIR_CHANGES_PER_HOUR = 1 as const;
+export const LEGACY_DEHUMIDIFIER_CAPACITY_G_PER_H = 500 as const;
+export const LEGACY_HUMIDIFIER_CAPACITY_G_PER_H = 300 as const;
+
+export const PEST_DISEASE_RISK_LEVEL_THRESHOLDS = {
+  moderate: 0.35,
+  high: 0.7
+} as const;
+
+export const HUMIDITY_MIN = PEST_DISEASE_RISK_LEVEL_THRESHOLDS.moderate;
+export const HUMIDITY_MAX = PEST_DISEASE_RISK_LEVEL_THRESHOLDS.high;
+
+export const TEMPERATURE_COMFORT_RANGE_C = { min: 20, max: 26 } as const;
+export const HUMIDITY_COMFORT_RANGE_PCT = { min: 45, max: 60 } as const;
+export const MAX_TEMPERATURE_DEVIATION_C = 10 as const;
+export const MAX_HUMIDITY_DEVIATION_PCT = 25 as const;
+export const TEMPERATURE_WEIGHT = 0.35 as const;
+export const HUMIDITY_WEIGHT = 0.25 as const;
+export const HYGIENE_WEIGHT = 0.4 as const;
+export const BASE_DECAY_RATE = 0.12 as const;
+export const QUARANTINE_DECAY_BONUS = 0.18 as const;
+
+export { AMBIENT_CO2_PPM, SAFETY_MAX_CO2_PPM };

--- a/packages/engine/src/backend/src/constants/economy.ts
+++ b/packages/engine/src/backend/src/constants/economy.ts
@@ -1,0 +1,5 @@
+/**
+ * Placeholder for economy-related constants. Populate as tariffs and economic
+ * defaults graduate from configuration into shared constants.
+ */
+export {};

--- a/packages/engine/src/backend/src/constants/lighting.ts
+++ b/packages/engine/src/backend/src/constants/lighting.ts
@@ -1,0 +1,2 @@
+export const LEGACY_PHOTON_EFFICACY_UMOL_PER_J = 2.5 as const;
+export const MICROMOLES_PER_MOLE = 1_000_000 as const;

--- a/packages/engine/src/backend/src/constants/physics.ts
+++ b/packages/engine/src/backend/src/constants/physics.ts
@@ -1,0 +1,22 @@
+import {
+  AIR_DENSITY_KG_PER_M3,
+  CP_AIR_J_PER_KG_K,
+  LATENT_HEAT_VAPORIZATION_WATER_J_PER_KG,
+  SECONDS_PER_HOUR
+} from './simConstants.ts';
+
+/**
+ * Conversion factor from watt-hours to joules.
+ */
+export const WATT_HOUR_TO_JOULE = SECONDS_PER_HOUR;
+
+/**
+ * Conversion factor from joules to watt-hours.
+ */
+export const JOULE_TO_WATT_HOUR = 1 / WATT_HOUR_TO_JOULE;
+
+export {
+  AIR_DENSITY_KG_PER_M3,
+  CP_AIR_J_PER_KG_K,
+  LATENT_HEAT_VAPORIZATION_WATER_J_PER_KG
+};

--- a/packages/engine/src/backend/src/constants/time.ts
+++ b/packages/engine/src/backend/src/constants/time.ts
@@ -1,0 +1,52 @@
+import {
+  HOURS_PER_DAY,
+  HOURS_PER_MONTH,
+  HOURS_PER_TICK,
+  HOURS_PER_YEAR,
+  LIGHT_SCHEDULE_GRID_HOURS,
+  SECONDS_PER_HOUR
+} from './simConstants.ts';
+
+/**
+ * Number of minutes contained in a single hour.
+ */
+export const MINUTES_PER_HOUR = 60 as const;
+
+/**
+ * Number of seconds contained within a single simulation tick.
+ */
+export const SECONDS_PER_TICK = SECONDS_PER_HOUR * HOURS_PER_TICK;
+
+/**
+ * Number of minutes contained within a single simulation tick.
+ */
+export const MINUTES_PER_TICK = MINUTES_PER_HOUR * HOURS_PER_TICK;
+
+/**
+ * Number of simulation ticks contained within a single in-game day.
+ */
+export const TICKS_PER_DAY = HOURS_PER_DAY / HOURS_PER_TICK;
+
+/**
+ * Number of simulation ticks contained within a single in-game month.
+ */
+export const TICKS_PER_MONTH = HOURS_PER_MONTH / HOURS_PER_TICK;
+
+/**
+ * Number of simulation ticks contained within a single in-game year.
+ */
+export const TICKS_PER_YEAR = HOURS_PER_YEAR / HOURS_PER_TICK;
+
+/**
+ * Canonical minutes step mandated by the SEC light schedule grid (15 minutes).
+ */
+export const MINUTES_STEP = LIGHT_SCHEDULE_GRID_HOURS * MINUTES_PER_HOUR;
+
+export {
+  HOURS_PER_DAY,
+  HOURS_PER_MONTH,
+  HOURS_PER_TICK,
+  HOURS_PER_YEAR,
+  LIGHT_SCHEDULE_GRID_HOURS,
+  SECONDS_PER_HOUR
+};

--- a/packages/engine/src/backend/src/constants/validation.ts
+++ b/packages/engine/src/backend/src/constants/validation.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_DEVICE_CONDITION01 = 0.9 as const;

--- a/packages/engine/src/backend/src/constants/workforce.ts
+++ b/packages/engine/src/backend/src/constants/workforce.ts
@@ -1,0 +1,14 @@
+import { HOURS_PER_DAY } from './simConstants.ts';
+
+export const SHIFT_MINUTES = 480 as const; // 8 hours
+export const BREAK_MINUTES = 15 as const;
+export const RAISE_COOLDOWN_DAYS = 180 as const;
+export const RAISE_MIN_EMPLOYMENT_DAYS = 180 as const;
+export const RAISE_JITTER_RANGE_DAYS = 45 as const;
+export const RAISE_ACCEPT_DEFAULT_RATE_INCREASE = 0.05 as const;
+export const RAISE_BONUS_DEFAULT_RATE_INCREASE = 0.03 as const;
+export const RAISE_ACCEPT_DEFAULT_MORALE_BOOST = 0.06 as const;
+export const RAISE_BONUS_DEFAULT_MORALE_BOOST = 0.04 as const;
+export const RAISE_IGNORE_DEFAULT_MORALE_PENALTY = -0.08 as const;
+
+export const WORKDAY_MINUTES = HOURS_PER_DAY * 60;

--- a/packages/engine/src/backend/src/engine/pipeline/sensorReadingSchema.ts
+++ b/packages/engine/src/backend/src/engine/pipeline/sensorReadingSchema.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 
 import { SAFETY_MAX_CO2_PPM } from '@/backend/src/constants/simConstants';
+import {
+  HUMIDITY_SENSOR_MAX_PCT,
+  HUMIDITY_SENSOR_MIN_PCT,
+  TEMPERATURE_SENSOR_MAX_C,
+  TEMPERATURE_SENSOR_MIN_C
+} from '@/backend/src/constants/climate';
 import { createFiniteNumber } from '../../domain/schemas/primitives.ts';
 import { SENSOR_MEASUREMENT_TYPES } from '../../domain/entities.ts';
 import type { SensorReading } from '../../domain/interfaces/ISensor.ts';
@@ -27,9 +33,9 @@ function isMeasurementWithinRange(
 ): boolean {
   switch (measurementType) {
     case 'temperature':
-      return value >= -50 && value <= 150;
+      return value >= TEMPERATURE_SENSOR_MIN_C && value <= TEMPERATURE_SENSOR_MAX_C;
     case 'humidity':
-      return value >= 0 && value <= 100;
+      return value >= HUMIDITY_SENSOR_MIN_PCT && value <= HUMIDITY_SENSOR_MAX_PCT;
     case 'co2':
       return value >= 0 && value <= SAFETY_MAX_CO2_PPM;
     case 'ppfd':

--- a/packages/engine/src/backend/src/health/pestDiseaseRisk.ts
+++ b/packages/engine/src/backend/src/health/pestDiseaseRisk.ts
@@ -1,3 +1,15 @@
+import {
+  BASE_DECAY_RATE,
+  HUMIDITY_COMFORT_RANGE_PCT,
+  HUMIDITY_WEIGHT,
+  MAX_HUMIDITY_DEVIATION_PCT,
+  MAX_TEMPERATURE_DEVIATION_C,
+  PEST_DISEASE_RISK_LEVEL_THRESHOLDS,
+  QUARANTINE_DECAY_BONUS,
+  TEMPERATURE_COMFORT_RANGE_C,
+  TEMPERATURE_WEIGHT,
+  HYGIENE_WEIGHT
+} from '../constants/climate.ts';
 import { clamp, clamp01 } from '../util/math.ts';
 import type { ZoneEnvironment } from '../domain/world.ts';
 import type { PestDiseaseRiskLevel } from '../domain/health/pestDisease.ts';
@@ -20,21 +32,6 @@ export interface PestDiseaseRiskResult {
   readonly risk01: number;
   readonly contributions: PestDiseaseRiskContributions;
 }
-
-export const PEST_DISEASE_RISK_LEVEL_THRESHOLDS = {
-  moderate: 0.35,
-  high: 0.7,
-} as const;
-
-export const TEMPERATURE_COMFORT_RANGE_C = { min: 20, max: 26 } as const;
-export const HUMIDITY_COMFORT_RANGE_PCT = { min: 45, max: 60 } as const;
-export const MAX_TEMPERATURE_DEVIATION_C = 10;
-export const MAX_HUMIDITY_DEVIATION_PCT = 25;
-export const TEMPERATURE_WEIGHT = 0.35;
-export const HUMIDITY_WEIGHT = 0.25;
-export const HYGIENE_WEIGHT = 0.4;
-export const BASE_DECAY_RATE = 0.12;
-export const QUARANTINE_DECAY_BONUS = 0.18;
 
 function normalisedDeviation(value: number, range: { min: number; max: number }, maxDeviation: number): number {
   const clamped = clamp(value, range.min, range.max);
@@ -85,3 +82,5 @@ export function evaluatePestDiseaseRisk(inputs: PestDiseaseRiskInputs): PestDise
     },
   } satisfies PestDiseaseRiskResult;
 }
+
+export { PEST_DISEASE_RISK_LEVEL_THRESHOLDS } from '../constants/climate.ts';

--- a/packages/engine/src/backend/src/services/workforce/raises.ts
+++ b/packages/engine/src/backend/src/services/workforce/raises.ts
@@ -9,15 +9,16 @@ import type {
   WorkforceRaiseIntent,
 } from '../../domain/workforce/intents.ts';
 
-const RAISE_ACCEPT_DEFAULT_RATE_INCREASE = 0.05;
-const RAISE_BONUS_DEFAULT_RATE_INCREASE = 0.03;
-const RAISE_ACCEPT_DEFAULT_MORALE_BOOST = 0.06;
-const RAISE_BONUS_DEFAULT_MORALE_BOOST = 0.04;
-const RAISE_IGNORE_DEFAULT_MORALE_PENALTY = -0.08;
-const RAISE_JITTER_RANGE_DAYS = 45;
-
-export const RAISE_MIN_EMPLOYMENT_DAYS = 180;
-export const RAISE_BASE_COOLDOWN_DAYS = 180;
+import {
+  RAISE_ACCEPT_DEFAULT_MORALE_BOOST,
+  RAISE_ACCEPT_DEFAULT_RATE_INCREASE,
+  RAISE_COOLDOWN_DAYS,
+  RAISE_BONUS_DEFAULT_MORALE_BOOST,
+  RAISE_BONUS_DEFAULT_RATE_INCREASE,
+  RAISE_IGNORE_DEFAULT_MORALE_PENALTY,
+  RAISE_JITTER_RANGE_DAYS,
+  RAISE_MIN_EMPLOYMENT_DAYS
+} from '../../constants/workforce.ts';
 
 export interface RaiseIntentOutcome {
   readonly employee: Employee;
@@ -58,7 +59,7 @@ function computeNextEligibleDay(
 ): number {
   const rng = createRng(employee.rngSeedUuid, `workforce:raise:${nextSequence}`);
   const jitter = Math.round((rng() * 2 - 1) * RAISE_JITTER_RANGE_DAYS);
-  const baseTarget = currentSimDay + RAISE_BASE_COOLDOWN_DAYS + jitter;
+  const baseTarget = currentSimDay + RAISE_COOLDOWN_DAYS + jitter;
   const minimum = currentSimDay + RAISE_MIN_EMPLOYMENT_DAYS;
   return Math.max(minimum, baseTarget);
 }
@@ -123,3 +124,14 @@ export function applyRaiseIntent(options: {
     bonusAmount_cc: (intent as WorkforceRaiseBonusIntent).bonusAmount_cc,
   } satisfies RaiseIntentOutcome;
 }
+
+export {
+  RAISE_ACCEPT_DEFAULT_MORALE_BOOST,
+  RAISE_ACCEPT_DEFAULT_RATE_INCREASE,
+  RAISE_COOLDOWN_DAYS,
+  RAISE_BONUS_DEFAULT_MORALE_BOOST,
+  RAISE_BONUS_DEFAULT_RATE_INCREASE,
+  RAISE_IGNORE_DEFAULT_MORALE_PENALTY,
+  RAISE_JITTER_RANGE_DAYS,
+  RAISE_MIN_EMPLOYMENT_DAYS
+} from '../../constants/workforce.ts';

--- a/packages/engine/src/backend/src/stubs/LightEmitterStub.ts
+++ b/packages/engine/src/backend/src/stubs/LightEmitterStub.ts
@@ -1,4 +1,5 @@
 import { SECONDS_PER_HOUR } from '../constants/simConstants.ts';
+import { MICROMOLES_PER_MOLE } from '../constants/lighting.ts';
 import type {
   ILightEmitter,
   LightEmitterInputs,
@@ -93,7 +94,7 @@ export function createLightEmitterStub(): ILightEmitter {
       const ppfd_effective_umol_m2s = ppfd_center_umol_m2s * dim;
       const tickSeconds = resolvedDt_h * SECONDS_PER_HOUR;
       const dli_mol_m2d_inc =
-        (ppfd_effective_umol_m2s * tickSeconds) / 1_000_000;
+        (ppfd_effective_umol_m2s * tickSeconds) / MICROMOLES_PER_MOLE;
       const energy_Wh = resolveEnergyWh(inputs, resolvedDt_h);
 
       return ensureFiniteOutputs({

--- a/packages/engine/src/backend/src/stubs/SensorStub.ts
+++ b/packages/engine/src/backend/src/stubs/SensorStub.ts
@@ -1,10 +1,17 @@
 import { SAFETY_MAX_CO2_PPM } from '@/backend/src/constants/simConstants';
+import {
+  HUMIDITY_SENSOR_MAX_PCT,
+  HUMIDITY_SENSOR_MIN_PCT,
+  TEMPERATURE_SENSOR_MAX_C,
+  TEMPERATURE_SENSOR_MIN_C
+} from '@/backend/src/constants/climate';
 import type { ISensor, SensorInputs, SensorOutputs } from '../domain/interfaces/ISensor.ts';
 import type { SensorMeasurementType } from '../domain/entities.ts';
 import type { RandomNumberGenerator } from '../util/rng.ts';
 import { clamp } from '../util/math.ts';
 
 function boxMullerTransform(rng: RandomNumberGenerator): number {
+  const TWO = 2 as const;
   let u1 = 0;
   let u2 = 0;
 
@@ -17,17 +24,17 @@ function boxMullerTransform(rng: RandomNumberGenerator): number {
     u2 = rng();
   }
 
-  const radius = Math.sqrt(-2.0 * Math.log(u1));
-  const theta = 2.0 * Math.PI * u2;
+  const radius = Math.sqrt(-TWO * Math.log(u1));
+  const theta = TWO * Math.PI * u2;
   return radius * Math.cos(theta);
 }
 
 function clampMeasuredValue(measurementType: SensorMeasurementType, value: number): number {
   switch (measurementType) {
     case 'temperature':
-      return clamp(value, -50, 150);
+      return clamp(value, TEMPERATURE_SENSOR_MIN_C, TEMPERATURE_SENSOR_MAX_C);
     case 'humidity':
-      return clamp(value, 0, 100);
+      return clamp(value, HUMIDITY_SENSOR_MIN_PCT, HUMIDITY_SENSOR_MAX_PCT);
     case 'co2':
       return clamp(value, 0, SAFETY_MAX_CO2_PPM);
     case 'ppfd':

--- a/packages/engine/tests/unit/services/workforce/raises.test.ts
+++ b/packages/engine/tests/unit/services/workforce/raises.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   applyRaiseIntent,
   createInitialRaiseState,
-  RAISE_BASE_COOLDOWN_DAYS,
+  RAISE_COOLDOWN_DAYS,
   RAISE_MIN_EMPLOYMENT_DAYS,
 } from '@/backend/src/services/workforce/raises';
 import { createRng } from '@/backend/src/util/rng';
@@ -83,7 +83,7 @@ describe('workforce raise cadence', () => {
     const jitter = Math.round((rng() * 2 - 1) * 45);
     const expectedNext = Math.max(
       currentSimDay + RAISE_MIN_EMPLOYMENT_DAYS,
-      currentSimDay + RAISE_BASE_COOLDOWN_DAYS + jitter,
+      currentSimDay + RAISE_COOLDOWN_DAYS + jitter,
     );
     expect(result.employee.raise.nextEligibleDay).toBe(expectedNext);
   });

--- a/packages/facade/package.json
+++ b/packages/facade/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "tsc --project tsconfig.json",
     "test": "vitest run",
-    "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\"",
+    "lint": "eslint --max-warnings=0 \"src/**/*.ts\" \"tests/**/*.ts\"",
     "format": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\"",
     "dev": "tsx watch src/index.ts"
   },

--- a/packages/tools-monitor/package.json
+++ b/packages/tools-monitor/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "tsc --project tsconfig.json",
     "test": "vitest run",
-    "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\"",
+    "lint": "eslint --max-warnings=0 \"src/**/*.ts\" \"tests/**/*.ts\"",
     "format": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\"",
     "dev": "tsx watch src/index.ts",
     "start": "tsx src/index.ts",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "tsc --project tsconfig.json",
     "test": "vitest run --passWithNoTests",
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --max-warnings=0 \"src/**/*.ts\"",
     "format": "prettier --check \"src/**/*.ts\"",
     "dev": "tsx watch src/index.ts",
     "report:packages": "tsx src/cli/report.ts report packages"
@@ -25,6 +25,7 @@
     "globby": "^14.1.0",
     "pino": "^9.13.1",
     "pino-pretty": "^11.3.0",
-    "yaml": "^2.8.1"
+    "yaml": "^2.8.1",
+    "ts-morph": "^24.0.0"
   }
 }

--- a/packages/tools/scripts/codemods/extract-magic-thresholds.ts
+++ b/packages/tools/scripts/codemods/extract-magic-thresholds.ts
@@ -1,0 +1,56 @@
+import { Project, SyntaxKind } from 'ts-morph';
+
+interface Replacement {
+  readonly value: number;
+  readonly import: {
+    readonly from: string;
+    readonly name: string;
+  };
+}
+
+const project = new Project({ tsConfigFilePath: 'tsconfig.json' });
+const files = project.addSourceFilesAtPaths(['packages/**/src/**/*.{ts,tsx}']);
+
+const REPLACEMENTS: readonly Replacement[] = [
+  { value: 0.35, import: { from: '@engine/constants/climate', name: 'HUMIDITY_MIN' } },
+  { value: 15, import: { from: '@engine/constants/time', name: 'MINUTES_STEP' } },
+  { value: 180, import: { from: '@engine/constants/workforce', name: 'RAISE_COOLDOWN_DAYS' } }
+];
+
+for (const sourceFile of files) {
+  let changed = false;
+
+  sourceFile.forEachDescendant((node) => {
+    if (node.getKind() === SyntaxKind.NumericLiteral) {
+      const literalValue = Number(node.getText());
+      const match = REPLACEMENTS.find((candidate) => Object.is(candidate.value, literalValue));
+
+      if (match) {
+        const existingImport = sourceFile
+          .getImportDeclarations()
+          .find((declaration) => declaration.getModuleSpecifierValue() === match.import.from);
+
+        if (existingImport) {
+          const namedImports = new Set(existingImport.getNamedImports().map((item) => item.getName()));
+          if (!namedImports.has(match.import.name)) {
+            existingImport.addNamedImport(match.import.name);
+          }
+        } else {
+          sourceFile.addImportDeclaration({
+            moduleSpecifier: match.import.from,
+            namedImports: [match.import.name]
+          });
+        }
+
+        node.replaceWithText(match.import.name);
+        changed = true;
+      }
+    }
+  });
+
+  if (changed) {
+    await sourceFile.fixUnusedIdentifiers();
+  }
+}
+
+await project.save();

--- a/packages/transport-sio/package.json
+++ b/packages/transport-sio/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "tsc --project tsconfig.json",
     "test": "vitest run",
-    "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\"",
+    "lint": "eslint --max-warnings=0 \"src/**/*.ts\" \"tests/**/*.ts\"",
     "format": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\"",
     "dev": "tsx watch src/index.ts"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
       pino-pretty:
         specifier: ^11.3.0
         version: 11.3.0
+      ts-morph:
+        specifier: ^24.0.0
+        version: 24.0.0
       yaml:
         specifier: ^2.8.1
         version: 2.8.1
@@ -650,6 +653,9 @@ packages:
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
 
+  '@ts-morph/common@0.25.0':
+    resolution: {integrity: sha512-kMnZz+vGGHi4GoHnLmMhGNjm44kGtKUXGnOvrKmMwAuvNjM/PgKVGfUnL7IDvK7Jb2QQ82jq3Zmp04Gy+r3Dkg==}
+
   '@types/blessed@0.1.25':
     resolution: {integrity: sha512-kQsjBgtsbJLmG6CJA+Z6Nujj+tq1fcSE3UIowbDvzQI4wWmoTV7djUDhSo5lDjgwpIN0oRvks0SA5mMdKE5eFg==}
 
@@ -865,6 +871,9 @@ packages:
   cli-table3@0.6.5:
     resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
     engines: {node: 10.* || >= 12.*}
+
+  code-block-writer@13.0.3:
+    resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1306,6 +1315,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1558,6 +1570,9 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  ts-morph@24.0.0:
+    resolution: {integrity: sha512-2OAOg/Ob5yx9Et7ZX4CvTCc0UFoZHwLEJ+dpDPSUi5TgwwlTlX47w+iFRrEwzUZwYACjq83cgjS/Da50Ga37uw==}
 
   tsx@4.20.6:
     resolution: {integrity: sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==}
@@ -2055,6 +2070,12 @@ snapshots:
 
   '@socket.io/component-emitter@3.1.2': {}
 
+  '@ts-morph/common@0.25.0':
+    dependencies:
+      minimatch: 9.0.5
+      path-browserify: 1.0.1
+      tinyglobby: 0.2.15
+
   '@types/blessed@0.1.25':
     dependencies:
       '@types/node': 20.19.19
@@ -2323,6 +2344,8 @@ snapshots:
       string-width: 4.2.3
     optionalDependencies:
       '@colors/colors': 1.5.0
+
+  code-block-writer@13.0.3: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -2802,6 +2825,8 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  path-browserify@1.0.1: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -3078,6 +3103,11 @@ snapshots:
   ts-api-utils@2.1.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  ts-morph@24.0.0:
+    dependencies:
+      '@ts-morph/common': 0.25.0
+      code-block-writer: 13.0.3
 
   tsx@4.20.6:
     dependencies:

--- a/tools/scripts/scan-magic-numbers.mjs
+++ b/tools/scripts/scan-magic-numbers.mjs
@@ -1,0 +1,111 @@
+import { spawnSync } from 'node:child_process';
+
+function run(command, args) {
+  return spawnSync(command, args, { encoding: 'utf8' });
+}
+
+function resolveDiffBase() {
+  const baseRef = process.env.GITHUB_BASE_REF ? `origin/${process.env.GITHUB_BASE_REF}` : 'origin/main';
+  const mergeBase = run('git', ['merge-base', 'HEAD', baseRef]);
+
+  if (mergeBase.status === 0 && mergeBase.stdout.trim().length > 0) {
+    return mergeBase.stdout.trim();
+  }
+
+  const headParent = run('git', ['rev-parse', 'HEAD^']);
+  if (headParent.status === 0) {
+    return headParent.stdout.trim();
+  }
+
+  throw new Error('Unable to determine diff base for magic number scan.');
+}
+
+function getChangedFiles(base) {
+  const diff = run('git', ['diff', '--name-only', base]);
+  if (diff.status !== 0) {
+    throw new Error(`git diff failed: ${diff.stderr}`);
+  }
+
+  return diff.stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+function isProductionTsFile(filePath) {
+  if (!filePath.endsWith('.ts') && !filePath.endsWith('.tsx')) {
+    return false;
+  }
+
+  if (filePath.includes('/constants/')) {
+    return false;
+  }
+
+  if (filePath.includes('/schemas/')) {
+    return false;
+  }
+
+  if (filePath.endsWith('.test.ts') || filePath.endsWith('.spec.ts')) {
+    return false;
+  }
+
+  return filePath.startsWith('packages/');
+}
+
+const diffBase = resolveDiffBase();
+const changedFiles = getChangedFiles(diffBase).filter(isProductionTsFile);
+
+if (changedFiles.length === 0) {
+  console.log('Magic number scan skipped (no production TypeScript changes).');
+  process.exit(0);
+}
+
+const pattern = "\\b(?<![A-Za-z_])(-?\\d+(\\.\\d+)?)(?!\\s*[:,}\\]])\\b";
+const scan = run('rg', ['--json', '--pcre2', pattern, ...changedFiles]);
+
+if (scan.error) {
+  console.error('Failed to execute ripgrep:', scan.error);
+  process.exit(scan.status ?? 1);
+}
+
+const allowed = new Set(['-1', '0', '1', '2', '10', '60', '100', '1000']);
+const violations = [];
+
+for (const line of scan.stdout.split('\n')) {
+  if (!line) {
+    continue;
+  }
+
+  const event = JSON.parse(line);
+
+  if (event.type !== 'match') {
+    continue;
+  }
+
+  const [submatch] = event.data.submatches;
+  if (!submatch) {
+    continue;
+  }
+
+  if (allowed.has(submatch.match.text)) {
+    continue;
+  }
+
+  violations.push({
+    file: event.data.path.text,
+    line: event.data.line_number,
+    text: event.data.lines.text.trim()
+  });
+}
+
+if (violations.length === 0) {
+  console.log('Magic number scan passed.');
+  process.exit(0);
+}
+
+console.error('Magic numbers detected in modified production files:\n');
+for (const violation of violations) {
+  console.error(`${violation.file}:${violation.line}: ${violation.text}`);
+}
+
+process.exit(1);

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -42,6 +42,9 @@
       "@wb/tools-monitor": [
         "packages/tools-monitor/src/index.ts"
       ],
+      "@engine/constants/*": [
+        "packages/engine/src/backend/src/constants/*"
+      ],
       "@/backend/*": [
         "packages/engine/src/backend/*"
       ],


### PR DESCRIPTION
**Summary:** Centralized constants; removed magic numbers; added ESLint & CI guards.

**Contracts referenced:** SEC v0.2.1; DD §2 (Canonical Constants), AGENTS §3/§11.

**Notes:** `simConstants.ts` remains the canonical source; domain modules re-export or extend.

**Verification:** `pnpm scan:magic`; `pnpm -r lint` *(fails on pre-existing unsafe member access violations)*

------
https://chatgpt.com/codex/tasks/task_e_68e6c26458ec83259b3b94641e707f5c