### PR TITLE
feat(task:0055): ci-temporary-warning-budget-guard

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### Unreleased — Blueprint Taxonomy v2
 
+- HOTFIX-042 (Task 0055): Added a workspace `lint:strict` script that pipes `pnpm -r lint`
+  through `tools/check-warn-budget.mjs` to enforce the temporary 30-warning ESLint budget
+  in CI, and documented the guard plus retirement plan in the contributor handbook so
+  the backlog burn-down stays visible.
+
 - HOTFIX-042 (Task 0054): Updated the shared determinism hash helper to cache
   the wasm API via nullish coalescing assignment so falsy-but-valid promises
   persist and the prefer-nullish-coalescing lint stays satisfied.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -20,6 +20,6 @@
 ## Magic number guardrail
 
 - Numeric literals in production TypeScript must live in `packages/engine/src/backend/src/constants/**` (or re-export from `simConstants.ts`).
-- ESLint enforces the `@typescript-eslint/no-magic-numbers` rule with a narrow allowlist. Lint warnings fail CI because `pnpm -r lint` runs with `--max-warnings=0`.
+- ESLint enforces the `@typescript-eslint/no-magic-numbers` rule with a narrow allowlist. A temporary `pnpm run lint:strict` guard runs `pnpm -r lint` through `tools/check-warn-budget.mjs` and fails CI when combined warnings exceed the 30-warning budget while the backlog is burned down; once the warning count returns to zero the helper will be retired as noted in HOTFIX-042.
 - Run `pnpm scan:magic` to execute the ripgrep audit locally. The scan ignores tests, schemas, and the constants directory and fails when new literals slip through.
 - When introducing a new threshold or default, document it in the appropriate constants module and update `/docs/constants/README.md`.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "pnpm -r build",
     "typecheck": "pnpm -w tsc -p packages/engine/tsconfig.spec.json --noEmit",
     "lint": "pnpm exec eslint --max-warnings 0 \"packages/**/*.{ts,tsx}\"",
+    "lint:strict": "node ./tools/check-warn-budget.mjs --budget 30 -- pnpm -r --workspace-concurrency=1 lint -- --max-warnings=2147483647 --format json",
     "test": "pnpm -r test",
     "test:imports": "pnpm --filter @wb/engine test:imports",
     "lint:imports": "pnpm exec eslint --max-warnings=0 --config tools/eslint/import-guard.config.js packages tools",

--- a/packages/tools/tests/checkWarnBudget.test.ts
+++ b/packages/tools/tests/checkWarnBudget.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import {
+  countWarningsFromReports,
+  extractLintReportsFromOutput,
+  parseCliArguments
+} from '../../../tools/check-warn-budget.mjs';
+
+describe('check-warn-budget helper', () => {
+  it('extracts JSON arrays from lint output with interleaved logs', () => {
+    const sampleOutput = `Scope: 4 of 4 packages\n` +
+      `{"some":"log"}\n` +
+      `[{
+        "filePath": "packages/engine/src/foo.ts",
+        "warningCount": 2,
+        "messages": [
+          { "ruleId": "no-console", "severity": 1 },
+          { "ruleId": "no-alert", "severity": 1 }
+        ]
+      }]\n` +
+      `Progress: done\n` +
+      `[{"filePath": "packages/facade/src/bar.ts", "warningCount": 1, "messages": []}]\n`;
+
+    const reports = extractLintReportsFromOutput(sampleOutput);
+    expect(reports).toHaveLength(2);
+    expect(reports[0][0]?.filePath).toBe('packages/engine/src/foo.ts');
+    expect(reports[1][0]?.filePath).toBe('packages/facade/src/bar.ts');
+  });
+
+  it('counts warnings using warningCount metadata when available', () => {
+    const reports = [
+      [
+        { filePath: 'a.ts', warningCount: 1, messages: [] },
+        { filePath: 'b.ts', warningCount: 0, messages: [] }
+      ],
+      [
+        { filePath: 'c.ts', warningCount: 2, messages: [] }
+      ]
+    ];
+
+    expect(countWarningsFromReports(reports)).toBe(3);
+  });
+
+  it('counts warning messages when warningCount is missing', () => {
+    const reports = [
+      [
+        {
+          filePath: 'missing.ts',
+          messages: [
+            { ruleId: 'no-console', severity: 1 },
+            { ruleId: 'no-unused-vars', severity: 2 },
+            { ruleId: 'curly', severity: 1 }
+          ]
+        }
+      ]
+    ];
+
+    expect(countWarningsFromReports(reports)).toBe(2);
+  });
+
+  it('parses CLI arguments with defaults when no command override is supplied', () => {
+    const parsed = parseCliArguments(['--budget', '25']);
+    expect(parsed.budget).toBe(25);
+    expect(parsed.command.command).toBe('pnpm');
+    expect(parsed.command.args).toContain('lint');
+  });
+});

