### PR TITLE
feat(task:0040): eslint test program includes tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Unreleased — Blueprint Taxonomy v2
 
+- HOTFIX-042: Added `packages/engine/tsconfig.eslint.json` and updated the
+  workspace ESLint parser project list so engine tests participate in the
+  type-aware program without `parserOptions.project` resolution failures.
+
 - HOTFIX-07: Added workspace `pnpm typecheck`, `pnpm lint`, and `pnpm test` commands,
   wired `pnpm prepush` to chain them locally, and updated CI to run the trio with
   ESLint warnings treated as failures so regression guards stay aligned across

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,7 +29,8 @@ export default tseslint.config(
       parserOptions: {
         project: [
           "./packages/*/tsconfig.json",
-          "./packages/*/tsconfig.spec.json"
+          "./packages/*/tsconfig.spec.json",
+          "./packages/engine/tsconfig.eslint.json"
         ],
         tsconfigRootDir: import.meta.dirname,
         sourceType: "module"

--- a/packages/engine/tsconfig.eslint.json
+++ b/packages/engine/tsconfig.eslint.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.spec.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "tests/**/*.ts",
+    "tests/**/*.tsx"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- add `packages/engine/tsconfig.eslint.json` extending the spec compiler setup so ESLint can load both engine source and test files
- point the workspace ESLint configuration at the new project file to restore test-aware type analysis
- document the lint configuration touchpoint in the hotfix CHANGELOG entry

## References
- SEC v0.2.1 §0.1 (tooling alignment)
- TDD §2 (test taxonomy & lint coverage)

## Testing
- `pnpm i`
- `pnpm -r test`
- `pnpm --reporter append-only -r lint` *(fails: existing engine lint/type debt surfaced once tests participate in the program; no `parserOptions.project` errors remain)*
- `pnpm -r build` *(fails: existing TypeScript errors in packages/tools unrelated to this change)*


------
https://chatgpt.com/codex/tasks/task_e_68e8245319a8832590970091b75d7ef4