### PR TITLE
feat(task:0047): remove-impossible-branches-and-optional-chain-misuse

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Unreleased — Blueprint Taxonomy v2
 
+- HOTFIX-042 (Task 0047): Removed redundant optional chaining in the irrigation
+  pipeline and workforce payroll accumulator so deterministic records are
+  treated as required data, and clarified p95 wait computations to avoid
+  impossible fallbacks flagged by the lint guards.
 - HOTFIX-042 (Task 0046): Normalised engine, transport, and tooling catch handlers
   to capture `unknown`, added a shared error normaliser so non-`Error` values are
   wrapped before propagation, guarded telemetry/intent acknowledgements against

--- a/packages/engine/src/backend/src/engine/pipeline/applyIrrigationAndNutrients.ts
+++ b/packages/engine/src/backend/src/engine/pipeline/applyIrrigationAndNutrients.ts
@@ -77,11 +77,11 @@ function createBufferInputs(
   nutrients_mg: Record<string, number>,
 ): NutrientBufferInputs {
   const keys = new Set<string>([
-    ...Object.keys(bufferState ?? {}),
-    ...Object.keys(nutrients_mg ?? {}),
+    ...Object.keys(bufferState),
+    ...Object.keys(nutrients_mg),
   ]);
   const capacity_mg: Record<string, number> = {};
-  const buffer_mg: Record<string, number> = normalizeBufferState(bufferState ?? {});
+  const buffer_mg: Record<string, number> = normalizeBufferState(bufferState);
 
   for (const key of keys) {
     capacity_mg[key] = Number.MAX_SAFE_INTEGER;
@@ -181,7 +181,7 @@ export function applyIrrigationAndNutrients(
           events: zoneEvents,
           nutrientSource: 'solution',
         };
-        const bufferState = zone.nutrientBuffer_mg ?? {};
+        const bufferState = zone.nutrientBuffer_mg;
         const outputs = irrigationStub.computeEffect(inputs, bufferState, dt_h);
 
         if (outputs.water_L <= 0 && Object.keys(outputs.nutrients_mg).length === 0) {

--- a/packages/engine/src/backend/src/workforce/index.ts
+++ b/packages/engine/src/backend/src/workforce/index.ts
@@ -166,7 +166,7 @@ function createSnapshot(
   const utilisation = capacityMinutes > 0 ? clamp01((baseMinutes + overtimeMinutes) / capacityMinutes) : 0;
   const sortedWaits = [...waitTimes].sort((a, b) => a - b);
   const index = sortedWaits.length > 0 ? Math.max(0, Math.ceil(sortedWaits.length * 0.95) - 1) : 0;
-  const p95Wait = sortedWaits.length > 0 ? sortedWaits[index] ?? 0 : 0;
+  const p95Wait = sortedWaits.length > 0 ? sortedWaits[index] : 0;
 
   return {
     simTimeHours,
@@ -565,7 +565,7 @@ export function applyWorkforce(world: SimulationWorld, ctx: EngineRunContext): S
     workforceState.taskDefinitions.map((definition) => [definition.taskCode, definition]),
   );
 
-  const previousPayroll = workforceState.payroll ?? createEmptyPayrollState(currentSimDay);
+  const previousPayroll = workforceState.payroll;
   let payrollDayIndex = previousPayroll.dayIndex;
   let payrollTotals = clonePayrollTotals(previousPayroll.totals);
   let structurePayroll = cloneStructurePayroll(previousPayroll.byStructure);


### PR DESCRIPTION
## Summary
- tighten the irrigation pipeline buffer handling by treating zone nutrient inventories and stub outputs as required data structures, removing redundant optional fallbacks
- streamline workforce KPI and payroll handling by relying on the deterministic state branch instead of impossible nullish guards, and log the cleanup in the changelog

## Touched SEC/TDD references
- SEC §4.2 Tick Pipeline ordering; SEC §7 Irrigation, Nutrients & Cultivation; SEC §10 Workforce & HR
- TDD §5a Workforce Schema Coverage; TDD §7 Tick Pipeline order; TDD §9 Cultivation Methods on Zones

## Test evidence
- `pnpm -r test`
- `pnpm -r lint` *(fails: pre-existing eslint violations across @wb/engine)*
- `pnpm -r build` *(fails: @wb/tools tsconfig requires allowImportingTsExtensions w/ noEmit or emitDeclarationOnly)*

## Contract deviations
- Workspace lint suite still fails with legacy violations unrelated to this hotfix.
- Workspace build fails because the tools package tsconfig violates TS5096; unchanged by this hotfix.


------
https://chatgpt.com/codex/tasks/task_e_68e8547894e4832583c0eac27f5a61d5