### PR TITLE
feat(task:0020): transport server bootstrap

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Unreleased — Blueprint Taxonomy v2
 
+- Bootstrapped the façade transport server factory exposing `/telemetry` and
+  `/intents` namespaces, shipped integration coverage for the namespace wiring
+  and health endpoint, added a dev script for local runs, and documented the
+  startup flow in `docs/tools/dev-stack.md`.
 - Added a CI LOC guard for `packages/**/src/**` that surfaces warnings at
   700 LOC and fails the build at 1,200 LOC so oversized modules are caught
   before review while allowing deliberate refactors to land incrementally.

--- a/docs/tools/dev-stack.md
+++ b/docs/tools/dev-stack.md
@@ -1,0 +1,23 @@
+# Dev Stack Notes
+
+## Façade Transport Server Bootstrap
+
+The façade exposes a Socket.IO transport server that brokers telemetry and intent
+traffic. For local development you can launch the server with:
+
+```bash
+pnpm --filter @wb/facade transport:dev
+```
+
+By default the script binds to `127.0.0.1:7101`, enables CORS for
+`http://localhost:5173`, and prints the `/healthz` endpoint URL to the console.
+Adjust behaviour via the following environment variables:
+
+- `FACADE_TRANSPORT_HOST` — optional host override (defaults to `127.0.0.1`).
+- `FACADE_TRANSPORT_PORT` — positive integer port override (defaults to `7101`).
+- `FACADE_TRANSPORT_CORS_ORIGIN` — CORS origin forwarded to Socket.IO and the
+  health endpoint (defaults to `http://localhost:5173`).
+
+The server currently exposes the `/telemetry` (read-only) and `/intents`
+namespaces. Intents are accepted but not processed until downstream tracks wire
+an intent handler. Shutdown is triggered via `SIGINT`/`SIGTERM`.

--- a/packages/facade/package.json
+++ b/packages/facade/package.json
@@ -18,7 +18,8 @@
     "test": "vitest run",
     "lint": "eslint --max-warnings=0 \"src/**/*.ts\" \"tests/**/*.ts\"",
     "format": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\"",
-    "dev": "tsx watch src/index.ts"
+    "dev": "tsx watch src/index.ts",
+    "transport:dev": "tsx src/transport/devServer.ts"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/packages/facade/src/index.ts
+++ b/packages/facade/src/index.ts
@@ -43,6 +43,12 @@ export {
   createHiringMarketHireIntent,
   createHiringMarketScanIntent,
 } from './intents/hiring.ts';
