### PR TITLE
Fix cultivation scheduling bootstrap

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,9 @@
   trait, and telemetry logic into dedicated modules under `src/workforce/**`, kept
   each file under 500 LOC, and routed all workforce side-effects through a single
   telemetry batch emitter so the tick stage now orchestrates pure functions only.
+- Fixed workforce cultivation scheduling so fresh worlds without a pre-existing
+  workforce state still enqueue cultivation tasks and bootstrap the module when
+  cultivation is the first subsystem to request labor.
 - Added import hygiene guardrails: `simple-git-hooks` pre-commit runs lint + import resolution specs, ESLint now blocks local
   `.js` suffixes in TypeScript, and a Vitest probe dynamically `import()`s engine schemas/pipeline stages to catch bad specifiers
   before CI.


### PR DESCRIPTION
## Summary
- allow cultivation scheduling to bootstrap a workforce state before enqueuing tasks so fresh worlds still generate work
- document the cultivation scheduling fix in the changelog

## Testing
- pnpm --filter @wb/engine test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e7404bf3d483258f7911041325efc3