### PR TITLE
Add CI LOC guard for packages src directories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Magic number scan
         run: pnpm scan:magic
 
+      - name: LOC guard (packages/**/src/**)
+        run: pnpm loc:guard
+
       - name: Import resolution guardrail
         run: pnpm test:imports
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Unreleased — Blueprint Taxonomy v2
 
+- Added a CI LOC guard for `packages/**/src/**` that surfaces warnings at
+  700 LOC and fails the build at 1,200 LOC so oversized modules are caught
+  before review while allowing deliberate refactors to land incrementally.
+
 - Split the domain world validation suite into `validation/company.ts`,
   `validation/devices.ts`, and `validation/roomsZones.ts`, keeping
   `validateCompanyWorld`'s public surface intact while reducing the

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:imports": "pnpm --filter @wb/engine test:imports",
     "lint": "pnpm -r lint",
     "lint:imports": "pnpm exec eslint --max-warnings=0 --config tools/eslint/import-guard.config.js packages tools",
+    "loc:guard": "node ./tools/scripts/loc-guard.mjs",
     "perf:ci": "pnpm --filter @wb/engine perf:ci",
     "format": "pnpm -r format",
     "migrate:folders": "node scripts/migrate-blueprint-folders.mjs",

--- a/tools/scripts/loc-guard.mjs
+++ b/tools/scripts/loc-guard.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+import { readFile } from 'node:fs/promises';
+import { glob } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const WARN_THRESHOLD = 700;
+const FAIL_THRESHOLD = 1200;
+
+const INCLUDE_GLOBS = [
+  'packages/**/src/**/*.{ts,tsx,js,jsx,mjs,mts,cjs,cts}'
+];
+
+const IGNORE_GLOBS = [
+  '**/node_modules/**',
+  '**/dist/**',
+  '**/build/**',
+  '**/.turbo/**',
+  '**/.cache/**'
+];
+
+const toRelative = (filePath) => path.relative(process.cwd(), filePath);
+
+const countLoc = (source) => {
+  if (source.length === 0) {
+    return 0;
+  }
+
+  const normalized = source.replace(/\r\n?/g, '\n');
+  return normalized.split('\n').length;
+};
+
+const collectFiles = async () => {
+  const fileSet = new Set();
+
+  for (const pattern of INCLUDE_GLOBS) {
+    for await (const match of glob(pattern, {
+      ignore: IGNORE_GLOBS,
+      nodir: true
+    })) {
+      fileSet.add(match);
+    }
+  }
+
+  return Array.from(fileSet).sort();
+};
+
+const run = async () => {
+  const files = await collectFiles();
+
+  const results = [];
+  for (const filePath of files) {
+    const content = await readFile(filePath, 'utf8');
+    const loc = countLoc(content);
+    results.push({ filePath, loc });
+  }
+
+  const warnings = results
+    .filter(({ loc }) => loc >= WARN_THRESHOLD && loc < FAIL_THRESHOLD)
+    .sort((a, b) => b.loc - a.loc);
+
+  const failures = results
+    .filter(({ loc }) => loc >= FAIL_THRESHOLD)
+    .sort((a, b) => b.loc - a.loc);
+
+  if (warnings.length > 0) {
+    console.warn('⚠️  LOC guard warnings (≥ ' + WARN_THRESHOLD + ' LOC):');
+    for (const { filePath, loc } of warnings) {
+      console.warn('   - %s (%d LOC)', toRelative(filePath), loc);
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error('❌ LOC guard failures (≥ ' + FAIL_THRESHOLD + ' LOC):');
+    for (const { filePath, loc } of failures) {
+      console.error('   - %s (%d LOC)', toRelative(filePath), loc);
+    }
+    process.exit(1);
+  }
+
+  const max = results.reduce((acc, entry) => Math.max(acc, entry.loc), 0);
+  console.log(
+    '✅ LOC guard scanned %d files under packages/**/src/** (max %d LOC).',
+    results.length,
+    max
+  );
+};
+
+run().catch((error) => {
+  console.error('Failed to execute LOC guard:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a reusable loc guard script that scans packages/**/src/** and warns at 700 LOC while failing at 1,200
- expose the guard via `pnpm loc:guard` and call it from the CI quality workflow
- document the new guardrail in the changelog

## Testing
- pnpm loc:guard

------
https://chatgpt.com/codex/tasks/task_e_68e75f4d89c483258b47681c36e5b5aa