+export {
+  createTransportServer,
+  type TransportCorsOptions,
+  type TransportServer,
+  type TransportServerOptions,
+} from './transport/server.ts';
 
 /**
  * Parameters required to initialise the façade layer that brokers between the engine and clients.

--- a/packages/facade/src/transport/devServer.ts
+++ b/packages/facade/src/transport/devServer.ts
@@ -1,0 +1,38 @@
+import process from 'node:process';
+import { createTransportServer } from './server.ts';
+
+const host = process.env.FACADE_TRANSPORT_HOST ?? '127.0.0.1';
+const port = Number.parseInt(process.env.FACADE_TRANSPORT_PORT ?? '7101', 10);
+const corsOrigin = process.env.FACADE_TRANSPORT_CORS_ORIGIN ?? 'http://localhost:5173';
+
+async function main(): Promise<void> {
+  if (!Number.isInteger(port) || port <= 0) {
+    throw new Error('FACADE_TRANSPORT_PORT must be a positive integer.');
+  }
+
+  const server = await createTransportServer({
+    host,
+    port,
+    cors: { origin: corsOrigin },
+    async onIntent(intent) {
+      console.warn('Intent received without a registered handler:', intent);
+    },
+  });
+
+  console.info('Facade transport server listening on %s', server.url);
+  console.info('Health endpoint available at %s/healthz', server.url);
+
+  const handleShutdown = async () => {
+    console.info('\nShutting down transport server...');
+    await server.close();
+    process.exit(0);
+  };
+
+  process.once('SIGINT', handleShutdown);
+  process.once('SIGTERM', handleShutdown);
+}
+
+main().catch((error) => {
+  console.error('Failed to start transport server:', error);
+  process.exit(1);
+});

--- a/packages/facade/src/transport/server.ts
+++ b/packages/facade/src/transport/server.ts
@@ -1,0 +1,240 @@
+import {
+  createServer as createHttpServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from 'node:http';
+import type { AddressInfo } from 'node:net';
+import {
+  createSocketTransportAdapter,
+  type SocketTransportAdapter,
+  type SocketTransportAdapterOptions,
+  type TransportIntentEnvelope,
+} from './adapter.ts';
+
+const DEFAULT_HOST = '127.0.0.1';
+const DEFAULT_PORT = 7101;
+
+/**
+ * CORS configuration compatible with the underlying Socket.IO transport adapter.
+ */
+export type TransportCorsOptions = NonNullable<
+  NonNullable<SocketTransportAdapterOptions['serverOptions']>['cors']
+>;
+
+/**
+ * Options accepted by {@link createTransportServer}.
+ */
+export interface TransportServerOptions {
+  /** Hostname where the transport server should bind. Defaults to {@link DEFAULT_HOST}. */
+  readonly host?: string;
+  /** TCP port where the transport server listens. Defaults to {@link DEFAULT_PORT}. */
+  readonly port?: number;
+  /** Optional CORS configuration forwarded to the Socket.IO adapter. */
+  readonly cors?: TransportCorsOptions;
+  /** Intent handler invoked whenever the intents namespace receives a submission. */
+  readonly onIntent: (intent: TransportIntentEnvelope) => void | Promise<void>;
+}
+
+/**
+ * Runtime transport server exposing Socket.IO namespaces and lifecycle helpers.
+ */
+export interface TransportServer {
+  /** Resolved hostname after the server binds. */
+  readonly host: string;
+  /** Resolved TCP port. */
+  readonly port: number;
+  /** HTTP origin clients should target. */
+  readonly url: string;
+  /** Bound Socket.IO namespaces. */
+  readonly namespaces: SocketTransportAdapter['namespaces'];
+  /** Closes the Socket.IO adapter and HTTP listener. */
+  close(): Promise<void>;
+}
+
+function normaliseHeaderValue(value: string | string[]): string {
+  return Array.isArray(value) ? value.join(', ') : value;
+}
+
+function resolveAllowedOrigin(
+  request: IncomingMessage,
+  cors?: TransportCorsOptions
+): string | undefined {
+  if (!cors?.origin) {
+    return undefined;
+  }
+
+  const requestOriginHeader = request.headers.origin;
+  const requestOrigin = Array.isArray(requestOriginHeader)
+    ? requestOriginHeader[0]
+    : requestOriginHeader;
+  const { origin } = cors;
+
+  if (origin === '*') {
+    return '*';
+  }
+
+  if (origin === true) {
+    return requestOrigin ?? '*';
+  }
+
+  if (typeof origin === 'string') {
+    return origin;
+  }
+
+  if (Array.isArray(origin)) {
+    if (origin.length === 0) {
+      return undefined;
+    }
+
+    if (requestOrigin && origin.includes(requestOrigin)) {
+      return requestOrigin;
+    }
+
+    return origin[0];
+  }
+
+  if (origin instanceof RegExp) {
+    if (requestOrigin && origin.test(requestOrigin)) {
+      return requestOrigin;
+    }
+
+    return undefined;
+  }
+
+  return undefined;
+}
+
+function applyCorsHeaders(
+  request: IncomingMessage,
+  response: ServerResponse,
+  cors?: TransportCorsOptions
+): void {
+  if (!cors) {
+    return;
+  }
+
+  const allowedOrigin = resolveAllowedOrigin(request, cors);
+
+  if (allowedOrigin) {
+    response.setHeader('access-control-allow-origin', allowedOrigin);
+
+    if (allowedOrigin !== '*') {
+      response.setHeader('vary', 'Origin');
+    }
+  }
+
+  if (cors.credentials) {
+    response.setHeader('access-control-allow-credentials', 'true');
+  }
+
+  if (cors.allowedHeaders) {
+    response.setHeader(
+      'access-control-allow-headers',
+      normaliseHeaderValue(cors.allowedHeaders)
+    );
+  }
+
+  if (cors.exposedHeaders) {
+    response.setHeader(
+      'access-control-expose-headers',
+      normaliseHeaderValue(cors.exposedHeaders)
+    );
+  }
+
+  if (typeof cors.maxAge === 'number') {
+    response.setHeader('access-control-max-age', String(cors.maxAge));
+  }
+}
+
+function createHealthHandler(statusBody: string, cors?: TransportCorsOptions) {
+  return (request: IncomingMessage, response: ServerResponse): void => {
+    if (!request.url) {
+      response.writeHead(404);
+      response.end();
+      return;
+    }
+
+    const { method, url } = request;
+
+    if (method === 'GET' && new URL(url, 'http://localhost').pathname === '/healthz') {
+      applyCorsHeaders(request, response, cors);
+      response.statusCode = 200;
+      response.setHeader('content-type', 'application/json; charset=utf-8');
+      response.end(statusBody);
+      return;
+    }
+
+    if (method === 'OPTIONS') {
+      applyCorsHeaders(request, response, cors);
+      response.setHeader('access-control-allow-methods', 'GET, OPTIONS');
+      response.end();
+      return;
+    }
+
+    response.writeHead(404);
+    response.end();
+  };
+}
+
+async function closeHttpServer(server: ReturnType<typeof createHttpServer>): Promise<void> {
+  if (!server.listening) {
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error && (error as NodeJS.ErrnoException).code !== 'ERR_SERVER_NOT_RUNNING') {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+/**
+ * Creates an HTTP server bound to Socket.IO namespaces (`/telemetry`, `/intents`) while
+ * exposing a deterministic `/healthz` endpoint.
+ *
+ * @param options - Transport configuration.
+ * @returns A running transport server reference.
+ */
+export async function createTransportServer(options: TransportServerOptions): Promise<TransportServer> {
+  const host = options.host ?? DEFAULT_HOST;
+  const port = options.port ?? DEFAULT_PORT;
+  const httpServer = createHttpServer(
+    createHealthHandler('{"status":"ok"}', options.cors)
+  );
+  const adapter = createSocketTransportAdapter({
+    httpServer,
+    onIntent: options.onIntent,
+    serverOptions: options.cors ? { cors: options.cors } : undefined,
+  });
+
+  await new Promise<void>((resolve) => {
+    httpServer.listen(port, host, () => resolve());
+  });
+
+  const address = httpServer.address();
+
+  if (!address || typeof address === 'string') {
+    await adapter.close();
+    await closeHttpServer(httpServer);
+    throw new Error('Transport server failed to resolve a TCP address.');
+  }
+
+  const { port: resolvedPort } = address as AddressInfo;
+  const url = `http://${host}:${resolvedPort}`;
+
+  return {
+    host,
+    port: resolvedPort,
+    url,
+    namespaces: adapter.namespaces,
+    async close() {
+      await adapter.close();
+      await closeHttpServer(httpServer);
+    },
+  } satisfies TransportServer;
+}

--- a/packages/facade/tests/integration/transport/serverNamespaces.spec.ts
+++ b/packages/facade/tests/integration/transport/serverNamespaces.spec.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { io as createClient, type Socket } from 'socket.io-client';
+import {
+  SOCKET_ERROR_CODES,
+  TELEMETRY_ERROR_EVENT,
+  type TransportAck,
+} from '../../../src/transport/adapter.ts';
+import {
+  createTransportServer,
+  type TransportServer,
+} from '../../../src/transport/server.ts';
+import { disconnectClient, onceConnected } from './helpers.ts';
+
+const TEST_HOST = '127.0.0.1';
+
+describe('transport server bootstrap', () => {
+  let server: TransportServer | null = null;
+  const activeSockets = new Set<Socket>();
+
+  afterEach(async () => {
+    for (const socket of activeSockets) {
+      await disconnectClient(socket);
+    }
+
+    activeSockets.clear();
+
+    if (server) {
+      await server.close();
+      server = null;
+    }
+  });
+
+  it('exposes telemetry and intent namespaces and responds to health checks', async () => {
+    server = await createTransportServer({
+      host: TEST_HOST,
+      port: 0,
+      cors: { origin: 'http://localhost:5173' },
+      async onIntent() {
+        // Intents are not handled during bootstrap; this will be wired by later tracks.
+      },
+    });
+
+    expect(server.namespaces.telemetry.name).toBe('/telemetry');
+    expect(server.namespaces.intents.name).toBe('/intents');
+    expect(server.namespaces.telemetry.server.opts.cors?.origin).toBe(
+      'http://localhost:5173'
+    );
+
+    const healthResponse = await fetch(`${server.url}/healthz`, {
+      headers: { Origin: 'http://localhost:5173' },
+    });
+
+    expect(healthResponse.status).toBe(200);
+    await expect(healthResponse.json()).resolves.toEqual({ status: 'ok' });
+    expect(healthResponse.headers.get('access-control-allow-origin')).toBe(
+      'http://localhost:5173'
+    );
+  });
+
+  it('rejects telemetry writes when no handler is registered', async () => {
+    server = await createTransportServer({
+      host: TEST_HOST,
+      port: 0,
+      async onIntent() {},
+    });
+
+    const client = createClient(`${server.url}/telemetry`, {
+      transports: ['websocket'],
+      forceNew: true,
+    });
+
+    activeSockets.add(client);
+
+    await onceConnected(client);
+
+    const errorEvent = new Promise<TransportAck>((resolve) => {
+      client.once(TELEMETRY_ERROR_EVENT, (ack: TransportAck) => resolve(ack));
+    });
+
+    const ack = await new Promise<TransportAck>((resolve) => {
+      client.emit('telemetry:rogue', { attempt: true }, (response: TransportAck) => {
+        resolve(response);
+      });
+    });
+
+    const emittedAck = await errorEvent;
+
+    expect(ack.ok).toBe(false);
+    expect(ack.error?.code).toBe(SOCKET_ERROR_CODES.TELEMETRY_WRITE_REJECTED);
+    expect(emittedAck.ok).toBe(false);
+    expect(emittedAck.error?.code).toBe(SOCKET_ERROR_CODES.TELEMETRY_WRITE_REJECTED);
+  });
+});


### PR DESCRIPTION
## Summary
- add a facade transport server factory that wires the telemetry and intent namespaces, exposes a `/healthz` probe, and forwards CORS metadata to the Socket.IO adapter
- ship a dev runner and documentation so the transport server can be started locally with configurable host, port, and allowed origin
- extend the transport integration suite to cover namespace registration, health probing, and read-only telemetry enforcement

## Testing
- `pnpm i`
- `pnpm -r test`
- `CI=1 pnpm -r lint` *(fails: existing `@wb/engine` lint violations)*
- `pnpm -r build` *(fails: existing `@wb/tools` TypeScript errors)*

## References
- SEC §1, §11 (telemetry read-only invariants)
- TDD §11 (transport namespace expectations)

## Deviations
- Workspace lint fails on pre-existing `@wb/engine` issues.
- Workspace build fails on pre-existing `@wb/tools` TypeScript errors.

------
https://chatgpt.com/codex/tasks/task_e_68e7de8ccf2483259e972bbeb560beb7