### PR TITLE
feat(task:0062): immutable-state-handling

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - HOTFIX-043 (Task 0060): Replace perf harness device price lookups, workforce economy context fixtures, and telemetry integration assertions with schema-validated DTOs so `no-unsafe-*` lint guards stay green and SEC §1 determinism stays enforced.
 - HOTFIX-043 (Task 0061): Remove redundant optional chains, adopt `??` defaults, and document invariants across workforce/pipeline modules to satisfy nullish guardrails and SEC §5 contracts.
-- HOTFIX-043 (Task 0062): Replace dynamic deletes with immutable helpers in workforce and pipeline state transitions, keeping SEC §2 tick ordering deterministic.
+- HOTFIX-043 (Task 0062): Replaced dynamic deletes with WeakMap-backed runtime stores and immutable intent/config helpers across workforce, cultivation, device, sensor, irrigation, and economy pipelines so SEC §2 tick snapshots stay deterministic and lint no-dynamic-delete guards remain green.
 - HOTFIX-043 (Task 0063): Introduce explicit formatting helpers for telemetry/reporting, removing implicit `.toString()` usage and redundant escapes so string safety lint rules pass.
 - HOTFIX-043 (Task 0064): Hoist engine trait weights, builder constants, and RNG seeds into `simConstants` with mirrored docs, eliminating magic number lint warnings.
 - HOTFIX-043 (Task 0065): Prune unused bindings, normalise `const`/`async` usage, and refresh tests in schema utilities to meet lint hygiene expectations.

--- a/packages/engine/src/backend/src/engine/pipeline/applyWorkforce.ts
+++ b/packages/engine/src/backend/src/engine/pipeline/applyWorkforce.ts
@@ -6,6 +6,9 @@ export {
   consumeWorkforcePayrollAccrual,
   clearWorkforcePayrollAccrual,
   consumeWorkforceMarketCharges,
+  queueWorkforceIntents,
+  configureWorkforceContext,
+  seedWorkforcePayrollAccrual,
 } from '../../workforce/index.ts';
 export type {
   WorkforceAssignment,

--- a/packages/engine/tests/integration/pipeline/economyAccrual.integration.test.ts
+++ b/packages/engine/tests/integration/pipeline/economyAccrual.integration.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { FLOAT_TOLERANCE } from '@/backend/src/constants/simConstants';
+import { FLOAT_TOLERANCE, HOURS_PER_DAY } from '@/backend/src/constants/simConstants';
 import { runTick, type EngineRunContext } from '@/backend/src/engine/Engine';
 import { applyEconomyAccrual } from '@/backend/src/engine/pipeline/applyEconomyAccrual';
+import { seedWorkforcePayrollAccrual } from '@/backend/src/engine/pipeline/applyWorkforce';
 import { createDemoWorld } from '@/backend/src/engine/testHarness';
 import {
   parseDeviceBlueprint,
@@ -318,9 +319,9 @@ describe('economy accrual integration', () => {
         byStructure: [],
       } satisfies WorkforcePayrollState;
 
-      (ctx as { __wb_workforcePayrollAccrual?: unknown }).__wb_workforcePayrollAccrual = {
+      seedWorkforcePayrollAccrual(ctx, {
         current: currentState,
-      } satisfies { current: WorkforcePayrollState };
+      });
 
       (world).simTimeHours = hour;
       world = applyEconomyAccrual(world, ctx) as Mutable<SimulationWorld>;
@@ -355,10 +356,10 @@ describe('economy accrual integration', () => {
       byStructure: [],
     } satisfies WorkforcePayrollState;
 
-    (ctx as { __wb_workforcePayrollAccrual?: unknown }).__wb_workforcePayrollAccrual = {
+    seedWorkforcePayrollAccrual(ctx, {
       current: nextDay,
       finalized,
-    } satisfies { current: WorkforcePayrollState; finalized: WorkforcePayrollState };
+    });
 
     (world).simTimeHours = hourlySlices.length;
     world = applyEconomyAccrual(world, ctx) as Mutable<SimulationWorld>;

--- a/packages/engine/tests/integration/workforce/workforceScheduling.integration.test.ts
+++ b/packages/engine/tests/integration/workforce/workforceScheduling.integration.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { createDemoWorld, runStages } from '@/backend/src/engine/testHarness';
 import type { EngineRunContext } from '@/backend/src/engine/Engine';
+import { queueWorkforceIntents } from '@/backend/src/engine/pipeline/applyWorkforce';
 import type {
   Employee,
   EmployeeRole,
@@ -546,16 +547,16 @@ describe('applyWorkforce integration', () => {
           telemetryEvents.push({ topic, payload });
         },
       },
-      workforceIntents: [
-        {
-          type: 'workforce.employee.terminate',
-          employeeId: janitor.id,
-          moraleRipple01: -0.05,
-          reasonSlug: 'restructure',
-          severanceCc: 2000,
-        },
-      ],
     } satisfies EngineRunContext;
+    queueWorkforceIntents(ctx, [
+      {
+        type: 'workforce.employee.terminate',
+        employeeId: janitor.id,
+        moraleRipple01: -0.05,
+        reasonSlug: 'restructure',
+        severanceCc: 2000,
+      },
+    ]);
 
     const nextWorld = runStages(
       createWorldWithWorkforce(workforce),


### PR DESCRIPTION
## Summary
- replace context `delete` usage with WeakMap-backed runtime stores and helper APIs for workforce pipelines
- migrate cultivation, device, economy, irrigation, and sensor runtimes to the same immutable pattern
- update integration tests and changelog to cover the new helpers and document the immutable state handling

## Contract References
- SEC §2 (no hidden globals and deterministic tick snapshots)
- TDD §7 (pipeline tick stages reset their runtime state)

## Testing
- pnpm --filter @wb/engine test -- --runInBand

## Deviations
- pnpm -r lint fails due to longstanding engine lint violations unrelated to this change
- pnpm -r build fails because the tools tsconfig uses `allowImportingTsExtensions` without `noEmit`/`emitDeclarationOnly`

------
https://chatgpt.com/codex/tasks/task_e_68e8ba2804348325835f536316243c8c