### PR TITLE
feat(task:0021): telemetry read-only contract tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,8 @@
   `/intents` namespaces, shipped integration coverage for the namespace wiring
   and health endpoint, added a dev script for local runs, and documented the
   startup flow in `docs/tools/dev-stack.md`.
+- Added `@wb/transport-sio` integration specs guarding telemetry read-only
+  rejections and intent acknowledgement paths in line with SEC §11/TDD §11.
 - Added a CI LOC guard for `packages/**/src/**` that surfaces warnings at
   700 LOC and fails the build at 1,200 LOC so oversized modules are caught
   before review while allowing deliberate refactors to land incrementally.

--- a/packages/transport-sio/package.json
+++ b/packages/transport-sio/package.json
@@ -8,6 +8,9 @@
   "dependencies": {
     "socket.io": "^4.7.5"
   },
+  "devDependencies": {
+    "socket.io-client": "^4.8.1"
+  },
   "scripts": {
     "build": "tsc --project tsconfig.json",
     "test": "vitest run",

--- a/packages/transport-sio/tests/integration/telemetryReadonly.spec.ts
+++ b/packages/transport-sio/tests/integration/telemetryReadonly.spec.ts
@@ -1,0 +1,207 @@
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { io as createClient, type Socket } from 'socket.io-client';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  INTENT_EVENT,
+  SOCKET_ERROR_CODES,
+  TELEMETRY_ERROR_EVENT,
+  createSocketTransportAdapter,
+  type SocketTransportAdapter,
+  type TransportAck,
+  type TransportIntentEnvelope,
+} from '../../src/index.ts';
+
+interface TransportHarness {
+  readonly port: number;
+  readonly adapter: SocketTransportAdapter;
+  close(): Promise<void>;
+}
+
+async function createTransportHarness(
+  onIntent: (intent: TransportIntentEnvelope) => void | Promise<void> = () => {
+    /* noop */
+  }
+): Promise<TransportHarness> {
+  const httpServer = createServer();
+
+  await new Promise<void>((resolve) => {
+    httpServer.listen(0, '127.0.0.1', () => {
+      resolve();
+    });
+  });
+
+  const address = httpServer.address() as AddressInfo | null;
+
+  if (!address || typeof address === 'string') {
+    throw new Error('Socket server failed to bind to a port.');
+  }
+
+  const adapter = createSocketTransportAdapter({
+    httpServer,
+    onIntent,
+  });
+
+  return {
+    port: address.port,
+    adapter,
+    async close() {
+      await adapter.close();
+      await new Promise<void>((resolve) => {
+        httpServer.close(() => {
+          resolve();
+        });
+      });
+    },
+  } satisfies TransportHarness;
+}
+
+async function connectNamespace(harness: TransportHarness, namespace: '/telemetry' | '/intents') {
+  const socket = createClient(`http://127.0.0.1:${String(harness.port)}${namespace}`, {
+    transports: ['websocket'],
+    forceNew: true,
+  });
+
+  await onceConnected(socket);
+
+  return socket;
+}
+
+function onceConnected(socket: Socket): Promise<void> {
+  if (socket.connected) {
+    return Promise.resolve();
+  }
+
+  return new Promise<void>((resolve, reject) => {
+    const handleError = (error: Error) => {
+      socket.off('connect', handleConnect);
+      reject(error);
+    };
+
+    const handleConnect = () => {
+      socket.off('connect_error', handleError);
+      resolve();
+    };
+
+    socket.once('connect_error', handleError);
+    socket.once('connect', handleConnect);
+  });
+}
+
+function disconnectClient(socket: Socket): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (!socket.connected) {
+      socket.disconnect();
+      resolve();
+      return;
+    }
+
+    socket.once('disconnect', () => {
+      resolve();
+    });
+    socket.disconnect();
+  });
+}
+
+describe('createSocketTransportAdapter — telemetry read-only contract', () => {
+  it('rejects telemetry emits with acknowledgements and mirrors the error event', async () => {
+    const onIntent = vi.fn();
+    const harness = await createTransportHarness(onIntent);
+
+    const telemetrySocket = await connectNamespace(harness, '/telemetry');
+
+    try {
+      const errorEventPromise = new Promise<TransportAck>((resolve) => {
+        telemetrySocket.once(TELEMETRY_ERROR_EVENT, (payload: TransportAck) => {
+          resolve(payload);
+        });
+      });
+
+      const ackPromise = new Promise<TransportAck>((resolve) => {
+        telemetrySocket.emit('telemetry:write', { topic: 'test' }, (ack: TransportAck) => {
+          resolve(ack);
+        });
+      });
+
+      const [ack, errorPayload] = await Promise.all([ackPromise, errorEventPromise]);
+
+      expect(ack.ok).toBe(false);
+      expect(ack.error?.code).toBe(SOCKET_ERROR_CODES.TELEMETRY_WRITE_REJECTED);
+      expect(errorPayload).toEqual(ack);
+      expect(onIntent).not.toHaveBeenCalled();
+    } finally {
+      await disconnectClient(telemetrySocket);
+      await harness.close();
+    }
+  });
+
+  it('rejects telemetry emits without acknowledgements', async () => {
+    const onIntent = vi.fn();
+    const harness = await createTransportHarness(onIntent);
+
+    const telemetrySocket = await connectNamespace(harness, '/telemetry');
+
+    try {
+      const errorEventPromise = new Promise<TransportAck>((resolve) => {
+        telemetrySocket.once(TELEMETRY_ERROR_EVENT, (payload: TransportAck) => {
+          resolve(payload);
+        });
+      });
+
+      telemetrySocket.emit('telemetry:write', { topic: 'test' });
+
+      const errorPayload = await errorEventPromise;
+
+      expect(errorPayload.ok).toBe(false);
+      expect(errorPayload.error?.code).toBe(SOCKET_ERROR_CODES.TELEMETRY_WRITE_REJECTED);
+      expect(onIntent).not.toHaveBeenCalled();
+    } finally {
+      await disconnectClient(telemetrySocket);
+      await harness.close();
+    }
+  });
+});
+
+describe('createSocketTransportAdapter — intent submissions', () => {
+  it('accepts valid intent submissions with ok acknowledgements', async () => {
+    const onIntent = vi.fn();
+    const harness = await createTransportHarness(onIntent);
+    const intentSocket = await connectNamespace(harness, '/intents');
+
+    try {
+      const ack = await new Promise<TransportAck>((resolve) => {
+        intentSocket.emit(INTENT_EVENT, { type: 'facility.startup' }, (payload: TransportAck) => {
+          resolve(payload);
+        });
+      });
+
+      expect(ack).toEqual({ ok: true });
+      expect(onIntent).toHaveBeenCalledTimes(1);
+      expect(onIntent).toHaveBeenCalledWith({ type: 'facility.startup' });
+    } finally {
+      await disconnectClient(intentSocket);
+      await harness.close();
+    }
+  });
+
+  it('rejects malformed intent submissions with WB_INTENT_INVALID', async () => {
+    const onIntent = vi.fn();
+    const harness = await createTransportHarness(onIntent);
+    const intentSocket = await connectNamespace(harness, '/intents');
+
+    try {
+      const ack = await new Promise<TransportAck>((resolve) => {
+        intentSocket.emit(INTENT_EVENT, { payload: 'invalid' }, (payload: TransportAck) => {
+          resolve(payload);
+        });
+      });
+
+      expect(ack.ok).toBe(false);
+      expect(ack.error?.code).toBe(SOCKET_ERROR_CODES.INTENT_INVALID);
+      expect(onIntent).not.toHaveBeenCalled();
+    } finally {
+      await disconnectClient(intentSocket);
+      await harness.close();
+    }
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,10 @@ importers:
       socket.io:
         specifier: ^4.7.5
         version: 4.8.1
+    devDependencies:
+      socket.io-client:
+        specifier: ^4.8.1
+        version: 4.8.1
 
 packages:
 


### PR DESCRIPTION
## Summary
- add a Socket.IO client-backed integration harness in `@wb/transport-sio` to assert telemetry emits reject with `WB_TEL_READONLY` and intents resolve/validate per SEC §11 / TDD §11
- pull in `socket.io-client` as a dev dependency so the transport tests can exercise namespace handshakes end-to-end
- document the new coverage in the changelog

## Testing
- `pnpm i`
- `pnpm -r test`
- `pnpm --filter @wb/transport-sio lint`
- `pnpm -r lint` *(fails: workspace currently reports thousands of pre-existing `@typescript-eslint/no-unsafe-*` violations in @wb/engine)*
- `pnpm --filter @wb/transport-sio build` *(fails: TypeScript 5.9 enforces `allowImportingTsExtensions` to be paired with `noEmit` or `emitDeclarationOnly` in package tsconfig)*
- `pnpm -r build` *(fails for the same TypeScript 5.9 `allowImportingTsExtensions` restriction across multiple packages)*

------
https://chatgpt.com/codex/tasks/task_e_68e7e2b0c8b08325b6fec12de867e807