### PR TITLE
feat(task:0051): facade-transport-promise-and-async-safety

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### Unreleased — Blueprint Taxonomy v2
 
+- HOTFIX-042 (Task 0051): Hardened the façade transport server startup to reject
+  listener errors deterministically, normalised shutdown/startup catch handlers
+  to wrap unknown failures, and updated the integration harness teardown to
+  surface HTTP close errors so async safety lint guards stay satisfied.
+
 - HOTFIX-042 (Task 0050): Hardened the CO₂ injector stub by replacing non-null
   assertions with explicit guard helpers, normalising optional bounds before
   clamping, and keeping the deterministic capacity logic intact for lint

--- a/packages/facade/src/transport/devServer.ts
+++ b/packages/facade/src/transport/devServer.ts
@@ -5,6 +5,10 @@ const host = process.env.FACADE_TRANSPORT_HOST ?? '127.0.0.1';
 const port = Number.parseInt(process.env.FACADE_TRANSPORT_PORT ?? '7101', 10);
 const corsOrigin = process.env.FACADE_TRANSPORT_CORS_ORIGIN ?? 'http://localhost:5173';
 
+function ensureError(candidate: unknown): Error {
+  return candidate instanceof Error ? candidate : new Error(String(candidate));
+}
+
 async function main(): Promise<void> {
   if (!Number.isInteger(port) || port <= 0) {
     throw new Error('FACADE_TRANSPORT_PORT must be a positive integer.');
@@ -22,17 +26,27 @@ async function main(): Promise<void> {
   console.info('Facade transport server listening on %s', server.url);
   console.info('Health endpoint available at %s/healthz', server.url);
 
-  const handleShutdown = async () => {
+  const initiateShutdown = () => {
     console.info('\nShutting down transport server...');
-    await server.close();
-    process.exit(0);
+
+    void (async () => {
+      try {
+        await server.close();
+        process.exit(0);
+      } catch (error) {
+        const normalisedError = ensureError(error);
+        console.error('Failed to close transport server:', normalisedError);
+        process.exit(1);
+      }
+    })();
   };
 
-  process.once('SIGINT', handleShutdown);
-  process.once('SIGTERM', handleShutdown);
+  process.once('SIGINT', initiateShutdown);
+  process.once('SIGTERM', initiateShutdown);
 }
 
-main().catch((error) => {
-  console.error('Failed to start transport server:', error);
+main().catch((error: unknown) => {
+  const normalisedError = ensureError(error);
+  console.error('Failed to start transport server:', normalisedError);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- Wrap the façade transport server bootstrap in an error-aware promise that closes the Socket.IO adapter and HTTP listener before rethrowing normalised errors, keeping startup deterministic. 【F:packages/facade/src/transport/server.ts†L51-L59】【F:packages/facade/src/transport/server.ts†L207-L260】
- Ensure the dev transport entrypoint responds to shutdown signals via awaited closures and converts unknown failures to `Error` instances so lint promise rules stay satisfied. 【F:packages/facade/src/transport/devServer.ts†L8-L52】
- Harden the integration transport harness to surface listen/close failures with consistent error wrapping, preventing swallowed promise rejections in tests. 【F:packages/facade/tests/integration/transport/helpers.ts†L9-L64】
- Document the hotfix in the project changelog. 【F:docs/CHANGELOG.md†L3-L8】

## SEC/TDD References
- SEC §11.3 — Transport policy separation and deterministic acknowledgements.
- TDD §11 — Telemetry read-only transport separation and façade transport coverage.

## Testing
- `pnpm i` 【96a3bf†L1-L12】
- `pnpm -r test` 【231130†L1-L3】
- `pnpm --filter @wb/facade test` 【9b0894†L1-L41】
- `pnpm -r lint` *(fails: workspace already has outstanding ESLint violations outside this task scope)* 【669ff5†L1-L53】
- `pnpm -r build` *(fails: tools package tsconfig requires baseline fix)* 【b945b1†L1-L7】【757baa†L1-L10】

## Deviations
- Workspace lint/build remain red because of pre-existing issues in other packages; no new lint errors were introduced in the touched façade transport files.

------
https://chatgpt.com/codex/tasks/task_e_68e8996a0ac8832595f1b72d35b1e490