### PR TITLE
chore: align vitest aliases with engine source

### DIFF
--- a/packages/engine/tsconfig.spec.json
+++ b/packages/engine/tsconfig.spec.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "target": "ES2022",
+    "verbatimModuleSyntax": true,
+    "resolveJsonModule": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}

--- a/packages/engine/vitest.config.ts
+++ b/packages/engine/vitest.config.ts
@@ -3,14 +3,14 @@ import { fileURLToPath } from 'node:url';
 
 import { defineConfig } from 'vitest/config';
 
-const packageDir = fileURLToPath(new URL('.', import.meta.url));
+const packageDir = path.dirname(fileURLToPath(new URL('.', import.meta.url)));
 
 export default defineConfig({
   resolve: {
     alias: {
+      '@': path.resolve(packageDir, 'src'),
+      '@/backend': path.resolve(packageDir, 'src/backend/src'),
       '@wb/engine': path.resolve(packageDir, 'src/index.ts'),
-      '@/backend': path.resolve(packageDir, 'src/backend'),
-      '@/shared': path.resolve(packageDir, 'src/shared'),
       '@/tests': path.resolve(packageDir, 'tests')
     }
   },

--- a/packages/facade/vitest.config.ts
+++ b/packages/facade/vitest.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
       '@wb/engine': resolve(currentDir, '../engine/src/index.ts'),
       '@wb/transport-sio': resolve(currentDir, '../transport-sio/src/index.ts'),
       '@wb/transport-sio/': resolve(currentDir, '../transport-sio/src/'),
-      '@/backend': resolve(currentDir, '../engine/src/backend'),
+      '@/backend': resolve(currentDir, '../engine/src/backend/src'),
       '@': resolve(currentDir, 'src')
     }
   }


### PR DESCRIPTION
## Summary
- add a Vitest-focused tsconfig in the engine package with bundler-style module resolution
- point the engine Vitest aliases at the source tree and expose the root `@` alias
- update the facade Vitest backend alias to resolve into the backend source directory

## Testing
- pnpm -w tsc -p packages/engine/tsconfig.spec.json --noEmit *(fails: existing type errors surfaced under the stricter spec config)*

------
https://chatgpt.com/codex/tasks/task_e_68e7eb8ac300832598140a7efb9345c9