### PR TITLE
HOTFIX-02: Wire ESLint to package tsconfigs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### Unreleased — Blueprint Taxonomy v2
 
+- HOTFIX-02: Restored ESLint's type-aware parser wiring by pointing the
+  workspace config at package build + spec tsconfigs and adding the
+  missing `tsconfig.spec.json` manifests so unsafe-any rules only flag
+  real issues.
+
 - Published the transport acknowledgement contract: extracted the shared error
   code registry/TypeScript types into `@wb/transport-sio`, added the
   `assertTransportAck` runtime guard with unit coverage, re-exported the

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,8 +27,12 @@ export default tseslint.config(
     files: ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"],
     languageOptions: {
       parserOptions: {
-        projectService: true,
-        tsconfigRootDir: import.meta.dirname
+        project: [
+          "./packages/*/tsconfig.json",
+          "./packages/*/tsconfig.spec.json"
+        ],
+        tsconfigRootDir: import.meta.dirname,
+        sourceType: "module"
       }
     },
     plugins: {

--- a/packages/facade/tsconfig.spec.json
+++ b/packages/facade/tsconfig.spec.json
@@ -1,0 +1,21 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "target": "ES2022",
+    "verbatimModuleSyntax": true,
+    "resolveJsonModule": true,
+    "types": ["vitest/globals"]
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.mts",
+    "tests/**/*.ts",
+    "tests/**/*.mts",
+    "scripts/**/*.ts",
+    "scripts/**/*.mts",
+    "vitest.config.ts"
+  ],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/tools-monitor/tsconfig.spec.json
+++ b/packages/tools-monitor/tsconfig.spec.json
@@ -1,0 +1,21 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "target": "ES2022",
+    "verbatimModuleSyntax": true,
+    "resolveJsonModule": true,
+    "types": ["vitest/globals"]
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.mts",
+    "tests/**/*.ts",
+    "tests/**/*.mts",
+    "scripts/**/*.ts",
+    "scripts/**/*.mts",
+    "vitest.config.ts"
+  ],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/tools/tsconfig.spec.json
+++ b/packages/tools/tsconfig.spec.json
@@ -1,0 +1,21 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "target": "ES2022",
+    "verbatimModuleSyntax": true,
+    "resolveJsonModule": true,
+    "types": ["vitest/globals"]
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.mts",
+    "tests/**/*.ts",
+    "tests/**/*.mts",
+    "scripts/**/*.ts",
+    "scripts/**/*.mts",
+    "vitest.config.ts"
+  ],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/transport-sio/tsconfig.spec.json
+++ b/packages/transport-sio/tsconfig.spec.json
@@ -1,0 +1,21 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "target": "ES2022",
+    "verbatimModuleSyntax": true,
+    "resolveJsonModule": true,
+    "types": ["vitest/globals", "node"]
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.mts",
+    "tests/**/*.ts",
+    "tests/**/*.mts",
+    "scripts/**/*.ts",
+    "scripts/**/*.mts",
+    "vitest.config.ts"
+  ],
+  "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
## Summary
- configure the flat eslint setup to resolve workspace tsconfigs for full type-aware analysis
- add tsconfig.spec.json files to every package with tests so eslint can load project contexts
- document the hotfix in the changelog

## Testing
- `pnpm -w eslint "packages/**/*.{ts,tsx}"` *(fails: existing lint violations surfaced once type-checking is enabled)*

------
https://chatgpt.com/codex/tasks/task_e_68e7ecdad348832591621c06ff587fdc