### PR TITLE
feat(task:0050): stubs-safety-pass

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### Unreleased — Blueprint Taxonomy v2
 
+- HOTFIX-042 (Task 0050): Hardened the CO₂ injector stub by replacing non-null
+  assertions with explicit guard helpers, normalising optional bounds before
+  clamping, and keeping the deterministic capacity logic intact for lint
+  conformance.
+
 - HOTFIX-042 (Task 0049): Removed redundant numeric coercions, `as` assertions,
   and non-null assertions across the perf harness, stubs, workforce scheduler,
   and façade tests by replacing them with schema parsing, explicit guards, and


### PR DESCRIPTION
## Summary
- replace the CO₂ injector stub’s non-null assertions with explicit guard helpers so optional readings are validated before use.
- normalise optional target, ambient, and hysteresis bounds to preserve the deterministic clamping behaviour and keep RNG-free outputs pure.
- document the safety hardening in the CHANGELOG under the Unreleased section.

## References
- SEC §1 (Core Invariants — deterministic guardrails)【F:docs/SEC.md†L80-L89】
- TDD §9a (Stub Tests & Test Vectors expectations)【F:docs/TDD.md†L290-L323】

## Testing
- `pnpm i`
- `pnpm -r test`
- `pnpm -r lint` *(fails: existing workspace lint debt — 536 problems across legacy modules)*【fc2382†L1-L84】
- `pnpm -r build` *(fails: packages/tools TypeScript config requires noEmit/emitDeclarationOnly)*【913ca0†L1-L7】

## Deviations
- Workspace lint (`pnpm -r lint`) still fails because of pre-existing ESLint debt unrelated to the CO₂ stub edits.【fc2382†L1-L84】
- Workspace build (`pnpm -r build`) fails due to the TypeScript compiler constraint in `packages/tools/tsconfig.json`; the task scope does not extend to that package.【913ca0†L1-L7】

------
https://chatgpt.com/codex/tasks/task_e_68e894e8cf7c83259245ce548c71b476