### PR TITLE
docs: add frontend mini proposal tasks

### DIFF
--- a/docs/tasks/frontend/0020-transport-server-bootstrap.md
+++ b/docs/tasks/frontend/0020-transport-server-bootstrap.md
@@ -1,0 +1,32 @@
+# Transport Server Bootstrap
+
+**ID:** 0020
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** frontend, transport, track-1
+
+## Rationale
+The transport slice must expose dedicated telemetry and intent namespaces with a health endpoint before any clients can hydrate or emit intents. Wiring the façade HTTP server to the Socket.IO adapter early unblocks later tracks that depend on stable URLs and namespaces defined in the proposal.
+
+## Scope
+- In: create façade-side HTTP server factory with `/healthz` route and Socket.IO namespaces (`/telemetry`, `/intents`).
+- In: surface minimal server options (CORS, origins) required for local dev bootstrap.
+- Out: business logic for read-model handlers, telemetry publishing, or intent processing beyond invoking the provided callback.
+
+## Deliverables
+- `packages/facade/src/transport/server.ts` standing up the HTTP server and binding `createSocketTransportAdapter`.
+- `packages/facade/tests/integration/transport/serverNamespaces.spec.ts` covering namespace registration and health response.
+- New `docs/tools/dev-stack.md` note describing how to launch the façade transport server locally.
+
+## Acceptance Criteria
+- Creating the server returns references to `/telemetry` and `/intents` namespaces and a `close()` helper.
+- `GET /healthz` responds with HTTP 200 and `{status:"ok"}`.
+- Integration test asserts that custom CORS origin configuration is accepted and telemetry namespace rejects inbound emits by default (no handler registered yet).
+- Documentation explains the pnpm script (or command sequence) to start the transport server and the expected port configuration.
+
+## References
+- [Proposal §3](../../proposals/20251009-mini_frontend.md#3-architectural-contracts)
+- [Proposal §5](../../proposals/20251009-mini_frontend.md#5-thin-transport-slice-mvp-wiring)
+- [SEC §1](../../SEC.md#1-core-invariants-guardrails)
+- [TDD §11](../../TDD.md#11-telemetry-read-only-transport-separation-sec-11)

--- a/docs/tasks/frontend/0021-telemetry-readonly-contract-tests.md
+++ b/docs/tasks/frontend/0021-telemetry-readonly-contract-tests.md
@@ -1,0 +1,30 @@
+# Telemetry Read-only Contract Tests
+
+**ID:** 0021
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** frontend, transport, tests, track-1
+
+## Rationale
+Read-only enforcement on the telemetry namespace is a hard contract in SEC and the proposal. Adding focused contract tests ensures regressions are caught before UI integration and provides fixtures for later telemetry binder work.
+
+## Scope
+- In: write integration tests against `createSocketTransportAdapter` verifying that telemetry emits are rejected with `WB_TEL_READONLY` and that no handler is invoked.
+- In: add fixtures ensuring the intents namespace still accepts `intent:submit` when payload is valid.
+- Out: UI-side handling of these errors or documentation updates (covered by other tasks).
+
+## Deliverables
+- `packages/transport-sio/tests/integration/telemetryReadonly.spec.ts` covering negative cases and ack expectations.
+- Updates to existing vitest config if needed to run the new integration suite.
+
+## Acceptance Criteria
+- Tests assert that any client emit on `/telemetry` (with or without ack) yields `WB_TEL_READONLY` and does not call the provided handler.
+- Tests confirm that `/intents` continues to resolve valid submissions with `{ok:true}` and rejects malformed payloads with `WB_INTENT_INVALID`.
+- The new test suite runs via `pnpm --filter @wb/transport-sio test` without additional manual wiring.
+
+## References
+- [Proposal §3](../../proposals/20251009-mini_frontend.md#3-architectural-contracts)
+- [Proposal §5](../../proposals/20251009-mini_frontend.md#5-thin-transport-slice-mvp-wiring)
+- [SEC §1](../../SEC.md#1-core-invariants-guardrails)
+- [TDD §11](../../TDD.md#11-telemetry-read-only-transport-separation-sec-11)

--- a/docs/tasks/frontend/0022-transport-ack-contract.md
+++ b/docs/tasks/frontend/0022-transport-ack-contract.md
@@ -1,0 +1,32 @@
+# Transport Ack Contract Publication
+
+**ID:** 0022
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** frontend, transport, contracts, track-1
+
+## Rationale
+The UI and intent flows require a single source of truth for transport acknowledgements and error codes. Publishing typed helpers and documentation ensures both sides agree on the ack payload structure ahead of telemetry and intent wiring.
+
+## Scope
+- In: factor shared `TransportAck`/error-code definitions into a dedicated module that can be imported by façade, UI, and tests.
+- In: add lightweight runtime guard (e.g., zod or manual predicate) to validate incoming ack payloads on the client side.
+- Out: UI usage of the guard (covered by later tracks) or backend business logic for handling intents.
+
+## Deliverables
+- `packages/transport-sio/src/contracts/ack.ts` exporting error-code registry, ack types, and a `assertTransportAck` (or similar) runtime validator.
+- Re-export hook in `packages/facade/src/transport/adapter.ts` so downstream packages consume the new module.
+- `docs/constants/transport-error-codes.md` describing codes and linking back to SEC proposal sections.
+
+## Acceptance Criteria
+- Module exports a frozen error-code map containing at least `WB_TEL_READONLY`, `WB_INTENT_INVALID`, `WB_INTENT_CHANNEL_INVALID`, `WB_INTENT_HANDLER_ERROR`.
+- Validator throws (or returns false) when ack payloads violate the contract; unit tests cover positive/negative cases.
+- Existing transport adapter compiles against the new module without duplicating constants.
+- Documentation lists the codes, describes when they surface, and references SEC/TDD clauses.
+
+## References
+- [Proposal §3](../../proposals/20251009-mini_frontend.md#3-architectural-contracts)
+- [Proposal §5](../../proposals/20251009-mini_frontend.md#5-thin-transport-slice-mvp-wiring)
+- [SEC §1](../../SEC.md#1-core-invariants-guardrails)
+- [TDD §11](../../TDD.md#11-telemetry-read-only-transport-separation-sec-11)

--- a/docs/tasks/frontend/0023-readmodel-schema-types.md
+++ b/docs/tasks/frontend/0023-readmodel-schema-types.md
@@ -1,0 +1,31 @@
+# Read-model Schema Types
+
+**ID:** 0023
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** frontend, read-models, track-2
+
+## Rationale
+Typed DTOs and validators for the three MVP read models are required before wiring HTTP endpoints or hydrating the UI. Establishing these schemas prevents drift and enables reuse across façade and client code.
+
+## Scope
+- In: define TypeScript types and zod (or equivalent) validators for `companyTree`, `structureTariffs`, and `workforceView` read models.
+- In: include `schemaVersion` and `simTime` metadata in each schema per proposal boot sequence.
+- Out: HTTP route handlers or persistence of the data (handled by subsequent tasks).
+
+## Deliverables
+- `packages/facade/src/readModels/api/schemas.ts` exporting types and validators.
+- `packages/facade/tests/unit/readModels/schemas.spec.ts` covering positive/negative validation cases.
+- New `docs/constants/read-model-schemas.md` listing schema identifiers and linking back to the proposal.
+
+## Acceptance Criteria
+- Validators ensure required fields match the proposal shapes including nested structures.
+- Schemas expose string literal `schemaVersion` fields and numeric `simTime` (hours) metadata.
+- Unit tests cover at least one invalid payload per schema and assert descriptive error messages.
+- Documentation lists the current schema version identifiers for the three read models.
+
+## References
+- [Proposal §4](../../proposals/20251009-mini_frontend.md#4-ui-surfaces-data-flows)
+- [Proposal §6](../../proposals/20251009-mini_frontend.md#6-data-schemas-mvp-minimal-fields)
+- [DD §3](../../DD.md#3-domain-data-models)

--- a/docs/tasks/frontend/0024-readmodel-http-endpoints.md
+++ b/docs/tasks/frontend/0024-readmodel-http-endpoints.md
@@ -1,0 +1,31 @@
+# Read-model HTTP Endpoints
+
+**ID:** 0024
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** frontend, read-models, facade, track-2
+
+## Rationale
+With schemas in place, the façade needs deterministic HTTP endpoints so the UI can hydrate its store. Implementing the three MVP endpoints ensures consistent responses and schema-version signalling per the proposal.
+
+## Scope
+- In: add `/api/companyTree`, `/api/structureTariffs`, and `/api/workforceView` GET handlers returning validated payloads.
+- In: reuse schema validators to ensure responses conform before sending.
+- Out: persistence/backing data sources beyond in-memory stubs sourced from engine bootstrap (follow-up tasks may replace data sources).
+
+## Deliverables
+- `packages/facade/src/server/http.ts` (new) or equivalent Express/Fastify module wiring the three routes.
+- `packages/facade/tests/integration/readModels/httpEndpoints.spec.ts` covering happy paths and schema mismatch failures.
+- Update to façade package `package.json` to expose a `dev:server` script if missing.
+
+## Acceptance Criteria
+- Each endpoint responds with HTTP 200, includes `schemaVersion` and `simTime`, and matches schema types.
+- Invalid payloads trigger HTTP 500 with logged error and test coverage verifying the guard.
+- Integration tests run under `pnpm --filter @wb/facade test`.
+- Dev script instructions (package README or scripts) document how to start the HTTP server alongside the transport server.
+
+## References
+- [Proposal §4](../../proposals/20251009-mini_frontend.md#4-ui-surfaces-data-flows)
+- [Proposal §6](../../proposals/20251009-mini_frontend.md#6-data-schemas-mvp-minimal-fields)
+- [TDD §5](../../TDD.md#5-read-model-contracts)

--- a/docs/tasks/frontend/0025-readmodel-client-sdk.md
+++ b/docs/tasks/frontend/0025-readmodel-client-sdk.md
@@ -1,0 +1,30 @@
+# Read-model Client SDK
+
+**ID:** 0025
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** frontend, read-models, sdk, track-2
+
+## Rationale
+UI hydration requires a thin client that fetches the three read models, validates responses, and surfaces typed results. Building this SDK now decouples later UI work from transport details and locks down error handling expectations.
+
+## Scope
+- In: implement fetch helpers for the three read models using the schemas from Task 0023.
+- In: expose unified error type for schema mismatches or network failures.
+- Out: state management or UI rendering (covered in later tracks).
+
+## Deliverables
+- `packages/facade/src/readModels/client.ts` exporting async functions `fetchCompanyTree`, `fetchStructureTariffs`, `fetchWorkforceView` that accept a base URL.
+- `packages/facade/tests/unit/readModels/client.spec.ts` stubbing `fetch` to cover success, HTTP error, and schema mismatch cases.
+- `docs/tools/rest-client.md` (new) providing `.http` examples or curl snippets for the three endpoints.
+
+## Acceptance Criteria
+- Each helper validates payloads via schema validators and throws a typed error when validation fails.
+- Unit tests demonstrate rejection on non-2xx responses and invalid JSON.
+- Documentation includes example requests/responses matching schema versions.
+
+## References
+- [Proposal §4](../../proposals/20251009-mini_frontend.md#4-ui-surfaces-data-flows)
+- [Proposal §6](../../proposals/20251009-mini_frontend.md#6-data-schemas-mvp-minimal-fields)
+- [TDD §5](../../TDD.md#5-read-model-contracts)

--- a/docs/tasks/frontend/0026-ui-workspace-bootstrap.md
+++ b/docs/tasks/frontend/0026-ui-workspace-bootstrap.md
@@ -1,0 +1,31 @@
+# UI Workspace Bootstrap
+
+**ID:** 0026
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** frontend, ui, tooling, track-4
+
+## Rationale
+We need a dedicated React + Vite workspace aligned with the monorepo conventions before building telemetry binders or UI surfaces. Bootstrapping the package establishes routing, Tailwind configuration, and base layout plumbing for subsequent tasks.
+
+## Scope
+- In: create `packages/ui` with Vite (React, TypeScript, ESM) scaffold wired into pnpm workspaces.
+- In: configure Tailwind + shadcn/ui baseline, shared design tokens, and lint/test scripts.
+- Out: feature-specific components (handled by follow-up tasks).
+
+## Deliverables
+- `packages/ui/package.json`, Vite config, Tailwind config, and base `src/App.tsx` rendering a placeholder shell with left rail + main content slots.
+- Workspace wiring updates: `pnpm-workspace.yaml`, root scripts, and Git ignore entries if required.
+- `packages/ui/README.md` describing dev commands and environment variables.
+
+## Acceptance Criteria
+- `pnpm install` succeeds with the new workspace and `pnpm --filter @wb/ui dev` launches Vite.
+- Base layout renders left rail + main content placeholder without runtime errors.
+- Lint/test scripts (e.g., `pnpm --filter @wb/ui lint`/`test`) are defined even if tests are stubbed.
+- Documentation captures setup steps, Node 22 expectation, and how to run the dev server alongside façade.
+
+## References
+- [Proposal §4](../../proposals/20251009-mini_frontend.md#4-ui-surfaces-data-flows)
+- [AGENTS §1](../../AGENTS.md#1-platform-monorepo-must-haves)
+- [TDD §2](../../TDD.md#2-tooling-and-workflow)

--- a/docs/tasks/frontend/0027-ui-left-rail.md
+++ b/docs/tasks/frontend/0027-ui-left-rail.md
@@ -1,0 +1,29 @@
+# UI Left Rail Navigation
+
+**ID:** 0027
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** frontend, ui, navigation, track-4
+
+## Rationale
+The left rail provides global navigation between Dashboard, Zone Detail, and Workforce KPIs. Implementing the shell early enables other surfaces to slot into consistent routes and keeps layout work isolated.
+
+## Scope
+- In: add React Router (or existing routing strategy) with routes for Dashboard, Zone Detail, Workforce KPIs placeholders.
+- In: implement left rail component with accordion-style structures/zones per proposal, using mock data sourced from read-model types (can be hard-coded until hydration tasks land).
+- Out: actual data hydration or real-time updates (handled by later tasks).
+
+## Deliverables
+- `packages/ui/src/components/layout/LeftRail.tsx` rendering navigation sections and active state styling.
+- Routing updates in `packages/ui/src/App.tsx` (or router module) hooking the left rail + outlet.
+- `packages/ui/src/components/layout/__tests__/LeftRail.test.tsx` verifying navigation links render and active route highlighting works.
+
+## Acceptance Criteria
+- Left rail lists structures and zones with accordion behaviour; selecting items updates URL routes.
+- Navigation supports keyboard interaction (tab + enter/space) per accessibility expectations.
+- Tests cover initial render and route change highlighting.
+
+## References
+- [Proposal §4](../../proposals/20251009-mini_frontend.md#4-ui-surfaces-data-flows)
+- [VISION Scope §2](../../VISION_SCOPE.md#2-product-pillars)

--- a/docs/tasks/frontend/0028-ui-dashboard-skeleton.md
+++ b/docs/tasks/frontend/0028-ui-dashboard-skeleton.md
@@ -1,0 +1,29 @@
+# Dashboard Skeleton
+
+**ID:** 0028
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** frontend, ui, dashboard, track-4
+
+## Rationale
+The dashboard is the primary landing surface summarising simulation tick rate, day/time, and key metrics. Building a skeleton with placeholder widgets lets telemetry wiring drop in later without layout churn.
+
+## Scope
+- In: create dashboard page component with cards for tick rate, sim day/time, daily cost rollups, energy/water usage, and an event stream list.
+- In: stub selectors/hooks that read from a forthcoming store interface (define TypeScript interfaces to be fulfilled later).
+- Out: live data binding or telemetry subscriptions (handled in telemetry track).
+
+## Deliverables
+- `packages/ui/src/pages/DashboardPage.tsx` with layout components and placeholder values.
+- `packages/ui/src/pages/__tests__/DashboardPage.test.tsx` ensuring sections render and placeholder copy is present.
+- Shared style tokens or utility classes in `packages/ui/src/styles/dashboard.css` (or Tailwind config) as needed.
+
+## Acceptance Criteria
+- Dashboard renders all specified widgets with accessible headings and placeholders.
+- Page consumes typed selectors (e.g., `useDashboardSnapshot`) that currently return stub data but enforce shape for later wiring.
+- Tests confirm the placeholder values and headings; snapshot or DOM assertions accepted.
+
+## References
+- [Proposal §4](../../proposals/20251009-mini_frontend.md#4-ui-surfaces-data-flows)
+- [VISION Scope §2](../../VISION_SCOPE.md#2-product-pillars)

--- a/docs/tasks/frontend/0029-ui-zone-detail-skeleton.md
+++ b/docs/tasks/frontend/0029-ui-zone-detail-skeleton.md
@@ -1,0 +1,29 @@
+# Zone Detail Skeleton
+
+**ID:** 0029
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** frontend, ui, zone-detail, track-4
+
+## Rationale
+The zone detail page must present live environmental metrics and action panels for intents. A skeleton with deterministic layout unlocks telemetry binding and intent UX work later.
+
+## Scope
+- In: create zone detail page layout with sections for environmental metrics (PPFD, DLI, Temp, RH, CO₂, ACH), device coverage summaries, and an actions panel placeholder.
+- In: define TypeScript interfaces/hooks for zone telemetry + metadata that the telemetry track will populate.
+- Out: real data binding or form submission (handled by telemetry/intent tracks).
+
+## Deliverables
+- `packages/ui/src/pages/ZoneDetailPage.tsx` with structured sections and placeholder values.
+- `packages/ui/src/pages/__tests__/ZoneDetailPage.test.tsx` verifying key sections render.
+- Shared component `packages/ui/src/components/zones/MetricCard.tsx` (or similar) reused by the page.
+
+## Acceptance Criteria
+- Page renders metric cards with labelled placeholders and warns if data is unavailable (stub message acceptable).
+- Actions panel includes buttons or call-to-actions disabled until intents are wired, with tooltip copy referencing upcoming tasks.
+- Tests assert presence of all metric labels and placeholder states.
+
+## References
+- [Proposal §4](../../proposals/20251009-mini_frontend.md#4-ui-surfaces-data-flows)
+- [Proposal §6](../../proposals/20251009-mini_frontend.md#6-data-schemas-mvp-minimal-fields)

--- a/docs/tasks/frontend/0030-ui-workforce-kpi-skeleton.md
+++ b/docs/tasks/frontend/0030-ui-workforce-kpi-skeleton.md
@@ -1,0 +1,29 @@
+# Workforce KPI Skeleton
+
+**ID:** 0030
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** frontend, ui, workforce, track-4
+
+## Rationale
+Workforce KPIs must surface headcount, role distribution, and warnings. Providing a dedicated page with structured placeholders ensures telemetry and read-model wiring have a stable target.
+
+## Scope
+- In: build workforce KPI page with cards for headcount, role mix, utilization, and warning list.
+- In: create hooks/selectors using the read-model client interfaces to supply data once hydration is implemented.
+- Out: live data binding or filters beyond static placeholders.
+
+## Deliverables
+- `packages/ui/src/pages/WorkforcePage.tsx` with layout components.
+- `packages/ui/src/pages/__tests__/WorkforcePage.test.tsx` verifying placeholders and list rendering.
+- Shared components (e.g., `packages/ui/src/components/workforce/KpiCard.tsx`) for consistent visuals.
+
+## Acceptance Criteria
+- Workforce page renders sections for headcount, roles, utilization, and warnings with placeholder data.
+- Hooks/interfaces for workforce data defined under `packages/ui/src/state/workforce.ts` returning stubbed values.
+- Tests assert placeholder content and warning list fallback state.
+
+## References
+- [Proposal §4](../../proposals/20251009-mini_frontend.md#4-ui-surfaces-data-flows)
+- [Proposal §6](../../proposals/20251009-mini_frontend.md#6-data-schemas-mvp-minimal-fields)

--- a/docs/tasks/frontend/0031-telemetry-store-foundation.md
+++ b/docs/tasks/frontend/0031-telemetry-store-foundation.md
@@ -1,0 +1,30 @@
+# Telemetry Store Foundation
+
+**ID:** 0031
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** frontend, telemetry, state, track-3
+
+## Rationale
+Before wiring socket listeners we need a deterministic client store schema to hold telemetry snapshots for dashboard, zones, and workforce KPIs. Defining the store now enables subsequent binder tasks to focus on transport plumbing.
+
+## Scope
+- In: design TypeScript interfaces for the four telemetry topics and create a Zustand (or equivalent) store with setter actions.
+- In: provide selectors/hooks consumed by dashboard, zone detail, and workforce pages (currently returning defaults).
+- Out: real socket subscriptions (handled next).
+
+## Deliverables
+- `packages/ui/src/state/telemetry.ts` defining topic interfaces, store initial state, and hooks (`useTelemetryTick`, `useZoneSnapshot`, etc.).
+- `packages/ui/src/state/__tests__/telemetryStore.test.ts` covering default state and action reducers.
+- Update placeholder selectors in dashboard/zone/workforce pages to use the new hooks.
+
+## Acceptance Criteria
+- Store exposes state slices for `telemetry.tick.completed.v1`, `telemetry.zone.snapshot.v1`, `telemetry.workforce.kpi.v1`, and `telemetry.harvest.created.v1` topics.
+- Hooks return sensible defaults (e.g., `null` snapshot) before data arrives and TypeScript enforces topic payload shapes per schemas.
+- Unit tests validate reducer behaviour for each topic action.
+
+## References
+- [Proposal §3](../../proposals/20251009-mini_frontend.md#3-architectural-contracts)
+- [Proposal §4](../../proposals/20251009-mini_frontend.md#4-ui-surfaces-data-flows)
+- [Proposal §6](../../proposals/20251009-mini_frontend.md#6-data-schemas-mvp-minimal-fields)

--- a/docs/tasks/frontend/0032-telemetry-socket-binder.md
+++ b/docs/tasks/frontend/0032-telemetry-socket-binder.md
@@ -1,0 +1,31 @@
+# Telemetry Socket Binder
+
+**ID:** 0032
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** frontend, telemetry, transport, track-3
+
+## Rationale
+With store slices defined, the UI needs a binder that connects to the `/telemetry` namespace, subscribes to four topics, and dispatches updates deterministically. This task builds the socket client plumbing and reconnection policy described in the proposal.
+
+## Scope
+- In: implement `packages/ui/src/transport/telemetryBinder.ts` using `socket.io-client`, handling connect/disconnect and exponential backoff.
+- In: register handlers for the four telemetry topics, dispatching to the store actions from Task 0031.
+- In: surface a minimal event emitter for components to listen for heartbeat/connection status.
+- Out: UI integration tests (handled next) or intent handling.
+
+## Deliverables
+- Telemetry binder module + index export.
+- `packages/ui/src/transport/__tests__/telemetryBinder.test.ts` using mocked Socket.IO client to assert subscriptions and reconnection behaviour.
+- Update `packages/ui/src/App.tsx` (or root provider) to initialise the binder at boot with configurable base URL.
+
+## Acceptance Criteria
+- Binder connects to `/telemetry`, listens for `telemetry:event`, and routes payloads based on `topic` string.
+- Reconnect policy implements exponential backoff with jitter capped per proposal risk mitigations.
+- Tests verify handler registration, dispatch invocation per topic, and that inbound telemetry with unknown topics is ignored with a logged warning.
+
+## References
+- [Proposal §3](../../proposals/20251009-mini_frontend.md#3-architectural-contracts)
+- [Proposal §4](../../proposals/20251009-mini_frontend.md#4-ui-surfaces-data-flows)
+- [Proposal §8](../../proposals/20251009-mini_frontend.md#8-risks-mitigations)

--- a/docs/tasks/frontend/0033-telemetry-store-integration.md
+++ b/docs/tasks/frontend/0033-telemetry-store-integration.md
@@ -1,0 +1,29 @@
+# Telemetry Store Integration Tests
+
+**ID:** 0033
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** frontend, telemetry, tests, track-3
+
+## Rationale
+After wiring the binder, we need integration tests ensuring telemetry events propagate into the UI store and update selectors consumed by pages. This guards regressions before UI wiring is completed.
+
+## Scope
+- In: create integration tests that mount the store + binder with mocked socket client and assert selectors update for each topic.
+- In: verify connection status events surface to UI consumers (e.g., connection banner hook).
+- Out: visual UI updates (covered elsewhere).
+
+## Deliverables
+- `packages/ui/src/state/__tests__/telemetryIntegration.test.tsx` using React Testing Library to mount provider + binder.
+- Mock helpers for socket client events under `packages/ui/src/test-utils/socketMock.ts`.
+
+## Acceptance Criteria
+- Tests emit each telemetry topic and assert selectors return updated values.
+- Connection loss triggers status flag within store and resets to defaults on reconnect.
+- Unknown topics do not mutate state; test asserts store remains unchanged.
+
+## References
+- [Proposal §3](../../proposals/20251009-mini_frontend.md#3-architectural-contracts)
+- [Proposal §4](../../proposals/20251009-mini_frontend.md#4-ui-surfaces-data-flows)
+- [TDD §9](../../TDD.md#9-integration-testing-guidelines)

--- a/docs/tasks/frontend/0034-intent-error-dictionary.md
+++ b/docs/tasks/frontend/0034-intent-error-dictionary.md
@@ -1,0 +1,30 @@
+# Intent Error Dictionary & Client
+
+**ID:** 0034
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** frontend, intents, transport, track-5
+
+## Rationale
+Intent flows rely on deterministic ack handling and human-readable error messaging. Establishing a shared client for intent submission and an error dictionary ensures consistent UX across exemplar forms.
+
+## Scope
+- In: create `packages/ui/src/transport/intentClient.ts` that emits `intent:submit`, handles acks using the contract from Task 0022, and exposes typed results.
+- In: define centralized error dictionary mapping transport codes to localized messages and recommended user actions.
+- Out: specific form components (handled by follow-up tasks).
+
+## Deliverables
+- Intent client module with unit tests under `packages/ui/src/transport/__tests__/intentClient.test.ts` covering success, handler error, invalid payload, and telemetry misuse scenarios.
+- `packages/ui/src/intl/intentErrors.ts` (or similar) exporting dictionary + helper for toast copy.
+- Documentation snippet in `docs/tools/intent-playground.md` describing how to use the client in dev (curl/socket script).
+
+## Acceptance Criteria
+- Client rejects attempts to submit without ack handler and maps error codes to dictionary entries.
+- Dictionary covers at least `WB_TEL_READONLY`, `WB_INTENT_INVALID`, `WB_INTENT_CHANNEL_INVALID`, `WB_INTENT_HANDLER_ERROR` with actionable text.
+- Tests verify ack parsing uses the validator from Task 0022 and surfaces dictionary messages.
+
+## References
+- [Proposal §3](../../proposals/20251009-mini_frontend.md#3-architectural-contracts)
+- [Proposal §4](../../proposals/20251009-mini_frontend.md#4-ui-surfaces-data-flows)
+- [Proposal §5](../../proposals/20251009-mini_frontend.md#5-thin-transport-slice-mvp-wiring)

--- a/docs/tasks/frontend/0035-intent-set-light-schedule.md
+++ b/docs/tasks/frontend/0035-intent-set-light-schedule.md
@@ -1,0 +1,31 @@
+# Intent: Set Light Schedule UX
+
+**ID:** 0035
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** frontend, intents, ui, track-5
+
+## Rationale
+One exemplar intent is adjusting a zone's light schedule. Building a dedicated form with optimistic UX gated on ack success demonstrates the end-to-end intent flow and validates the error dictionary.
+
+## Scope
+- In: implement form component under `packages/ui/src/components/intents/SetLightScheduleForm.tsx` with validation aligned to SEC light schedule rules.
+- In: integrate with intent client to submit payloads, show loading state, and surface toast/error copy from dictionary.
+- Out: backend logic (already handled) or other intents.
+
+## Deliverables
+- Form component + hook, unit tests at `packages/ui/src/components/intents/__tests__/SetLightScheduleForm.test.tsx` covering validation and ack handling.
+- Storybook (or local preview) entry documenting states (loading, success, error) under `packages/ui/src/stories/intents/SetLightScheduleForm.stories.tsx`.
+- Copy updates in `packages/ui/src/intl/en.json` (or similar) for button text and error strings.
+
+## Acceptance Criteria
+- Form validates photoperiod hours sum to 24 and disables submit until valid.
+- On submit, spinner shows until ack resolves; success triggers optimistic UI update via store action.
+- Errors map to dictionary entries and show toast plus inline message.
+- Tests cover happy path, validation error, and transport error mapping.
+
+## References
+- [Proposal §4](../../proposals/20251009-mini_frontend.md#4-ui-surfaces-data-flows)
+- [Proposal §6](../../proposals/20251009-mini_frontend.md#6-data-schemas-mvp-minimal-fields)
+- [AGENTS Appendix A](../../AGENTS.md#16-appendix-a-light-schedule-validation-pseudocode)

--- a/docs/tasks/frontend/0036-intent-select-irrigation.md
+++ b/docs/tasks/frontend/0036-intent-select-irrigation.md
@@ -1,0 +1,29 @@
+# Intent: Select Irrigation Method UX
+
+**ID:** 0036
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** frontend, intents, ui, track-5
+
+## Rationale
+The second exemplar intent lets growers change irrigation methods. Providing a UX consistent with the light schedule form verifies shared intent plumbing and error handling.
+
+## Scope
+- In: create `packages/ui/src/components/intents/SelectIrrigationMethodForm.tsx` listing available methods from read-model data.
+- In: reuse intent client to submit selection, show progress/error states, and reset on success.
+- Out: backend validations beyond ack handling (covered elsewhere).
+
+## Deliverables
+- Form component + tests under `packages/ui/src/components/intents/__tests__/SelectIrrigationMethodForm.test.tsx` covering validation and ack mapping.
+- Toast/notification wiring via existing UI infrastructure to surface success/error feedback.
+- Documentation update in `packages/ui/README.md` explaining how to test intents locally (link to intent playground doc).
+
+## Acceptance Criteria
+- Form disables submit until a method is selected and shows spinner during submission.
+- Successful ack triggers confirmation toast and resets selection; errors map to dictionary entries.
+- Tests cover success, handler error, and invalid ack scenarios.
+
+## References
+- [Proposal §4](../../proposals/20251009-mini_frontend.md#4-ui-surfaces-data-flows)
+- [Proposal §6](../../proposals/20251009-mini_frontend.md#6-data-schemas-mvp-minimal-fields)

--- a/docs/tasks/frontend/0037-contract-test-harness.md
+++ b/docs/tasks/frontend/0037-contract-test-harness.md
@@ -1,0 +1,29 @@
+# Contract Test Harness
+
+**ID:** 0037
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** frontend, tests, ci, track-6
+
+## Rationale
+Cross-package contract tests must validate transport semantics, read-model schemas, and telemetry topics end-to-end. Establishing a harness now provides confidence before UI integration and supports CI automation.
+
+## Scope
+- In: set up a Vitest (or Playwright) contract suite under `packages/facade/tests/contract` spinning up façade HTTP + transport server.
+- In: verify read-model endpoints return schema-valid payloads, telemetry namespace rejects writes, and intents produce expected acks.
+- Out: UI rendering checks (handled elsewhere).
+
+## Deliverables
+- Contract test files (e.g., `transport.contract.spec.ts`, `readModels.contract.spec.ts`) under `packages/facade/tests/contract/`.
+- Helper scripts in `packages/facade/tests/contract/utils/server.ts` to start/stop servers for tests.
+
+## Acceptance Criteria
+- Contract suite runs via `pnpm --filter @wb/facade test:contract` (new script) and passes locally.
+- Tests assert telemetry read-only rejection, ack structure, and read-model schema compliance using validators from Task 0023.
+- Test harness cleans up servers to avoid port leaks.
+
+## References
+- [Proposal §5](../../proposals/20251009-mini_frontend.md#5-thin-transport-slice-mvp-wiring)
+- [Proposal §7](../../proposals/20251009-mini_frontend.md#7-acceptance-criteria-mvp)
+- [TDD §11](../../TDD.md#11-telemetry-read-only-transport-separation-sec-11)

--- a/docs/tasks/frontend/0038-ci-pipeline-integration.md
+++ b/docs/tasks/frontend/0038-ci-pipeline-integration.md
@@ -1,0 +1,29 @@
+# CI Pipeline Integration
+
+**ID:** 0038
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** frontend, ci, automation, track-6
+
+## Rationale
+Contract tests and UI lint/test suites must run in CI to uphold SEC/TDD guarantees. This task wires the new packages and test commands into GitHub Actions (or existing CI) with caching aligned to Node 22 + pnpm.
+
+## Scope
+- In: update `.github/workflows/ci.yml` (or create new workflow) to install dependencies, build, lint, and run unit + contract tests across façade, transport, and UI packages.
+- In: add caching for pnpm store and Vite build artifacts if applicable.
+- Out: deployment scripts or release automation.
+
+## Deliverables
+- Workflow file updates ensuring UI lint/test, telemetry tests, and contract suite run on PRs.
+- Status badges or README note referencing the new CI coverage.
+
+## Acceptance Criteria
+- CI workflow executes commands: `pnpm install`, `pnpm lint`, `pnpm test`, plus contract suite; logs show Node 22 runtime.
+- Failures in any new package/test block merges (non-optional job).
+- Documentation (README or `docs/tools/dev-stack.md`) mentions CI expectations for frontend tasks.
+
+## References
+- [Proposal §7](../../proposals/20251009-mini_frontend.md#7-acceptance-criteria-mvp)
+- [TDD §2](../../TDD.md#2-tooling-and-workflow)
+- [AGENTS §1](../../AGENTS.md#1-platform-monorepo-must-haves)


### PR DESCRIPTION
## Summary
- add frontend task backlog directory derived from the mini frontend proposal
- define transport, read-model, telemetry, UI, intent, and CI tracks with 19 scoped tasks
- annotate each task with rationale, scope, deliverables, acceptance criteria, and references

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68e7db000e2483259bc461233ae75f3d