### PR TITLE
Remove HOTFIX-06 ESLint overrides and harden transport tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Unreleased — Blueprint Taxonomy v2
 
+- Removed HOTFIX-06's temporary test-only ESLint overrides now that type-aware
+  linting is restored across the workspace, re-enabling unsafe assignment,
+  member access, call, non-null assertion, and magic number checks for tests.
 - HOTFIX-06: Added a temporary test-only ESLint override block that disables
   unsafe assignment/member/call and non-null assertion rules while HOTFIX-01
   through HOTFIX-05 finish restoring full type resolution, and recorded a

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -64,16 +64,5 @@ export default tseslint.config(
       "wb-sim/no-economy-per-tick": "error",
       "wb-sim/no-engine-percent-identifiers": "error"
     }
-  },
-  {
-    files: ["**/*.test.ts", "**/*.spec.ts"],
-    // TODO(HOTFIX-06-REMOVE): Temporary relaxations until HOTFIX-01..05 land.
-    rules: {
-      "@typescript-eslint/no-magic-numbers": "off",
-      "@typescript-eslint/no-unsafe-assignment": "off",
-      "@typescript-eslint/no-unsafe-member-access": "off",
-      "@typescript-eslint/no-unsafe-call": "off",
-      "@typescript-eslint/no-non-null-assertion": "off"
-    }
   }
 );

