### PR TITLE
feat(task:0053): perf-scenarios-and-budget-normalization

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### Unreleased — Blueprint Taxonomy v2
 
+- HOTFIX-042 (Task 0053): Normalised perf scenario device defaults by hoisting
+  the carbon filter duty cycle and maintenance service visit duration into
+  shared constants, wiring perf harness instantiation through the 0–1 naming
+  scheme so lint checks stop flagging inline magic numbers.
+
 - HOTFIX-042 (Task 0052): Hoisted workforce identity gender roll thresholds into
   shared constants, hardened hiring/workforce telemetry emitters to guard topics
   and clone payloads before dispatch, and added unit coverage confirming the

--- a/packages/engine/src/backend/src/constants/perfHarness.ts
+++ b/packages/engine/src/backend/src/constants/perfHarness.ts
@@ -12,6 +12,9 @@ export const PERF_HARNESS_EXHAUST_FAN_DUTY01 = 0.9 as const;
 /** Fallback device quality applied when a blueprint omits explicit ratings. */
 export const PERF_HARNESS_DEVICE_QUALITY_BASELINE01 = 0.85 as const;
 
+/** Duty cycle applied to passive filtration that runs continuously in perf scenarios. */
+export const PERF_HARNESS_CARBON_FILTER_DUTY01 = 1 as const;
+
 /** Default maintenance interval in days when blueprint data is absent. */
 export const PERF_HARNESS_MAINTENANCE_INTERVAL_DAYS = 90 as const;
 
@@ -26,6 +29,9 @@ export const PERF_HARNESS_MAINTENANCE_RESTORE01 = 0.3 as const;
 
 /** Fallback efficiency applied when blueprints do not specify a rating. */
 export const PERF_HARNESS_DEVICE_EFFICIENCY_BASELINE01 = 0.75 as const;
+
+/** Default hours allocated for a maintenance service visit when data is missing. */
+export const PERF_HARNESS_MAINTENANCE_SERVICE_HOURS = 1 as const;
 
 /** Number of cloned grow zones created in the target perf scenario. */
 export const PERF_HARNESS_ZONE_CLONE_COUNT = 5 as const;

--- a/packages/engine/src/backend/src/engine/perf/perfScenarios.ts
+++ b/packages/engine/src/backend/src/engine/perf/perfScenarios.ts
@@ -13,12 +13,14 @@ import { fmtNum } from '../../util/format.ts';
 import { HOURS_PER_DAY } from '../../constants/simConstants.ts';
 import {
   PERF_HARNESS_COOL_AIR_DUTY01,
+  PERF_HARNESS_CARBON_FILTER_DUTY01,
   PERF_HARNESS_DEVICE_EFFICIENCY_BASELINE01,
   PERF_HARNESS_DEVICE_LIFETIME_HOURS,
   PERF_HARNESS_DEVICE_QUALITY_BASELINE01,
   PERF_HARNESS_EXHAUST_FAN_DUTY01,
   PERF_HARNESS_LED_VEG_LIGHT_DUTY01,
   PERF_HARNESS_MAINTENANCE_INTERVAL_DAYS,
+  PERF_HARNESS_MAINTENANCE_SERVICE_HOURS,
   PERF_HARNESS_MAINTENANCE_RESTORE01,
   PERF_HARNESS_MAINTENANCE_THRESHOLD01,
   PERF_HARNESS_ZONE_CLONE_COUNT
@@ -41,7 +43,7 @@ const BASE_DEVICE_BLUEPRINTS: readonly DeviceBlueprintEntry[] = [
   { blueprint: parseDeviceBlueprint(coolAirSplitBlueprint), dutyCycle01: PERF_HARNESS_COOL_AIR_DUTY01 },
   { blueprint: parseDeviceBlueprint(ledVegLightBlueprint), dutyCycle01: PERF_HARNESS_LED_VEG_LIGHT_DUTY01 },
   { blueprint: parseDeviceBlueprint(exhaustFanBlueprint), dutyCycle01: PERF_HARNESS_EXHAUST_FAN_DUTY01 },
-  { blueprint: parseDeviceBlueprint(carbonFilterBlueprint), dutyCycle01: 1 }
+  { blueprint: parseDeviceBlueprint(carbonFilterBlueprint), dutyCycle01: PERF_HARNESS_CARBON_FILTER_DUTY01 }
 ];
 
 interface DevicePriceEntry {
@@ -124,7 +126,8 @@ function instantiateZoneDevice(
   const priceEntry = resolvePriceEntry(blueprint);
   const maintenanceIntervalDays =
     resolveMaintenanceNumber(blueprint, 'intervalDays') ?? PERF_HARNESS_MAINTENANCE_INTERVAL_DAYS;
-  const maintenanceServiceHours = resolveMaintenanceNumber(blueprint, 'hoursPerService') ?? 1;
+  const maintenanceServiceHours =
+    resolveMaintenanceNumber(blueprint, 'hoursPerService') ?? PERF_HARNESS_MAINTENANCE_SERVICE_HOURS;
 
   const maintenance = priceEntry
     ? {


### PR DESCRIPTION
## Summary of changes
- Hoisted passive filtration duty cycle and maintenance service-hour defaults into the perf harness constant registry so perf scenarios stay on the documented 0–1 scale.
- Updated perf scenario cloning to consume the new constants for device duty cycles and maintenance policies, eliminating the remaining inline literals.
- Recorded the hotfix in the changelog under the Unreleased section.

## Touched SEC/TDD references
- SEC §6 — Quality & Condition Scales (0–1 naming, percent handling)
- TDD §1 — Canonical Constants (centralising shared thresholds)

## Test evidence
- `pnpm i`
- `pnpm -r test`
- `pnpm -r lint` *(fails: existing lint debt across engine/tests packages)*
- `pnpm -r build` *(fails: existing TypeScript errors in @wb/tools build)*

## Deviations from contracts
- Workspace lint (`pnpm -r lint`) continues to fail with the pre-existing 538 lint errors reported in @wb/engine. Fixing those is outside the scope of Task 0053.
- Workspace build (`pnpm -r build`) fails because @wb/tools’ TypeScript build already exits with status 2; the task does not modify that package.

------
https://chatgpt.com/codex/tasks/task_e_68e8a4787be4832592e2936c497a3d61