### PR TITLE
feat(task:0042): Template literal safety cleanup

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### Unreleased — Blueprint Taxonomy v2
 
+- HOTFIX-042 (Task 0042): Routed numeric template literal segments in engine
+  perf/seed-to-harvest pipelines, save/load registries, workforce RNG stream
+  identifiers, and façade transport URLs through `fmtNum`/explicit string
+  conversion to satisfy the `restrict-template-expressions` lint guardrail.
+
 - HOTFIX-042 (Task 0041): Centralised golden master horizons and formatting helpers,
   extended `simConstants` with deterministic hash tolerances and MiB scaling, updated
   perf budgeting to consume the shared constants, refreshed conformance specs to use

--- a/packages/engine/src/backend/src/engine/perf/perfScenarios.ts
+++ b/packages/engine/src/backend/src/engine/perf/perfScenarios.ts
@@ -2,6 +2,7 @@ import type { SimulationWorld, Structure, Room, Zone, ZoneDeviceInstance } from 
 import type { Uuid } from '../../domain/schemas/primitives.ts';
 import { createDemoWorld } from '../testHarness.ts';
 import { deterministicUuid } from '../../util/uuid.ts';
+import { fmtNum } from '../../util/format.ts';
 import { HOURS_PER_DAY } from '../../constants/simConstants.ts';
 import { createDeviceInstance } from '../../device/createDeviceInstance.ts';
 import {
@@ -69,7 +70,10 @@ function instantiateZoneDevice(
   zoneSeed: string,
   deviceIndex: number
 ): ZoneDeviceInstance {
-  const id = deterministicUuid('perf-target', `${zoneSeed}:${blueprint.slug}:${deviceIndex}`);
+  const id = deterministicUuid(
+    'perf-target',
+    `${zoneSeed}:${blueprint.slug}:${fmtNum(deviceIndex)}`
+  );
   const qualityPolicy = { sampleQuality01: () => clamp01((blueprint as { quality?: number }).quality ?? 0.85) };
   const seeded = createDeviceInstance(qualityPolicy, zoneSeed, id, blueprint);
   const { effects } = seeded;
@@ -125,7 +129,7 @@ function instantiateZoneDevice(
 }
 
 function buildZoneDevices(zoneIndex: number): ZoneDeviceInstance[] {
-  const seed = `perf-zone-${zoneIndex}`;
+  const seed = `perf-zone-${fmtNum(zoneIndex)}`;
   return BASE_DEVICE_BLUEPRINTS.map((entry, index) =>
     instantiateZoneDevice(entry.blueprint, entry.dutyCycle01, seed, index)
   );
@@ -144,12 +148,12 @@ function cloneRoom(room: Room): Room {
 }
 
 function createPerfZone(baseZone: Zone, index: number): Zone {
-  const zoneSeed = `perf-target-zone-${index}`;
+  const zoneSeed = `perf-target-zone-${fmtNum(index)}`;
   return {
     ...baseZone,
     id: deterministicUuid('perf-target', `${zoneSeed}:id`),
-    slug: `${baseZone.slug}-perf-${index + 1}`,
-    name: `${baseZone.name} Perf ${index + 1}`,
+    slug: `${baseZone.slug}-perf-${fmtNum(index + 1)}`,
+    name: `${baseZone.name} Perf ${fmtNum(index + 1)}`,
     devices: buildZoneDevices(index),
     plants: baseZone.plants.map((plant) => ({ ...plant })),
     nutrientBuffer_mg: { ...baseZone.nutrientBuffer_mg }

--- a/packages/engine/src/backend/src/engine/seedToHarvest.ts
+++ b/packages/engine/src/backend/src/engine/seedToHarvest.ts
@@ -4,6 +4,7 @@ import { TELEMETRY_HARVEST_CREATED_V1 } from '../telemetry/topics.ts';
 import { deterministicUuid } from '../util/uuid.ts';
 import { calculateAccumulatedLightHours } from '../util/photoperiod.ts';
 import { HOURS_PER_DAY, HOURS_PER_TICK } from '../constants/simConstants.ts';
+import { fmtNum } from '../util/format.ts';
 import type {
   HarvestLot,
   LightSchedule,
@@ -253,11 +254,14 @@ function seedZoneWithPlants(
     const plants: Plant[] = [];
 
     for (let index = 0; index < plantCount; index += 1) {
-      const id = deterministicUuid(world.seed, `zone:${zone.id}:plant:${index}`);
+      const id = deterministicUuid(
+        world.seed,
+        `zone:${zone.id}:plant:${fmtNum(index)}`
+      );
       plants.push({
         id,
-        name: `Seedling ${index + 1}`,
-        slug: `seedling-${index + 1}`,
+        name: `Seedling ${fmtNum(index + 1)}`,
+        slug: `seedling-${fmtNum(index + 1)}`,
         strainId,
         lifecycleStage: 'seedling',
         ageHours: 0,

--- a/packages/engine/src/backend/src/saveLoad/migrations/registry.ts
+++ b/packages/engine/src/backend/src/saveLoad/migrations/registry.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { saveGameEnvelopeSchema } from '../schemas.ts';
+import { fmtNum } from '../../util/format.ts';
 
 export interface SaveGameMigrationStep {
   readonly fromVersion: number;
@@ -29,7 +30,7 @@ export class SaveGameMigrationRegistry {
 
   public register(step: SaveGameMigrationStep): void {
     if (this.steps.has(step.fromVersion)) {
-      throw new Error(`Migration from version ${step.fromVersion} already registered`);
+      throw new Error(`Migration from version ${fmtNum(step.fromVersion)} already registered`);
     }
 
     if (step.toVersion <= step.fromVersion) {
@@ -44,14 +45,14 @@ export class SaveGameMigrationRegistry {
     let version = extractSchemaVersion(working);
 
     if (version > targetVersion) {
-      throw new Error(`Cannot migrate save from newer schemaVersion ${version}`);
+      throw new Error(`Cannot migrate save from newer schemaVersion ${fmtNum(version)}`);
     }
 
     while (version < targetVersion) {
       const step = this.steps.get(version);
 
       if (!step) {
-        throw new Error(`No migration registered for schemaVersion ${version}`);
+        throw new Error(`No migration registered for schemaVersion ${fmtNum(version)}`);
       }
 
        
@@ -60,7 +61,7 @@ export class SaveGameMigrationRegistry {
 
       if (version !== step.toVersion) {
         throw new Error(
-          `Migration from ${step.fromVersion} returned schemaVersion ${version}; expected ${step.toVersion}`,
+          `Migration from ${fmtNum(step.fromVersion)} returned schemaVersion ${fmtNum(version)}; expected ${fmtNum(step.toVersion)}`,
         );
       }
     }

--- a/packages/engine/src/backend/src/saveLoad/saveManager.ts
+++ b/packages/engine/src/backend/src/saveLoad/saveManager.ts
@@ -8,6 +8,7 @@ import { saveGameEnvelopeSchema, saveGameSchema, type SaveGame } from './schemas
 import { type SaveGameMigrationRegistry } from './migrations/index.ts';
 import { validateCompanyWorld } from '../domain/validation.ts';
 import type { Company } from '../domain/entities.ts';
+import { fmtNum } from '../util/format.ts';
 
 /**
  * Optional configuration for {@link loadSaveGame}.
@@ -82,7 +83,9 @@ export async function loadSaveGame(filePath: string, options: LoadSaveGameOption
   const targetVersion = options.targetVersion ?? CURRENT_SAVE_SCHEMA_VERSION;
 
   if (envelope.schemaVersion > targetVersion) {
-    throw new Error(`Save file schemaVersion ${envelope.schemaVersion} exceeds supported version ${targetVersion}`);
+    throw new Error(
+      `Save file schemaVersion ${fmtNum(envelope.schemaVersion)} exceeds supported version ${fmtNum(targetVersion)}`,
+    );
   }
 
   if (envelope.schemaVersion === targetVersion) {

--- a/packages/engine/src/backend/src/services/workforce/market.ts
+++ b/packages/engine/src/backend/src/services/workforce/market.ts
@@ -11,6 +11,7 @@ import { HOURS_PER_DAY } from '../../constants/simConstants.ts';
 import type { WorkforceMarketScanConfig } from '../../config/workforce.ts';
 import { createRng, type RandomNumberGenerator } from '../../util/rng.ts';
 import { deterministicUuid } from '../../util/uuid.ts';
+import { fmtNum } from '../../util/format.ts';
 import {
   assignTraitStrength,
   applyTraitEffects,
@@ -245,13 +246,16 @@ export function generateCandidatePool(
 ): WorkforceMarketCandidate[] {
   const { worldSeed, structureId, scanCounter, poolSize, roles } = options;
   const skillUniverse = resolveSkillUniverse(roles);
-  const poolRng = createRng(worldSeed, `workforce:scan:${structureId}:${scanCounter}`);
+  const poolRng = createRng(
+    worldSeed,
+    `workforce:scan:${structureId}:${fmtNum(scanCounter)}`
+  );
 
   const candidates: WorkforceMarketCandidate[] = [];
 
   for (let index = 0; index < poolSize; index += 1) {
     const role = roles.length > 0 ? pickFrom(roles, poolRng) : undefined;
-    const candidateStreamId = `workforce:candidate:${structureId}:${scanCounter}:${index}`;
+    const candidateStreamId = `workforce:candidate:${structureId}:${fmtNum(scanCounter)}:${fmtNum(index)}`;
     const rng = createRng(worldSeed, candidateStreamId);
     const skills3 = buildSkillBundle(role, skillUniverse, rng);
     const traits = buildTraitSet(rng);

--- a/packages/engine/src/backend/src/services/workforce/raises.ts
+++ b/packages/engine/src/backend/src/services/workforce/raises.ts
@@ -1,5 +1,6 @@
 import { clamp01 } from '../../util/math.ts';
 import { createRng } from '../../util/rng.ts';
+import { fmtNum } from '../../util/format.ts';
 import type {
   Employee,
   EmployeeRaiseState,
@@ -57,7 +58,10 @@ function computeNextEligibleDay(
   currentSimDay: number,
   nextSequence: number,
 ): number {
-  const rng = createRng(employee.rngSeedUuid, `workforce:raise:${nextSequence}`);
+  const rng = createRng(
+    employee.rngSeedUuid,
+    `workforce:raise:${fmtNum(nextSequence)}`
+  );
   const jitter = Math.round((rng() * 2 - 1) * RAISE_JITTER_RANGE_DAYS);
   const baseTarget = currentSimDay + RAISE_COOLDOWN_DAYS + jitter;
   const minimum = currentSimDay + RAISE_MIN_EMPLOYMENT_DAYS;

--- a/packages/facade/src/transport/server.ts
+++ b/packages/facade/src/transport/server.ts
@@ -225,7 +225,8 @@ export async function createTransportServer(options: TransportServerOptions): Pr
   }
 
   const { port: resolvedPort } = address as AddressInfo;
-  const url = `http://${host}:${resolvedPort}`;
+  const resolvedPortLabel = String(resolvedPort);
+  const url = `http://${host}:${resolvedPortLabel}`;
 
   return {
     host,

--- a/packages/facade/tests/integration/transport/helpers.ts
+++ b/packages/facade/tests/integration/transport/helpers.ts
@@ -49,7 +49,8 @@ export async function createNamespaceClient(
   harness: TransportHarness,
   namespace: '/telemetry' | '/intents'
 ): Promise<Socket> {
-  const socket = createClient(`http://127.0.0.1:${harness.port}${namespace}`, {
+  const portSegment = String(harness.port);
+  const socket = createClient(`http://127.0.0.1:${portSegment}${namespace}`, {
     transports: ['websocket'],
     forceNew: true,
   });


### PR DESCRIPTION
## Summary
- route numeric template literal segments in perf scenarios, seed-to-harvest seeding, and workforce RNG stream identifiers through `fmtNum` to satisfy the strict template literal lint guardrail
- format save/load migration and schema-version error messages with `fmtNum` so version diagnostics remain lint-safe
- coerce façade transport URLs and test harness ports to strings and document the hotfix in the changelog

## SEC/TDD references
- SEC §1.0 Determinism & RNG isolation
- TDD §4.3 Logging & diagnostics hygiene

## Testing
- `pnpm i`
- `pnpm -r test`

## Deviations
- `pnpm -r lint` (fails: repository already contains thousands of lint violations outside HOTFIX-042 scope)
- `pnpm -r build` (fails: @wb/tools tsconfig requires `noEmit`/`emitDeclarationOnly` pairing before the compiler will proceed)

------
https://chatgpt.com/codex/tasks/task_e_68e82cda85cc8325aba6ec3ed7d0be43