### PR TITLE
Normalize schema test result handling

### DIFF
--- a/packages/engine/tests/unit/domain/HarvestLotSchema.spec.ts
+++ b/packages/engine/tests/unit/domain/HarvestLotSchema.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { HarvestLotSchema } from '@/backend/src/domain/schemas/HarvestLotSchema';
 import type { HarvestLot } from '@/backend/src/domain/world';
+import { unwrap } from '../../util/expectors';
 
 const BASE_LOT: HarvestLot = {
   id: '00000000-0000-0000-0000-000000000a00' as HarvestLot['id'],
@@ -23,10 +24,11 @@ describe('HarvestLotSchema', () => {
 
     expect(result.success).toBe(true);
     if (!result.success) {
-      return;
+      throw new Error('Harvest lot should parse successfully');
     }
 
-    expect(result.data).toEqual(BASE_LOT);
+    const parsed = unwrap(result);
+    expect(parsed).toEqual(BASE_LOT);
   });
 
   it('coerces createdAt_tick to an integer', () => {

--- a/packages/engine/tests/unit/domain/InventorySchema.spec.ts
+++ b/packages/engine/tests/unit/domain/InventorySchema.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { InventorySchema } from '@/backend/src/domain/schemas/InventorySchema';
 import type { HarvestLot, Inventory } from '@/backend/src/domain/world';
+import { unwrap } from '../../util/expectors';
 
 const LOT: HarvestLot = {
   id: '00000000-0000-0000-0000-000000000f00' as HarvestLot['id'],
@@ -24,10 +25,11 @@ describe('InventorySchema', () => {
 
     expect(result.success).toBe(true);
     if (!result.success) {
-      return;
+      throw new Error('Inventory schema should accept valid lots');
     }
 
-    expect(result.data.lots).toHaveLength(1);
+    const parsed = unwrap(result);
+    expect(parsed.lots).toHaveLength(1);
   });
 
   it('rejects inventories containing invalid lots', () => {
@@ -48,9 +50,10 @@ describe('InventorySchema', () => {
 
     expect(result.success).toBe(true);
     if (!result.success) {
-      return;
+      throw new Error('Inventory schema should default lots to an empty array');
     }
 
-    expect(result.data.lots).toHaveLength(0);
+    const parsed = unwrap(result);
+    expect(parsed.lots).toHaveLength(0);
   });
 });

--- a/packages/engine/tests/unit/domain/devicePriceMapSchema.test.ts
+++ b/packages/engine/tests/unit/domain/devicePriceMapSchema.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { devicePriceMapSchema, parseDevicePriceMap } from '@/backend/src/domain/world';
+import { unwrapErr } from '../../util/expectors';
 
 import devicePriceMap from '../../../../../data/prices/devicePrices.json' with { type: 'json' };
 
@@ -23,10 +24,12 @@ describe('devicePriceMapSchema', () => {
     const result = devicePriceMapSchema.safeParse(invalid);
 
     expect(result.success).toBe(false);
-    if (!result.success) {
-      const issuePaths = result.error.issues.map((issue) => issue.path.join('.'));
-      expect(issuePaths).toContain('devicePrices.00000000-0000-4000-8000-000000000111.maintenanceServiceCost');
+    if (result.success) {
+      throw new Error('Expected missing maintenanceServiceCost to fail validation');
     }
+
+    const issuePaths = unwrapErr(result).issues.map((issue) => issue.path.join('.'));
+    expect(issuePaths).toContain('devicePrices.00000000-0000-4000-8000-000000000111.maintenanceServiceCost');
   });
 
   it('exposes maintenance service cost for canonical devices', () => {

--- a/packages/engine/tests/util/expectors.ts
+++ b/packages/engine/tests/util/expectors.ts
@@ -14,6 +14,17 @@ export function hasKey<T extends string>(
   return !!o && Object.prototype.hasOwnProperty.call(o, k);
 }
 
+export type Ok<T> = { success: true; data: T };
+export type Err<E = unknown> = { success: false; error: E };
+
+export function unwrap<T>(result: Ok<T>): T {
+  return result.data;
+}
+
+export function unwrapErr<E>(result: Err<E>): E {
+  return result.error;
+}
+
 export function toNumber(x: unknown): number {
   expect(typeof x).toBe('number');
   return x as number;


### PR DESCRIPTION
## Summary
- add `unwrap`/`unwrapErr` helpers to the shared test expectors for result-style objects
- refactor domain schema/unit tests to use the helpers instead of direct `.data`/`.error` access
- tighten failure branches with explicit guards so expectations always execute

## Testing
- `pnpm --filter @wb/engine test -- --runTestsByPath packages/engine/tests/unit/domain/InventorySchema.spec.ts packages/engine/tests/unit/domain/HarvestLotSchema.spec.ts packages/engine/tests/unit/domain/devicePriceMapSchema.test.ts packages/engine/tests/unit/domain/deviceBlueprintSchema.test.ts packages/engine/tests/unit/domain/substrateBlueprintSchema.test.ts packages/engine/tests/unit/domain/schemas.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68e7fd75f6888325b1a7a34d9bc31fd3