### PR TITLE
refactor: add expectors helpers for engine tests

### DIFF
--- a/packages/engine/tests/integration/pipeline/economyAccrual.integration.test.ts
+++ b/packages/engine/tests/integration/pipeline/economyAccrual.integration.test.ts
@@ -13,6 +13,7 @@ import type {
 import { bankersRound } from '@/backend/src/util/math';
 import devicePrices from '../../../../../data/prices/devicePrices.json' with { type: 'json' };
 import dryboxBlueprint from '../../../../../data/blueprints/device/climate/drybox-200.json' with { type: 'json' };
+import { expectDefined } from '../../util/expectors';
 
 const EPS = FLOAT_TOLERANCE;
 
@@ -278,14 +279,17 @@ describe('economy accrual integration', () => {
     (world).simTimeHours = hourlySlices.length;
     world = applyEconomyAccrual(world, ctx) as Mutable<SimulationWorld>;
 
-    const workforceAccrual = (ctx as {
-      economyAccruals?: { workforce?: { current?: WorkforcePayrollState; finalizedDays: WorkforcePayrollState[] } };
-    }).economyAccruals?.workforce;
+    const workforceAccrual = expectDefined(
+      (ctx as {
+        economyAccruals?: {
+          workforce?: { current?: WorkforcePayrollState; finalizedDays: WorkforcePayrollState[] };
+        };
+      }).economyAccruals?.workforce
+    );
 
-    expect(workforceAccrual).toBeDefined();
-    expect(workforceAccrual?.finalizedDays).toHaveLength(1);
+    expect(workforceAccrual.finalizedDays).toHaveLength(1);
 
-    const [day0] = workforceAccrual!.finalizedDays;
+    const [day0] = workforceAccrual.finalizedDays;
     expect(day0.dayIndex).toBe(0);
 
     const sumBaseMinutes = hourlySlices.reduce((total, slice) => total + slice.baseMinutes, 0);
@@ -303,10 +307,10 @@ describe('economy accrual integration', () => {
     expect(day0.totals.otCost).toBeCloseTo(expectedOtCost, EPS);
     expect(day0.totals.totalLaborCost).toBeCloseTo(expectedTotalCost, EPS);
 
-    const current = workforceAccrual?.current;
-    expect(current?.dayIndex).toBe(1);
-    expect(current?.totals.baseMinutes).toBe(0);
-    expect(current?.totals.baseCost).toBe(0);
-    expect(current?.totals.totalLaborCost).toBe(0);
+    const current = expectDefined(workforceAccrual.current);
+    expect(current.dayIndex).toBe(1);
+    expect(current.totals.baseMinutes).toBe(0);
+    expect(current.totals.baseCost).toBe(0);
+    expect(current.totals.totalLaborCost).toBe(0);
   });
 });

--- a/packages/engine/tests/integration/pipeline/fanFilterChain.integration.test.ts
+++ b/packages/engine/tests/integration/pipeline/fanFilterChain.integration.test.ts
@@ -11,6 +11,8 @@ import { getDeviceEffectsRuntime } from '@/backend/src/engine/pipeline/applyDevi
 import { createDemoWorld } from '@/backend/src/engine/testHarness';
 import type { ZoneDeviceInstance, Uuid } from '@/backend/src/domain/world';
 
+import { expectDefined } from '../../util/expectors';
+
 function uuid(value: string): Uuid {
   return value as Uuid;
 }
@@ -105,11 +107,11 @@ describe('Tick pipeline — fan and filter chains', () => {
 
     runTick(world, ctx);
 
-    expect(runtime).toBeDefined();
+    const runtimeSnapshot = expectDefined(runtime);
 
-    const netAirflow = runtime!.zoneAirflowTotals_m3_per_h.get(zone.id) ?? 0;
-    const netAch = runtime!.zoneAirChangesPerHour.get(zone.id) ?? 0;
-    const reduction = runtime!.zoneAirflowReductions_m3_per_h.get(zone.id) ?? 0;
+    const netAirflow = runtimeSnapshot.zoneAirflowTotals_m3_per_h.get(zone.id) ?? 0;
+    const netAch = runtimeSnapshot.zoneAirChangesPerHour.get(zone.id) ?? 0;
+    const reduction = runtimeSnapshot.zoneAirflowReductions_m3_per_h.get(zone.id) ?? 0;
 
     expect(netAirflow).toBeGreaterThan(0);
     expect(netAirflow).toBeLessThan(200);
@@ -154,9 +156,9 @@ describe('Tick pipeline — fan and filter chains', () => {
 
     runTick(world, ctx);
 
-    expect(runtime).toBeDefined();
+    const runtimeSnapshot = expectDefined(runtime);
 
-    const netAch = runtime!.zoneAirChangesPerHour.get(zone.id) ?? 0;
+    const netAch = runtimeSnapshot.zoneAirChangesPerHour.get(zone.id) ?? 0;
     expect(netAch).toBeLessThan(1);
     expect(diagnostics).toEqual(
       expect.arrayContaining([
@@ -205,10 +207,10 @@ describe('Tick pipeline — fan and filter chains', () => {
 
     runTick(world, ctx);
 
-    expect(runtime).toBeDefined();
+    const runtimeSnapshot = expectDefined(runtime);
 
-    const netAirflow = runtime!.zoneAirflowTotals_m3_per_h.get(zone.id) ?? 0;
-    const reduction = runtime!.zoneAirflowReductions_m3_per_h.get(zone.id) ?? 0;
+    const netAirflow = runtimeSnapshot.zoneAirflowTotals_m3_per_h.get(zone.id) ?? 0;
+    const reduction = runtimeSnapshot.zoneAirflowReductions_m3_per_h.get(zone.id) ?? 0;
     const grossAirflow = 300;
 
     expect(netAirflow).toBeGreaterThan(0);
@@ -249,10 +251,10 @@ describe('Tick pipeline — fan and filter chains', () => {
 
     runTick(world, ctx);
 
-    expect(runtime).toBeDefined();
+    const runtimeSnapshot = expectDefined(runtime);
 
-    const odorDelta = runtime!.zoneOdorDelta.get(zone.id) ?? 0;
-    const particulate = runtime!.zoneParticulateRemoval_pct.get(zone.id) ?? 0;
+    const odorDelta = runtimeSnapshot.zoneOdorDelta.get(zone.id) ?? 0;
+    const particulate = runtimeSnapshot.zoneParticulateRemoval_pct.get(zone.id) ?? 0;
 
     expect(odorDelta).toBeLessThan(0);
     expect(particulate).toBeGreaterThan(0);
@@ -297,9 +299,9 @@ describe('Tick pipeline — fan and filter chains', () => {
 
     runTick(world, ctx);
 
-    expect(runtime).toBeDefined();
+    const runtimeSnapshot = expectDefined(runtime);
 
-    const netAirflow = runtime!.zoneAirflowTotals_m3_per_h.get(zone.id) ?? 0;
+    const netAirflow = runtimeSnapshot.zoneAirflowTotals_m3_per_h.get(zone.id) ?? 0;
     expect(netAirflow).toBeCloseTo(legacyFan.airflow_m3_per_h, 5);
   });
 });

--- a/packages/engine/tests/integration/pipeline/zoneCapacity.integration.test.ts
+++ b/packages/engine/tests/integration/pipeline/zoneCapacity.integration.test.ts
@@ -20,6 +20,7 @@ import {
 } from '@/backend/src/domain/world';
 import type { DeviceBlueprint } from '@/backend/src/domain/blueprints/deviceBlueprint';
 import { deviceQuality } from '../../testUtils/deviceHelpers.ts';
+import { expectDefined } from '../../util/expectors';
 
 function uuid(value: string): Uuid {
   return value as Uuid;
@@ -99,15 +100,14 @@ describe('Phase 1 zone capacity diagnostics', () => {
 
     applyDeviceEffects(world, ctx);
 
-    const runtime = getDeviceEffectsRuntime(ctx);
-    expect(runtime).toBeDefined();
+    const runtime = expectDefined(getDeviceEffectsRuntime(ctx));
 
     const rawDeltaC = applyDeviceHeat(zone, heater, HOURS_PER_TICK);
-    const recordedDeltaC = runtime!.zoneTemperatureDeltaC.get(zone.id) ?? 0;
+    const recordedDeltaC = runtime.zoneTemperatureDeltaC.get(zone.id) ?? 0;
 
     expect(recordedDeltaC).toBeCloseTo(rawDeltaC * 0.5, 6);
-    expect(runtime!.zoneCoverageTotals_m2.get(zone.id)).toBeCloseTo(10);
-    expect(runtime!.zoneCoverageEffectiveness01.get(zone.id)).toBeCloseTo(0.5);
+    expect(runtime.zoneCoverageTotals_m2.get(zone.id)).toBeCloseTo(10);
+    expect(runtime.zoneCoverageEffectiveness01.get(zone.id)).toBeCloseTo(0.5);
 
     expect(diagnostics).toEqual(
       expect.arrayContaining([
@@ -161,13 +161,12 @@ describe('Phase 1 zone capacity diagnostics', () => {
 
     applyDeviceEffects(world, ctx);
 
-    const runtime = getDeviceEffectsRuntime(ctx);
-    expect(runtime).toBeDefined();
+    const runtime = expectDefined(getDeviceEffectsRuntime(ctx));
 
     const expectedAch = 15 / (zone.floorArea_m2 * zone.height_m);
 
-    expect(runtime!.zoneAirflowTotals_m3_per_h.get(zone.id)).toBeCloseTo(15);
-    expect(runtime!.zoneAirChangesPerHour.get(zone.id)).toBeCloseTo(expectedAch, 6);
+    expect(runtime.zoneAirflowTotals_m3_per_h.get(zone.id)).toBeCloseTo(15);
+    expect(runtime.zoneAirChangesPerHour.get(zone.id)).toBeCloseTo(expectedAch, 6);
 
     expect(diagnostics).toEqual(
       expect.arrayContaining([

--- a/packages/engine/tests/unit/device/createDeviceInstance.test.ts
+++ b/packages/engine/tests/unit/device/createDeviceInstance.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { expectDefined } from '../../util/expectors';
+
 import {
   createDeviceInstance,
   type DeviceQualityPolicy,
@@ -153,8 +155,11 @@ describe('createDeviceInstance', () => {
     expect(Object.isFrozen(device.effectConfigs)).toBe(true);
     expect(Object.isFrozen(device.effectConfigs?.thermal)).toBe(true);
     expect(Object.isFrozen(device.effects)).toBe(true);
+    const effectConfigs = expectDefined(device.effectConfigs);
+    const thermalConfig = expectDefined(effectConfigs.thermal);
+
     expect(() => {
-      (device.effectConfigs!.thermal as { mode: string }).mode = 'cool';
+      (thermalConfig as { mode: string }).mode = 'cool';
     }).toThrow(TypeError);
   });
 

--- a/packages/engine/tests/unit/domain/strainBlueprintLoader.test.ts
+++ b/packages/engine/tests/unit/domain/strainBlueprintLoader.test.ts
@@ -15,6 +15,7 @@ import {
   AK47_STRAIN_ID,
   WHITE_WIDOW_STRAIN_ID
 } from '../../testUtils/strainFixtures.ts';
+import { expectDefined } from '../../util/expectors';
 
 const blueprintsRoot = path.resolve(resolveBlueprintPath(''));
 
@@ -28,10 +29,9 @@ describe('strainBlueprintLoader', () => {
     const blueprints = loadAllStrainBlueprints({ blueprintsRoot });
 
     expect(blueprints.size).toBeGreaterThanOrEqual(5);
-    const whiteWidow = blueprints.get(WHITE_WIDOW_STRAIN_ID);
-    expect(whiteWidow).toBeDefined();
-    expect(whiteWidow?.slug).toBe('white-widow');
-    expect(whiteWidow?.class).toBe('strain');
+    const whiteWidow = expectDefined(blueprints.get(WHITE_WIDOW_STRAIN_ID));
+    expect(whiteWidow.slug).toBe('white-widow');
+    expect(whiteWidow.class).toBe('strain');
   });
 
   it('loadStrainBlueprint retrieves a specific blueprint', () => {
@@ -80,12 +80,11 @@ describe('strainBlueprintLoader', () => {
   it('loadStrainBlueprint caches individual lookups', () => {
     const readSpy = vi.spyOn(fs, 'readFileSync');
 
-    const first = loadStrainBlueprint(AK47_STRAIN_ID, { blueprintsRoot });
-    expect(first).not.toBeNull();
+    const first = expectDefined(loadStrainBlueprint(AK47_STRAIN_ID, { blueprintsRoot }));
     const afterFirstReads = readSpy.mock.calls.length;
 
-    const second = loadStrainBlueprint(AK47_STRAIN_ID, { blueprintsRoot });
-    expect(second).toBe(first!);
+    const second = expectDefined(loadStrainBlueprint(AK47_STRAIN_ID, { blueprintsRoot }));
+    expect(second).toBe(first);
     expect(readSpy.mock.calls.length).toBe(afterFirstReads);
   });
 });

--- a/packages/engine/tests/unit/services/workforce/market.test.ts
+++ b/packages/engine/tests/unit/services/workforce/market.test.ts
@@ -13,6 +13,7 @@ import type {
   WorkforceState,
 } from '@/backend/src/domain/workforce/WorkforceState';
 import type { WorkforceConfig } from '@/backend/src/config/workforce';
+import { expectDefined } from '../../../util/expectors';
 
 const baseRoles: EmployeeRole[] = [
   {
@@ -93,17 +94,19 @@ describe('workforce market services', () => {
       roles: baseRoles,
     });
 
-    const candidate = scan.pool?.[0];
-    expect(candidate).toBeDefined();
+    const candidate = expectDefined(scan.pool?.[0]);
 
     const hireOptions: PerformMarketHireOptions = {
       market: scan.market,
       structureId,
-      candidateId: candidate!.id,
+      candidateId: candidate.id,
     } satisfies PerformMarketHireOptions;
 
     const hire = performMarketHire(hireOptions);
-    expect(hire.candidate?.id).toBe(candidate!.id);
-    expect(hire.market.structures[0]?.pool).not.toContain(candidate);
+    const hiredCandidate = expectDefined(hire.candidate);
+    expect(hiredCandidate.id).toBe(candidate.id);
+
+    const structure = expectDefined(hire.market.structures[0]);
+    expect(structure.pool).not.toContain(candidate);
   });
 });

--- a/packages/engine/tests/unit/services/workforce/raises.test.ts
+++ b/packages/engine/tests/unit/services/workforce/raises.test.ts
@@ -8,6 +8,7 @@ import {
 } from '@/backend/src/services/workforce/raises';
 import { createRng } from '@/backend/src/util/rng';
 import type { Employee, WorkforceRaiseIntent } from '@/backend/src/domain/world';
+import { expectDefined } from '../../../util/expectors';
 
 function createEmployee(overrides: Partial<Employee> = {}): Employee {
   const base: Employee = {
@@ -69,7 +70,7 @@ describe('workforce raise cadence', () => {
     const outcome = applyRaiseIntent({ employee, intent, currentSimDay });
 
     expect(outcome).not.toBeNull();
-    const result = outcome!;
+    const result = expectDefined(outcome);
 
     expect(result.moraleDelta01).toBeCloseTo(0.06);
     expect(result.rateIncreaseFactor).toBeCloseTo(0.05);
@@ -104,7 +105,7 @@ describe('workforce raise cadence', () => {
     const outcome = applyRaiseIntent({ employee: previous, intent, currentSimDay: 400 });
 
     expect(outcome).not.toBeNull();
-    const result = outcome!;
+    const result = expectDefined(outcome);
 
     expect(result.employee.baseRateMultiplier).toBeCloseTo(1.1, 5);
     expect(result.employee.morale01).toBeLessThan(previous.morale01);
@@ -133,7 +134,7 @@ describe('workforce raise cadence', () => {
     const outcome = applyRaiseIntent({ employee, intent, currentSimDay: 700 });
 
     expect(outcome).not.toBeNull();
-    const result = outcome!;
+    const result = expectDefined(outcome);
 
     expect(result.rateIncreaseFactor).toBeCloseTo(0.02, 5);
     expect(result.employee.baseRateMultiplier).toBeCloseTo(1.02, 5);

--- a/packages/engine/tests/util/expectors.ts
+++ b/packages/engine/tests/util/expectors.ts
@@ -1,0 +1,25 @@
+export function expectDefined<T>(val: T | null | undefined): T {
+  expect(val).toBeDefined();
+  return val as T;
+}
+
+export function asObject(e: unknown): Record<string, unknown> | null {
+  return e && typeof e === 'object' ? (e as Record<string, unknown>) : null;
+}
+
+export function hasKey<T extends string>(
+  o: Record<string, unknown> | null,
+  k: T
+): o is Record<T, unknown> {
+  return !!o && Object.prototype.hasOwnProperty.call(o, k);
+}
+
+export function toNumber(x: unknown): number {
+  expect(typeof x).toBe('number');
+  return x as number;
+}
+
+export function toBigInt(x: unknown): bigint {
+  expect(typeof x === 'bigint' || typeof x === 'number').toBe(true);
+  return typeof x === 'bigint' ? x : BigInt(x as number);
+}


### PR DESCRIPTION
## Summary
- add shared `expectors` test utilities for defined checks, object guards, and numeric conversions
- refactor engine workforce, device, and pipeline tests to use the helpers instead of non-null assertions and raw casts
- harden blueprint taxonomy checks by validating parsed JSON payloads before accessing properties

## Testing
- pnpm --filter engine exec vitest run tests/unit/services/workforce/market.test.ts
- pnpm --filter engine exec vitest run tests/unit/services/workforce/raises.test.ts
- pnpm --filter engine exec vitest run tests/unit/device/createDeviceInstance.test.ts
- pnpm --filter engine exec vitest run tests/integration/pipeline/zoneCapacity.integration.test.ts
- pnpm --filter engine exec vitest run tests/integration/pipeline/fanFilterChain.integration.test.ts
- pnpm --filter engine exec vitest run tests/integration/pipeline/economyAccrual.integration.test.ts
- pnpm --filter engine exec vitest run tests/integration/workforce/hiringMarket.integration.test.ts
- pnpm --filter engine exec vitest run tests/unit/domain/blueprintTaxonomyLayout.test.ts
- pnpm --filter engine exec vitest run tests/unit/domain/strainBlueprintLoader.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e7fa7edd588325a26cd63712d0b323