### PR TITLE
HOTFIX-06: relax unsafe lint rules for tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Unreleased — Blueprint Taxonomy v2
 
+- HOTFIX-06: Added a temporary test-only ESLint override block that disables
+  unsafe assignment/member/call and non-null assertion rules while HOTFIX-01
+  through HOTFIX-05 finish restoring full type resolution, and recorded a
+  follow-up task to remove the relaxation once the blockers clear.
 - Fixed – Restore shared workspace test setup (`packages/tests/setup.ts`) used by
   import guard tests.
 - HOTFIX-02: Restored ESLint's type-aware parser wiring by pointing the

--- a/docs/tasks/hotfix/HOTFIX-06-Remove-Test-Overrides.md
+++ b/docs/tasks/hotfix/HOTFIX-06-Remove-Test-Overrides.md
@@ -1,0 +1,36 @@
+# Remove HOTFIX-06 test-only ESLint overrides
+
+**ID:** HOTFIX-06-FOLLOWUP
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** lint, tooling
+
+## Rationale
+Residual type-resolution work from HOTFIX-01 through HOTFIX-05 is expected to make
+the HOTFIX-06 safety-rule relaxations obsolete. We need a clear follow-up to
+remove the temporary overrides so tests regain the same lint guarantees as
+production code once alias gaps are closed.
+
+## Scope
+- In: delete the HOTFIX-06 test-only rule overrides once type information is
+  fully resolved across tests.
+- In: restore the unsafe call/member/access/non-null assertion checks for test
+  sources.
+- Out: broader lint rule changes unrelated to the temporary overrides.
+
+## Deliverables
+- Update `eslint.config.js` to drop the HOTFIX-06 override block and TODO.
+- Ensure any residual unsafe usage surfaced by re-enabled rules is addressed in
+  tests or helper utilities.
+- Document the removal in `docs/CHANGELOG.md`.
+
+## Acceptance Criteria
+- Lint passes for the workspace with the HOTFIX-06 overrides removed and no new
+  unsafe lint violations in test files.
+- TODO comment referencing HOTFIX-06 is removed.
+
+## References
+- HOTFIX-01 through HOTFIX-05 task notes for the outstanding type-resolution
+  work.
+- SEC §14 and DD linting guidance for mandatory ESLint guardrails.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -67,8 +67,13 @@ export default tseslint.config(
   },
   {
     files: ["**/*.test.ts", "**/*.spec.ts"],
+    // TODO(HOTFIX-06-REMOVE): Temporary relaxations until HOTFIX-01..05 land.
     rules: {
-      "@typescript-eslint/no-magic-numbers": "off"
+      "@typescript-eslint/no-magic-numbers": "off",
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/no-unsafe-call": "off",
+      "@typescript-eslint/no-non-null-assertion": "off"
     }
   }
 );


### PR DESCRIPTION
## Summary
- add HOTFIX-06 test-only ESLint overrides for unsafe call/member/access/non-null checks with a removal TODO
- document the temporary relaxation in the changelog and track the follow-up removal task

## Testing
- pnpm -w eslint "packages/**/*.{ts,tsx}" *(fails: existing lint violations unrelated to HOTFIX-06 overrides)*

------
https://chatgpt.com/codex/tasks/task_e_68e806ef7464832593df7a09b95c94c9