--- a/packages/transport-sio/tests/integration/telemetryReadonly.spec.ts
+++ b/packages/transport-sio/tests/integration/telemetryReadonly.spec.ts
@@ -1,6 +1,6 @@
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
-import { io as createClient, type Socket } from 'socket.io-client';
+import { io as createClient } from 'socket.io-client';
 import { describe, expect, it, vi } from 'vitest';
 import {
   INTENT_EVENT,
@@ -11,6 +11,86 @@ import {
   type TransportAck,
   type TransportIntentEnvelope,
 } from '../../src/index.ts';
+
+type SocketClientFactory = (
+  url: string,
+  options: {
+    transports: readonly ['websocket'];
+    forceNew: true;
+  },
+) => unknown;
+
+const createSocketClient: SocketClientFactory = createClient as SocketClientFactory;
+
+interface BaseTestSocket {
+  readonly connected: boolean;
+  disconnect(): void;
+  once(event: 'connect' | 'disconnect', handler: () => void): this;
+  once(event: 'connect_error', handler: (error: Error) => void): this;
+  off(event: 'connect', handler: () => void): this;
+  off(event: 'connect_error', handler: (error: Error) => void): this;
+}
+
+interface TelemetrySocket extends BaseTestSocket {
+  once(event: typeof TELEMETRY_ERROR_EVENT, handler: (payload: TransportAck) => void): this;
+  emit(
+    event: 'telemetry:write',
+    payload: Record<string, unknown>,
+    ack?: (response: TransportAck) => void,
+  ): this;
+}
+
+interface IntentSocket extends BaseTestSocket {
+  emit(event: typeof INTENT_EVENT, payload: unknown, ack: (response: TransportAck) => void): this;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function assertBaseSocket(value: unknown): asserts value is BaseTestSocket {
+  if (!isObject(value)) {
+    throw new TypeError('Socket client must be an object.');
+  }
+
+  const candidate = value as Partial<BaseTestSocket>;
+
+  if (typeof candidate.connected !== 'boolean') {
+    throw new TypeError('Socket client must expose a boolean connected flag.');
+  }
+
+  if (typeof candidate.disconnect !== 'function') {
+    throw new TypeError('Socket client must expose a disconnect function.');
+  }
+
+  if (typeof candidate.once !== 'function') {
+    throw new TypeError('Socket client must expose a once function.');
+  }
+
+  if (typeof candidate.off !== 'function') {
+    throw new TypeError('Socket client must expose an off function.');
+  }
+}
+
+function assertTelemetrySocket(value: unknown): asserts value is TelemetrySocket {
+  assertBaseSocket(value);
+
+  const candidate = value as Partial<TelemetrySocket>;
+
+  if (typeof candidate.emit !== 'function') {
+    throw new TypeError('Telemetry socket must expose an emit function.');
+  }
+}
+
+function assertIntentSocket(value: unknown): asserts value is IntentSocket {
+  assertBaseSocket(value);
+
+  const candidate = value as Partial<IntentSocket>;
+
+  if (typeof candidate.emit !== 'function') {
+    throw new TypeError('Intent socket must expose an emit function.');
+  }
+}
 
 interface TransportHarness {
   readonly port: number;
@@ -56,18 +136,24 @@ async function createTransportHarness(
   } satisfies TransportHarness;
 }
 
-async function connectNamespace(harness: TransportHarness, namespace: '/telemetry' | '/intents') {
-  const socket = createClient(`http://127.0.0.1:${String(harness.port)}${namespace}`, {
+async function connectNamespace<TSocket extends BaseTestSocket>(
+  harness: TransportHarness,
+  namespace: '/telemetry' | '/intents',
+  assertSocket: (candidate: unknown) => asserts candidate is TSocket,
+): Promise<TSocket> {
+  const socket: unknown = createSocketClient(`http://127.0.0.1:${String(harness.port)}${namespace}`, {
     transports: ['websocket'],
     forceNew: true,
   });
+
+  assertSocket(socket);
 
   await onceConnected(socket);
 
   return socket;
 }
 
-function onceConnected(socket: Socket): Promise<void> {
+function onceConnected(socket: BaseTestSocket): Promise<void> {
   if (socket.connected) {
     return Promise.resolve();
   }
@@ -88,7 +174,7 @@ function onceConnected(socket: Socket): Promise<void> {
   });
 }
 
-function disconnectClient(socket: Socket): Promise<void> {
+function disconnectClient(socket: BaseTestSocket): Promise<void> {
   return new Promise<void>((resolve) => {
     if (!socket.connected) {
       socket.disconnect();
@@ -108,7 +194,11 @@ describe('createSocketTransportAdapter — telemetry read-only contract', () => 
     const onIntent = vi.fn();
     const harness = await createTransportHarness(onIntent);
 
-    const telemetrySocket = await connectNamespace(harness, '/telemetry');
+    const telemetrySocket: TelemetrySocket = await connectNamespace(
+      harness,
+      '/telemetry',
+      assertTelemetrySocket,
+    );
 
     try {
       const errorEventPromise = new Promise<TransportAck>((resolve) => {
@@ -139,7 +229,11 @@ describe('createSocketTransportAdapter — telemetry read-only contract', () => 
     const onIntent = vi.fn();
     const harness = await createTransportHarness(onIntent);
 
-    const telemetrySocket = await connectNamespace(harness, '/telemetry');
+    const telemetrySocket: TelemetrySocket = await connectNamespace(
+      harness,
+      '/telemetry',
+      assertTelemetrySocket,
+    );
 
     try {
       const errorEventPromise = new Promise<TransportAck>((resolve) => {
@@ -166,7 +260,11 @@ describe('createSocketTransportAdapter — intent submissions', () => {
   it('accepts valid intent submissions with ok acknowledgements', async () => {
     const onIntent = vi.fn();
     const harness = await createTransportHarness(onIntent);
-    const intentSocket = await connectNamespace(harness, '/intents');
+    const intentSocket: IntentSocket = await connectNamespace(
+      harness,
+      '/intents',
+      assertIntentSocket,
+    );
 
     try {
       const ack = await new Promise<TransportAck>((resolve) => {
@@ -187,7 +285,11 @@ describe('createSocketTransportAdapter — intent submissions', () => {
   it('rejects malformed intent submissions with WB_INTENT_INVALID', async () => {
     const onIntent = vi.fn();
     const harness = await createTransportHarness(onIntent);
-    const intentSocket = await connectNamespace(harness, '/intents');
+    const intentSocket: IntentSocket = await connectNamespace(
+      harness,
+      '/intents',
+      assertIntentSocket,
+    );
 
     try {
       const ack = await new Promise<TransportAck>((resolve) => {

--- a/packages/transport-sio/tests/unit/createSocketTransportDescriptor.test.ts
+++ b/packages/transport-sio/tests/unit/createSocketTransportDescriptor.test.ts
@@ -3,9 +3,10 @@ import { createSocketTransportDescriptor } from '../../src/index.ts';
 
 describe('createSocketTransportDescriptor', () => {
   it('creates a descriptor with the expected endpoint', () => {
-    const descriptor = createSocketTransportDescriptor({ host: '127.0.0.1', port: 1337 });
+    const TEST_PORT = 1337;
+    const descriptor = createSocketTransportDescriptor({ host: '127.0.0.1', port: TEST_PORT });
 
-    expect(descriptor).toEqual({ endpointUrl: 'http://127.0.0.1:1337' });
+    expect(descriptor).toEqual({ endpointUrl: `http://127.0.0.1:${String(TEST_PORT)}` });
   });
 
   it('validates the provided port', () => {


### PR DESCRIPTION
## Summary
- drop the HOTFIX-06 ESLint override block so test files once again receive the unsafe usage guardrails
- document the cleanup in the changelog
- tighten the transport integration tests with runtime socket type assertions and a magic-number constant so lint passes without the overrides

## Testing
- pnpm --filter @wb/transport-sio lint

------
https://chatgpt.com/codex/tasks/task_e_68e817f5c274832591cd77160b62a59f