### PR TITLE
feat(task:0054): shared-determinism-hash-nullish-assignment

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Unreleased — Blueprint Taxonomy v2
 
+- HOTFIX-042 (Task 0054): Updated the shared determinism hash helper to cache
+  the wasm API via nullish coalescing assignment so falsy-but-valid promises
+  persist and the prefer-nullish-coalescing lint stays satisfied.
+
 - HOTFIX-042 (Task 0053): Normalised perf scenario device defaults by hoisting
   the carbon filter duty cycle and maintenance service visit duration into
   shared constants, wiring perf harness instantiation through the 0–1 naming

--- a/packages/engine/src/shared/determinism/hash.ts
+++ b/packages/engine/src/shared/determinism/hash.ts
@@ -6,9 +6,7 @@ const SECONDARY_SEED = BigInt('0x9e3779b97f4a7c15');
 let hashApiPromise: Promise<Awaited<ReturnType<typeof xxhash>>> | undefined;
 
 async function getHashApi() {
-  if (!hashApiPromise) {
-    hashApiPromise = xxhash();
-  }
+  hashApiPromise ??= xxhash();
   return hashApiPromise;
 }
 


### PR DESCRIPTION
## Summary
- replace the cached xxhash wasm initialisation guard in `hashCanonicalJson` with nullish coalescing assignment so falsy-but-valid promise references persist.
- document the determinism helper adjustment in the Unreleased changelog entry for HOTFIX-042 task 0054.

## SEC/TDD References
- SEC v0.2.1 §2 (Determinism helpers must avoid falsy short-circuiting that changes hashing behaviour)
- TDD §0.2 (Determinism principle for shared helpers)

## Test Evidence
- `pnpm i`
- `pnpm -r test`
- `pnpm -r lint` *(fails: engine package has 500+ pre-existing lint violations — prefer-nullish-coalescing, no-magic-numbers, etc.)*
- `pnpm -r build` *(fails: @wb/tools tsconfig requires allowImportingTsExtensions with noEmit/emitDeclarationOnly)*

## Contract Deviations
- Unable to produce a green `pnpm -r lint` run because the engine workspace currently reports hundreds of unrelated lint violations.
- Unable to produce a green `pnpm -r build` because @wb/tools fails its TypeScript compile due to a tsconfig option conflict.

------
https://chatgpt.com/codex/tasks/task_e_68e8a7ec0b788325b4cf1268b5406246