### PR TITLE
feat(task:0060): unsafe-dynamic-types-hardening

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Unreleased — Hotfix Batch 03
 
-- HOTFIX-043 (Task 0060): Harden blueprint/domain loaders and integration suites with schema-validated DTOs so `no-unsafe-*` lint guards stay green and SEC §1 determinism is enforced.
+- HOTFIX-043 (Task 0060): Replace perf harness device price lookups, workforce economy context fixtures, and telemetry integration assertions with schema-validated DTOs so `no-unsafe-*` lint guards stay green and SEC §1 determinism stays enforced.
 - HOTFIX-043 (Task 0061): Remove redundant optional chains, adopt `??` defaults, and document invariants across workforce/pipeline modules to satisfy nullish guardrails and SEC §5 contracts.
 - HOTFIX-043 (Task 0062): Replace dynamic deletes with immutable helpers in workforce and pipeline state transitions, keeping SEC §2 tick ordering deterministic.
 - HOTFIX-043 (Task 0063): Introduce explicit formatting helpers for telemetry/reporting, removing implicit `.toString()` usage and redundant escapes so string safety lint rules pass.


### PR DESCRIPTION
## Summary
- parse device price maps and blueprint metadata in the perf harness to remove unsafe reflection and keep DTO usage deterministic.
- feed integration tests through typed blueprint/price helpers and structured telemetry assertions so economy and health fixtures no longer rely on `any` payloads.
- harden workforce scheduling telemetry checks with typed event guards to ensure deterministic payload cloning.

## SEC/TDD References
- SEC §1 (Determinism, schema enforcement)
- TDD §0 (Principles 2 & 5)

## Test Evidence
- `pnpm -r test`
- `pnpm exec eslint --max-warnings=0 packages/engine/src/backend/src/engine/perf/perfScenarios.ts packages/engine/tests/integration/pipeline/economyAccrual.integration.test.ts packages/engine/tests/integration/pipeline/pestDiseaseMvp.integration.test.ts packages/engine/tests/integration/workforce/workforceScheduling.integration.test.ts`
- `pnpm -r lint` *(fails: existing repo-wide lint backlog outside task scope)*
- `pnpm --reporter append-only -r build` *(fails: tools package TypeScript option conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68e8b355cb648325a1ab95ea3cc6b465