### PR TITLE
Normalize CI perf guard override to 0-1 naming

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Unreleased — Blueprint Taxonomy v2
 
+- HOTFIX-042 (Task 0045): Renamed the CI performance guard-band override to `PERF_CI_WARNING_GUARD_BAND_01`, kept a deprecation
+  warning for the old `%` variable, and clarified in the perf harness docs that overrides must stay on the canonical 0–1 scale
+  so `wb-sim/no-engine-percent-identifiers` remains green across engine scripts.
 - HOTFIX-042 (Task 0044): Normalised engine humidity and filtration metrics to the
   canonical [0,1] scale by renaming percent-based identifiers, updating stubs,
   pipelines, schemas, and sensor validation, and refreshing tests/docs to satisfy

--- a/docs/engine/simulation-reporting.md
+++ b/docs/engine/simulation-reporting.md
@@ -49,7 +49,7 @@ If the command fails with `Cannot find module '@npmcli/config'`, npm handled the
 ## 6) CI performance budget harness
 
 - The same perf harness powers the CI gate: `pnpm --filter @wb/engine perf:ci` traces 10 k demo-world ticks, enforces ≥ 5 k ticks/min throughput and a 64 MiB heap ceiling, and surfaces 5 % guard-band warnings for near-regressions that demand manual investigation.
-- Override knobs for local experimentation are exposed via environment variables (`PERF_CI_TICK_COUNT`, `PERF_CI_MIN_TICKS_PER_MINUTE`, `PERF_CI_MAX_HEAP_MIB`, `PERF_CI_WARNING_GUARD_PERCENTAGE`). CI never relaxes the failure thresholds; guard-band warnings document the review window.
+- Override knobs for local experimentation are exposed via environment variables (`PERF_CI_TICK_COUNT`, `PERF_CI_MIN_TICKS_PER_MINUTE`, `PERF_CI_MAX_HEAP_MIB`, `PERF_CI_WARNING_GUARD_BAND_01`). CI never relaxes the failure thresholds; guard-band warnings document the review window and expect a normalised 0–1 override when customised.
 
 ## 5) JSON schema
 

--- a/packages/engine/scripts/perf/ciPerfCheck.ts
+++ b/packages/engine/scripts/perf/ciPerfCheck.ts
@@ -17,7 +17,14 @@ function parseThresholdOverrides(): Partial<PerfBudgetThresholds> {
   const overrides: Partial<PerfBudgetThresholds> = {};
   const throughput = process.env.PERF_CI_MIN_TICKS_PER_MINUTE;
   const heap = process.env.PERF_CI_MAX_HEAP_MIB;
-  const guard = process.env.PERF_CI_WARNING_GUARD_PERCENTAGE;
+  const guardBand01 =
+    process.env.PERF_CI_WARNING_GUARD_BAND_01 ?? process.env.PERF_CI_WARNING_GUARD_PERCENTAGE;
+
+  if (!process.env.PERF_CI_WARNING_GUARD_BAND_01 && process.env.PERF_CI_WARNING_GUARD_PERCENTAGE) {
+    console.warn(
+      'PERF_CI_WARNING_GUARD_PERCENTAGE is deprecated; use PERF_CI_WARNING_GUARD_BAND_01 (0-1 scale).'
+    );
+  }
 
   if (throughput) {
     const value = Number.parseFloat(throughput);
@@ -35,8 +42,8 @@ function parseThresholdOverrides(): Partial<PerfBudgetThresholds> {
     }
   }
 
-  if (guard) {
-    const value = Number.parseFloat(guard);
+  if (guardBand01) {
+    const value = Number.parseFloat(guardBand01);
 
     if (Number.isFinite(value) && value >= 0 && value < 1) {
       overrides.warningGuard01 = value;

--- a/packages/engine/tests/unit/perf/perfBudget.spec.ts
+++ b/packages/engine/tests/unit/perf/perfBudget.spec.ts
@@ -57,6 +57,11 @@ describe('evaluatePerfBudget', () => {
     expect(evaluation.warnings).toHaveLength(0);
   });
 
+  it('exposes guard-band thresholds on the 0-1 scale', () => {
+    expect(PERF_CI_THRESHOLDS.warningGuard01).toBeGreaterThanOrEqual(0);
+    expect(PERF_CI_THRESHOLDS.warningGuard01).toBeLessThan(1);
+  });
+
   it('emits warnings when metrics are inside the guard band', () => {
     const averageDurationNs = Math.round((60 * 1_000_000_000) / 5_100);
     const result = createPerfHarnessResult({


### PR DESCRIPTION
## Summary
- rename the CI performance guard-band override to `PERF_CI_WARNING_GUARD_BAND_01` and emit a warning when the legacy `%` variable is used
- document the new override name in the perf harness guide and changelog, clarifying the expected 0–1 scale
- add a perf budget unit test that asserts the guard-band threshold stays within the canonical 0–1 range

## Testing
- pnpm --filter @wb/engine test
- pnpm lint *(fails: existing workspace lint violations outside this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e846d32c1c83259cbc6087ff3f0f1a