### PR TITLE
feat(task:0045): replace-dynamic-delete-operations

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Unreleased — Blueprint Taxonomy v2
 
+- HOTFIX-042 (Task 0045): Replaced dynamic runtime context deletions in the device effects,
+  irrigation/nutrient, sensor, and workforce pipelines with deterministic undefined resets so
+  `@typescript-eslint/no-dynamic-delete` stays green without changing tick outputs.
 - HOTFIX-042 (Task 0045): Renamed the CI performance guard-band override to `PERF_CI_WARNING_GUARD_BAND_01`, kept a deprecation
   warning for the old `%` variable, and clarified in the perf harness docs that overrides must stay on the canonical 0–1 scale
   so `wb-sim/no-engine-percent-identifiers` remains green across engine scripts.

--- a/packages/engine/src/backend/src/engine/pipeline/applyDeviceEffects.ts
+++ b/packages/engine/src/backend/src/engine/pipeline/applyDeviceEffects.ts
@@ -77,7 +77,11 @@ export function getDeviceEffectsRuntime(
 }
 
 export function clearDeviceEffectsRuntime(ctx: EngineRunContext): void {
-  delete (ctx as DeviceEffectsCarrier)[DEVICE_EFFECTS_CONTEXT_KEY];
+  const carrier = ctx as DeviceEffectsCarrier;
+
+  if (DEVICE_EFFECTS_CONTEXT_KEY in carrier) {
+    carrier[DEVICE_EFFECTS_CONTEXT_KEY] = undefined;
+  }
 }
 
 export function applyDeviceEffects(world: SimulationWorld, ctx: EngineRunContext): SimulationWorld {

--- a/packages/engine/src/backend/src/engine/pipeline/applyIrrigationAndNutrients.ts
+++ b/packages/engine/src/backend/src/engine/pipeline/applyIrrigationAndNutrients.ts
@@ -52,7 +52,11 @@ export function getIrrigationNutrientsRuntime(
 }
 
 export function clearIrrigationNutrientsRuntime(ctx: EngineRunContext): void {
-  delete (ctx as IrrigationRuntimeCarrier)[IRRIGATION_RUNTIME_CONTEXT_KEY];
+  const carrier = ctx as IrrigationRuntimeCarrier;
+
+  if (IRRIGATION_RUNTIME_CONTEXT_KEY in carrier) {
+    carrier[IRRIGATION_RUNTIME_CONTEXT_KEY] = undefined;
+  }
 }
 
 const DEFAULT_LEACHING_RATIO = 0.1;

--- a/packages/engine/src/backend/src/engine/pipeline/applySensors.ts
+++ b/packages/engine/src/backend/src/engine/pipeline/applySensors.ts
@@ -43,7 +43,11 @@ export function getSensorReadingsRuntime(ctx: EngineRunContext): SensorReadingsR
 }
 
 export function clearSensorReadingsRuntime(ctx: EngineRunContext): void {
-  delete (ctx as SensorRuntimeCarrier)[SENSOR_READINGS_CONTEXT_KEY];
+  const carrier = ctx as SensorRuntimeCarrier;
+
+  if (SENSOR_READINGS_CONTEXT_KEY in carrier) {
+    carrier[SENSOR_READINGS_CONTEXT_KEY] = undefined;
+  }
 }
 
 function emitDiagnostic(ctx: EngineRunContext, diagnostic: EngineDiagnostic): void {

--- a/packages/engine/src/backend/src/workforce/index.ts
+++ b/packages/engine/src/backend/src/workforce/index.ts
@@ -87,7 +87,11 @@ export function getWorkforceRuntime(ctx: EngineRunContext): WorkforceRuntime | u
 }
 
 export function clearWorkforceRuntime(ctx: EngineRunContext): void {
-  delete (ctx as WorkforceRuntimeCarrier)[WORKFORCE_RUNTIME_CONTEXT_KEY];
+  const carrier = ctx as WorkforceRuntimeCarrier;
+
+  if (WORKFORCE_RUNTIME_CONTEXT_KEY in carrier) {
+    carrier[WORKFORCE_RUNTIME_CONTEXT_KEY] = undefined;
+  }
 }
 
 function resolveLocationIndexTable(ctx: EngineRunContext): LocationIndexTable {
@@ -107,12 +111,16 @@ export function consumeWorkforcePayrollAccrual(ctx: EngineRunContext): Workforce
     return undefined;
   }
 
-  delete carrier[WORKFORCE_PAYROLL_CONTEXT_KEY];
+  carrier[WORKFORCE_PAYROLL_CONTEXT_KEY] = undefined;
   return snapshot;
 }
 
 export function clearWorkforcePayrollAccrual(ctx: EngineRunContext): void {
-  delete (ctx as PayrollContextCarrier)[WORKFORCE_PAYROLL_CONTEXT_KEY];
+  const carrier = ctx as PayrollContextCarrier;
+
+  if (WORKFORCE_PAYROLL_CONTEXT_KEY in carrier) {
+    carrier[WORKFORCE_PAYROLL_CONTEXT_KEY] = undefined;
+  }
 }
 
 function recordWorkforceMarketCharge(ctx: EngineRunContext, charge: WorkforceMarketCharge): void {
@@ -129,7 +137,7 @@ export function consumeWorkforceMarketCharges(ctx: EngineRunContext): readonly W
     return undefined;
   }
 
-  delete carrier[WORKFORCE_MARKET_CHARGES_CONTEXT_KEY];
+  carrier[WORKFORCE_MARKET_CHARGES_CONTEXT_KEY] = undefined;
   return charges;
 }
 
@@ -137,8 +145,8 @@ function extractWorkforceIntents(ctx: EngineRunContext): readonly WorkforceInten
   const carrier = ctx as WorkforceIntentCarrier;
   const intents = carrier.workforceIntents ?? [];
 
-  if (carrier.workforceIntents) {
-    delete carrier.workforceIntents;
+  if ('workforceIntents' in carrier) {
+    carrier.workforceIntents = undefined;
   }
 
   return intents;


### PR DESCRIPTION
## Summary
- replace dynamic runtime deletions in applyDeviceEffects, applyIrrigationAndNutrients, and applySensors with deterministic undefined resets so stage runtimes stay lint-compliant without mutating context shapes
- mirror the same undefined-reset pattern for workforce runtime, payroll, market charge, and intent carriers to remove the last dynamic deletes under workforce entry points
- document the immutable context clearing strategy in the changelog for HOTFIX-042 Task 0045

## SEC/TDD References
- SEC §1 (core invariants & determinism guardrails)
- SEC §4.2 (canonical 9-phase pipeline ordering)
- TDD §7 (pipeline instrumentation & phase checklist)

## Testing
- pnpm i
- pnpm -r test
- pnpm -r lint *(fails: existing workspace lint backlog; engine package reports legacy violations unrelated to this patch)*
- pnpm -r build *(fails: existing TypeScript errors in @wb/tools build script prior to this change)*

## Deviations
- Workspace lint/build targets remain red due to longstanding issues outside the modified modules; the patch keeps scope constrained to removing dynamic delete usage as requested.

------
https://chatgpt.com/codex/tasks/task_e_68e84a9c59a08325b7acb1b6b40a560d