--- a/tools/check-warn-budget.mjs
+++ b/tools/check-warn-budget.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import process from 'node:process';
+
+const DEFAULT_BUDGET = 30;
+const DEFAULT_COMMAND = {
+  command: 'pnpm',
+  args: [
+    '-r',
+    '--workspace-concurrency=1',
+    'lint',
+    '--',
+    '--max-warnings=2147483647',
+    '--format',
+    'json'
+  ]
+};
+
+export function extractLintReportsFromOutput(output) {
+  let capturing = false;
+  let depth = 0;
+  let current = '';
+  const segments = [];
+
+  for (const char of output) {
+    if (!capturing) {
+      if (char === '[') {
+        capturing = true;
+        depth = 1;
+        current = '[';
+      }
+      continue;
+    }
+
+    current += char;
+    if (char === '[') {
+      depth += 1;
+    } else if (char === ']') {
+      depth -= 1;
+      if (depth === 0) {
+        segments.push(current);
+        capturing = false;
+        current = '';
+      }
+    }
+  }
+
+  return segments.map((segment) => {
+    try {
+      return JSON.parse(segment);
+    } catch (error) {
+      const parsingError = new Error('Failed to parse ESLint JSON output segment');
+      parsingError.cause = error;
+      throw parsingError;
+    }
+  });
+}
+
+export function countWarningsFromReports(reportGroups) {
+  return reportGroups
+    .flat()
+    .reduce((total, report) => {
+      if (typeof report.warningCount === 'number') {
+        return total + report.warningCount;
+      }
+      const messages = Array.isArray(report.messages) ? report.messages : [];
+      const warningMessages = messages.filter((message) => message && message.severity === 1);
+      return total + warningMessages.length;
+    }, 0);
+}
+
+export function parseCliArguments(argv) {
+  let budget = DEFAULT_BUDGET;
+  let commandTokens = null;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === '--') {
+      commandTokens = argv.slice(index + 1);
+      break;
+    }
+
+    if (token === '--help' || token === '-h') {
+      return { showHelp: true };
+    }
+
+    if (token === '--budget' || token === '-b') {
+      const next = argv[index + 1];
+      if (typeof next === 'undefined') {
+        throw new Error('Missing value for --budget flag');
+      }
+      index += 1;
+      budget = Number.parseInt(next, 10);
+      continue;
+    }
+
+    if (token.startsWith('--budget=')) {
+      budget = Number.parseInt(token.split('=')[1] ?? '', 10);
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${token}`);
+  }
+
+  if (!Number.isInteger(budget) || budget < 0) {
+    throw new Error('Budget must be a non-negative integer');
+  }
+
+  if (commandTokens === null || commandTokens.length === 0) {
+    return {
+      budget,
+      command: DEFAULT_COMMAND
+    };
+  }
+
+  return {
+    budget,
+    command: {
+      command: commandTokens[0],
+      args: commandTokens.slice(1)
+    }
+  };
+}
+
+export async function runBudgetGuard({ budget, command }) {
+  const child = spawn(command.command, command.args, {
+    stdio: ['inherit', 'pipe', 'pipe']
+  });
+
+  let stdout = '';
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', (chunk) => {
+    stdout += chunk;
+    process.stdout.write(chunk);
+  });
+
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', (chunk) => {
+    process.stderr.write(chunk);
+  });
+
+  const exitCode = await new Promise((resolve, reject) => {
+    child.on('error', (error) => reject(error));
+    child.on('close', (code, signal) => {
+      if (signal) {
+        resolve(1);
+        return;
+      }
+      resolve(code ?? 0);
+    });
+  });
+
+  if (exitCode !== 0) {
+    return exitCode;
+  }
+
+  const reports = extractLintReportsFromOutput(stdout);
+  const warningCount = countWarningsFromReports(reports);
+  const budgetMessage = `[lint:strict] ESLint warnings: ${warningCount} / ${budget}`;
+  if (warningCount > budget) {
+    process.stderr.write(`\n${budgetMessage} — exceeds temporary budget.\n`);
+    return 1;
+  }
+
+  process.stdout.write(`\n${budgetMessage} — within budget.\n`);
+  return 0;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage: node tools/check-warn-budget.mjs [--budget <number>] [-- command ...]\n`);
+  process.stdout.write(`\nRuns the provided lint command (defaults to "pnpm -r lint") and fails when ESLint warnings exceed the budget.\n`);
+}
+
+async function cli() {
+  try {
+    const parsed = parseCliArguments(process.argv.slice(2));
+    if (parsed.showHelp) {
+      printHelp();
+      return;
+    }
+    const exitCode = await runBudgetGuard(parsed);
+    process.exitCode = exitCode;
+  } catch (error) {
+    process.stderr.write(`check-warn-budget: ${(error && error.message) || 'Unknown error'}\n`);
+    process.exitCode = 1;
+  }
+}
+
+const isDirectExecution = process.argv[1] && process.argv[1] === fileURLToPath(import.meta.url);
+if (isDirectExecution) {
+  cli();
+}


### PR DESCRIPTION
## Summary
- add a workspace `lint:strict` script that routes `pnpm -r lint` through the new `tools/check-warn-budget.mjs` helper so CI fails when warning totals exceed the temporary 30-warning budget
- cover the helper with vitest to lock down JSON report parsing, warning aggregation, and CLI argument handling
- document the temporary guard plus retirement plan in the contributor handbook and changelog so CI expectations stay aligned

## Touched SEC/TDD references
- TDD §14 (CI Pipeline)

## Test evidence
- `pnpm -r --workspace-concurrency=1 test`

## Deviations from contracts
- `pnpm -r --reporter=append-only lint` currently fails because the baseline `@wb/engine` package has outstanding ESLint errors and warnings unrelated to this change; the new guard will gate future regressions once the backlog is addressed.
- `pnpm -r build` fails in the existing tree because `@wb/tools` inherits `allowImportingTsExtensions` without `noEmit`, which TypeScript rejects; this change does not modify those configs.

------
https://chatgpt.com/codex/tasks/task_e_68e8abb3078883258dfc080c49d3bb7e