### PR TITLE
feat(task:0041): central constants and formatting helpers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### Unreleased — Blueprint Taxonomy v2
 
+- HOTFIX-042 (Task 0041): Centralised golden master horizons and formatting helpers,
+  extended `simConstants` with deterministic hash tolerances and MiB scaling, updated
+  perf budgeting to consume the shared constants, refreshed conformance specs to use
+  `fmtNum`, and documented the additions in `/docs/constants`.
+
 - HOTFIX-042: Added `packages/engine/tsconfig.eslint.json` and updated the
   workspace ESLint parser project list so engine tests participate in the
   type-aware program without `parserOptions.project` resolution failures.

--- a/docs/constants/README.md
+++ b/docs/constants/README.md
@@ -4,6 +4,7 @@ All production defaults and SEC-aligned thresholds live under `packages/engine/s
 
 - `simConstants.ts` remains the canonical registry for Simulation Engine Contract values. Domain modules may only re-export or derive from these values.
 - Domain shims (`time.ts`, `physics.ts`, `climate.ts`, `lighting.ts`, `workforce.ts`, `economy.ts`, `validation.ts`) group related thresholds to keep imports ergonomic.
+- `goldenMaster.ts` centralises the deterministic conformance horizons used by the golden master harness (30d/200d).
 - Export names use `UPPER_SNAKE_CASE` and include units (`*_PER_H`, `*_M2`, …) to avoid ambiguity.
 - When adding a new constant:
   - Define it in the relevant domain module (or `simConstants.ts` if SEC-level) and document the rationale inline.

--- a/docs/constants/simConstants.md
+++ b/docs/constants/simConstants.md
@@ -26,6 +26,11 @@ normalisation mandated by the SEC.
 | `HOURS_PER_MONTH` | `720` | h | Derived: `HOURS_PER_DAY × DAYS_PER_MONTH`. |
 | `HOURS_PER_YEAR` | `8 640` | h | Derived: `HOURS_PER_MONTH × MONTHS_PER_YEAR`. |
 | `FLOAT_TOLERANCE` | `1e-6` | — | Canonical tolerance for floating-point comparisons. |
+| `EPS_REL` | `1e-6` | — | Relative tolerance used for golden master hash and metric comparisons. |
+| `EPS_ABS` | `1e-9` | — | Absolute tolerance paired with `EPS_REL` for floating-point comparisons. |
+| `BYTES_PER_MEBIBYTE` | `1 048 576` | B | Bytes per MiB (2^20) for performance and memory diagnostics. |
+| `HASH_KEY_BYTES` | `16` | hex chars | Default SHA-256 digest truncation length for daily golden hashes. |
+| `HASH_TRUNC_BYTES` | `24` | hex chars | Default SHA-256 digest truncation length for summary golden hashes. |
 | `DEFAULT_COMPANY_LOCATION_LON` | `9.9937` | ° | Default headquarters longitude (Hamburg) until UI capture lands. |
 | `DEFAULT_COMPANY_LOCATION_LAT` | `53.5511` | ° | Default headquarters latitude (Hamburg) until UI capture lands. |
 | `LONGITUDE_MIN_DEG` | `-180` | ° | Minimal permissible longitude for world metadata. |

--- a/packages/engine/src/backend/src/constants/goldenMaster.ts
+++ b/packages/engine/src/backend/src/constants/goldenMaster.ts
@@ -1,0 +1,20 @@
+/**
+ * Canonical horizons for deterministic golden master scenario runs used by the
+ * conformance test harness.
+ */
+export const GM_DAYS_SHORT = 30 as const;
+
+/**
+ * Extended horizon for deterministic golden master scenario runs validating
+ * longer term behaviour.
+ */
+export const GM_DAYS_LONG = 200 as const;
+
+/**
+ * Readonly tuple of supported golden master horizons.
+ */
+export const GOLDEN_MASTER_DAY_RUNS = [GM_DAYS_SHORT, GM_DAYS_LONG] as const;
+
+type GoldenMasterRunTuple = typeof GOLDEN_MASTER_DAY_RUNS;
+
+export type GoldenMasterRunDayCount = GoldenMasterRunTuple[number];

--- a/packages/engine/src/backend/src/constants/simConstants.ts
+++ b/packages/engine/src/backend/src/constants/simConstants.ts
@@ -83,6 +83,31 @@ export interface SimulationConstants {
    */
   readonly FLOAT_TOLERANCE: number;
   /**
+   * Relative comparison tolerance used for golden master verification and
+   * other deterministic hash comparisons.
+   */
+  readonly EPS_REL: number;
+  /**
+   * Absolute comparison tolerance paired with {@link EPS_REL} when validating
+   * floating point series against golden references.
+   */
+  readonly EPS_ABS: number;
+  /**
+   * Number of bytes contained within a single mebibyte (2^20). Utilised by
+   * performance budgeting logic and memory diagnostics.
+   */
+  readonly BYTES_PER_MEBIBYTE: number;
+  /**
+   * Default truncation length, in hexadecimal characters, for deterministic
+   * hash keys derived from SHA-256 digests.
+   */
+  readonly HASH_KEY_BYTES: number;
+  /**
+   * Default truncation length, in hexadecimal characters, for summary hashes
+   * emitted by golden master fixtures.
+   */
+  readonly HASH_TRUNC_BYTES: number;
+  /**
    * Default longitude (decimal degrees) for company headquarters metadata
    * until the UI allows customisation.
    */
@@ -216,6 +241,37 @@ export const HOURS_PER_YEAR = HOURS_PER_MONTH * MONTHS_PER_YEAR;
 export const FLOAT_TOLERANCE = 1e-6 as const;
 
 /**
+ * Canonical relative tolerance applied when comparing floating point
+ * sequences against golden references.
+ */
+export const EPS_REL = FLOAT_TOLERANCE;
+
+/**
+ * Canonical absolute tolerance paired with {@link EPS_REL} for comparisons
+ * against golden fixtures.
+ */
+export const EPS_ABS = 1e-9 as const;
+
+/**
+ * Canonical multiplier describing the number of bytes contained in a single
+ * mebibyte (2^20). Used by performance budgeting to convert heap metrics to
+ * MiB.
+ */
+export const BYTES_PER_MEBIBYTE = 1_048_576 as const;
+
+/**
+ * Canonical truncation length applied to SHA-256 digests when deriving daily
+ * golden master hashes.
+ */
+export const HASH_KEY_BYTES = 16 as const;
+
+/**
+ * Canonical truncation length applied to SHA-256 digests when deriving
+ * summary hashes for golden master fixtures.
+ */
+export const HASH_TRUNC_BYTES = 24 as const;
+
+/**
  * Temporary default longitude for company headquarters metadata. Anchored to
  * Hamburg (Germany) until SEC-compliant UI capture is available.
  */
@@ -281,6 +337,11 @@ const SIMULATION_CONSTANT_REGISTRY = Object.freeze({
   HOURS_PER_MONTH,
   HOURS_PER_YEAR,
   FLOAT_TOLERANCE,
+  EPS_REL,
+  EPS_ABS,
+  BYTES_PER_MEBIBYTE,
+  HASH_KEY_BYTES,
+  HASH_TRUNC_BYTES,
   DEFAULT_COMPANY_LOCATION_LON,
   DEFAULT_COMPANY_LOCATION_LAT,
   LONGITUDE_MIN_DEG,

--- a/packages/engine/src/backend/src/engine/conformance/runDeterministic.ts
+++ b/packages/engine/src/backend/src/engine/conformance/runDeterministic.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 
 import { fileURLToPath } from 'node:url';
 
+import { fmtNum } from '../../util/format.ts';
 import { generateGoldenScenarioRun } from './goldenScenario.ts';
 import {
   assertDailyFixtureMatch,
@@ -29,7 +30,7 @@ const FIXTURE_ROOT = fileURLToPath(
 );
 
 function resolveFixtureDir(days: number): string {
-  return path.join(FIXTURE_ROOT, `${days}d`);
+  return path.join(FIXTURE_ROOT, `${fmtNum(days)}d`);
 }
 
 export function runDeterministic(options: DeterministicRunOptions): DeterministicRunResult {

--- a/packages/engine/src/backend/src/engine/conformance/updateGoldenFixtures.ts
+++ b/packages/engine/src/backend/src/engine/conformance/updateGoldenFixtures.ts
@@ -2,17 +2,20 @@ import path from 'node:path';
 
 import { fileURLToPath } from 'node:url';
 
+import { GM_DAYS_LONG, GM_DAYS_SHORT, GOLDEN_MASTER_DAY_RUNS } from '../../constants/goldenMaster.ts';
+import { fmtNum } from '../../util/format.ts';
 import { runDeterministic } from '../testHarness.ts';
 
 const FIXTURE_ROOT = fileURLToPath(
   new URL('../../../../../tests/fixtures/golden/', import.meta.url)
 );
 
-const RUNS = [30, 200] as const;
+const RUNS = GOLDEN_MASTER_DAY_RUNS satisfies readonly [typeof GM_DAYS_SHORT, typeof GM_DAYS_LONG];
 
 for (const days of RUNS) {
-  const outDir = path.join(FIXTURE_ROOT, `${days}d`);
-   
-  console.log(`Updating golden fixtures for ${days}-day run at ${outDir}`);
+  const label = `${fmtNum(days)}d`;
+  const outDir = path.join(FIXTURE_ROOT, label);
+
+  console.log(`Updating golden fixtures for ${fmtNum(days)}-day run at ${outDir}`);
   runDeterministic({ days, seed: 'gm-001', outDir });
 }

--- a/packages/engine/src/backend/src/engine/conformance/verify/hashes.ts
+++ b/packages/engine/src/backend/src/engine/conformance/verify/hashes.ts
@@ -2,16 +2,24 @@ import { createHash } from 'node:crypto';
 
 import safeStringify from 'safe-stable-stringify';
 
-import { FLOAT_TOLERANCE } from '@/backend/src/constants/simConstants';
+import {
+  EPS_ABS as SIM_EPS_ABS,
+  EPS_REL as SIM_EPS_REL,
+  HASH_KEY_BYTES,
+  HASH_TRUNC_BYTES,
+} from '@/backend/src/constants/simConstants';
 
 import type { DailyRecord, DailyRecordBase, ScenarioSummary } from '../types.ts';
 
-export const EPS_ABS = FLOAT_TOLERANCE * 1e-3;
-export const EPS_REL = FLOAT_TOLERANCE;
+export const EPS_ABS = SIM_EPS_ABS;
+export const EPS_REL = SIM_EPS_REL;
 
 export function recordDailyHash(payload: DailyRecordBase): string {
   const canonical = safeStringify(payload);
-  return createHash('sha256').update(canonical).digest('hex').slice(0, 16);
+  return createHash('sha256')
+    .update(canonical)
+    .digest('hex')
+    .slice(0, HASH_KEY_BYTES);
 }
 
 export function computeSummaryHash(
@@ -19,5 +27,8 @@ export function computeSummaryHash(
   daily: readonly DailyRecord[]
 ): string {
   const canonical = safeStringify({ summary, daily });
-  return createHash('sha256').update(canonical).digest('hex').slice(0, 24);
+  return createHash('sha256')
+    .update(canonical)
+    .digest('hex')
+    .slice(0, HASH_TRUNC_BYTES);
 }

--- a/packages/engine/src/backend/src/engine/perf/perfBudget.ts
+++ b/packages/engine/src/backend/src/engine/perf/perfBudget.ts
@@ -1,12 +1,13 @@
+import { BYTES_PER_MEBIBYTE } from '@/backend/src/constants/simConstants';
+
 import { type PerfHarnessResult } from '../testHarness.ts';
 
 const NS_PER_SECOND = 1_000_000_000;
 const SECONDS_PER_MINUTE = 60;
-const BYTES_PER_MIB = 1024 * 1024;
 
 export const PERF_CI_TICK_COUNT = 10_000;
 export const PERF_MIN_TICKS_PER_MINUTE = 5_000;
-export const PERF_MAX_HEAP_BYTES = 64 * BYTES_PER_MIB;
+export const PERF_MAX_HEAP_BYTES = 64 * BYTES_PER_MEBIBYTE;
 export const PERF_WARNING_GUARD_PERCENTAGE = 0.05;
 
 export interface PerfBudgetThresholds {
@@ -66,7 +67,7 @@ export function evaluatePerfBudget(
   const ticksPerMinute =
     totalDurationMinutes > 0 ? tickCount / totalDurationMinutes : Number.POSITIVE_INFINITY;
   const maxHeapUsedBytes = result.maxHeapUsedBytes;
-  const maxHeapUsedMiB = maxHeapUsedBytes / BYTES_PER_MIB;
+  const maxHeapUsedMiB = maxHeapUsedBytes / BYTES_PER_MEBIBYTE;
 
   const failures: string[] = [];
   const warnings: string[] = [];
@@ -99,7 +100,7 @@ export function evaluatePerfBudget(
 
   if (maxHeapUsedBytes > thresholds.maxHeapBytes) {
     failures.push(
-      `Heap peak ${(maxHeapUsedMiB).toFixed(2)} MiB exceeds ${(thresholds.maxHeapBytes / BYTES_PER_MIB).toFixed(
+      `Heap peak ${(maxHeapUsedMiB).toFixed(2)} MiB exceeds ${(thresholds.maxHeapBytes / BYTES_PER_MEBIBYTE).toFixed(
         2
       )} MiB budget.`
     );

--- a/packages/engine/src/backend/src/index.ts
+++ b/packages/engine/src/backend/src/index.ts
@@ -1,1 +1,2 @@
+export * from './constants/goldenMaster.ts';
 export * from './constants/simConstants.ts';

--- a/packages/engine/src/backend/src/util/format.ts
+++ b/packages/engine/src/backend/src/util/format.ts
@@ -1,0 +1,16 @@
+/**
+ * Ensures unknown values are converted into string form without triggering
+ * template literal restrictions that disallow direct interpolation of
+ * non-string types.
+ */
+export function toStr(value: unknown): string {
+  return typeof value === 'string' ? value : String(value);
+}
+
+/**
+ * Stable numeric formatter for log and diagnostic strings inside the engine.
+ * UI layers remain responsible for locale-aware presentation.
+ */
+export function fmtNum(value: number): string {
+  return Number.isFinite(value) ? value.toString() : String(value);
+}

--- a/packages/engine/tests/conformance/goldenMaster.200d.spec.ts
+++ b/packages/engine/tests/conformance/goldenMaster.200d.spec.ts
@@ -5,7 +5,9 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
+import { GM_DAYS_LONG } from '@/backend/src/constants/goldenMaster';
 import { runDeterministic } from '@/backend/src/engine/testHarness';
+import { fmtNum } from '@/backend/src/util/format';
 import type {
   DailyRecord,
   ScenarioSummary,
@@ -14,12 +16,12 @@ import type {
 const FIXTURE_ROOT = fileURLToPath(new URL('../fixtures/golden/', import.meta.url));
 
 function loadSummary(days: number) {
-  const fixturePath = path.join(FIXTURE_ROOT, `${days}d/summary.json`);
+  const fixturePath = path.join(FIXTURE_ROOT, `${fmtNum(days)}d/summary.json`);
   return JSON.parse(fs.readFileSync(fixturePath, 'utf8')) as Record<string, unknown>;
 }
 
 function loadDaily(days: number) {
-  const fixturePath = path.join(FIXTURE_ROOT, `${days}d/daily.jsonl`);
+  const fixturePath = path.join(FIXTURE_ROOT, `${fmtNum(days)}d/daily.jsonl`);
   return fs
     .readFileSync(fixturePath, 'utf8')
     .split(/\r?\n/)
@@ -29,14 +31,14 @@ function loadDaily(days: number) {
 
 describe('golden master 200-day soak', () => {
   it('golden-200d::replays the long-run fixture without drift', () => {
-    const expectedSummary = loadSummary(200);
-    const expectedDaily = loadDaily(200);
+    const expectedSummary = loadSummary(GM_DAYS_LONG);
+    const expectedDaily = loadDaily(GM_DAYS_LONG);
 
-    const result = runDeterministic({ days: 200, seed: 'gm-001' });
+    const result = runDeterministic({ days: GM_DAYS_LONG, seed: 'gm-001' });
 
     expect(result.summary).toEqual(expectedSummary);
     expect(result.daily).toEqual(expectedDaily);
-    expect(result.daily).toHaveLength(200);
+    expect(result.daily).toHaveLength(GM_DAYS_LONG);
 
     const typedSummary = result.summary as ScenarioSummary;
     const typedDaily = result.daily as DailyRecord[];
@@ -81,8 +83,8 @@ describe('golden master 200-day soak', () => {
   });
 
   it('golden-200d::writes soak artifacts to the reporting directory', () => {
-    const outDir = path.resolve(process.cwd(), 'reporting', '200d');
-    const result = runDeterministic({ days: 200, seed: 'gm-001', outDir });
+    const outDir = path.resolve(process.cwd(), 'reporting', `${fmtNum(GM_DAYS_LONG)}d`);
+    const result = runDeterministic({ days: GM_DAYS_LONG, seed: 'gm-001', outDir });
 
     const summaryOnDisk = JSON.parse(
       fs.readFileSync(path.join(outDir, 'summary.json'), 'utf8')

--- a/packages/engine/tests/unit/util/format.test.ts
+++ b/packages/engine/tests/unit/util/format.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { fmtNum, toStr } from '@/backend/src/util/format';
+
+describe('format helpers', () => {
+  it('converts non-string values to strings without mutation', () => {
+    expect(toStr('already-string')).toBe('already-string');
+    expect(toStr(42)).toBe('42');
+  });
+
+  it('formats numbers using canonical string conversion', () => {
+    expect(fmtNum(0)).toBe('0');
+    expect(fmtNum(123.456)).toBe('123.456');
+  });
+});


### PR DESCRIPTION
## Summary
- centralize golden-master horizons in `constants/goldenMaster.ts` and expose formatting helpers to remove literal day strings in conformance harnesses and specs
- extend `simConstants` with EPS tolerances, hash truncation lengths, and MiB scaling so perf and hash utilities share canonical values
- update perf budget logic, deterministic run utilities, and documentation to consume the shared constants and formatting helpers; add unit coverage for the new formatter

## References
- SEC §1.2 (canonical constants)
- TDD §1 (canonical constants guardrail), §12 (golden master harness)

## Testing
- `pnpm i`
- `pnpm -r test`
- `pnpm -r lint` *(fails: existing workspace lint backlog, 2627 problems in @wb/engine lint)*
- `pnpm -r build` *(fails: existing @wb/tools build failure tsc exit 2)*

## Deviations
- Global lint and build steps fail on pre-existing workspace issues outside the scope of Task 0041; no new lint violations were introduced in touched files.


------
https://chatgpt.com/codex/tasks/task_e_68e828a65cac83259c312c1905157da7