### PR TITLE
feat(task:0024): Read-model HTTP Endpoints

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased — Hotfix Batch 03
 
 - Task 0023: Added façade read-model schema validators with versioned metadata, unit coverage for happy/negative paths, and documentation for the three schema identifiers to lock UI contracts to Proposal §6.
+- Task 0024: Introduced Fastify-backed façade HTTP endpoints for company tree, structure tariffs, and workforce view read-models with schema validation guards, integration coverage for success/error responses, and a dev server script for local pairing with the transport adapter.
 - HOTFIX-043 (Task 0060): Replace perf harness device price lookups, workforce economy context fixtures, and telemetry integration assertions with schema-validated DTOs so `no-unsafe-*` lint guards stay green and SEC §1 determinism stays enforced.
 - HOTFIX-043 (Task 0061): Remove redundant optional chains, adopt `??` defaults, and document invariants across workforce/pipeline modules to satisfy nullish guardrails and SEC §5 contracts.
 - HOTFIX-043 (Task 0062): Replaced dynamic deletes with WeakMap-backed runtime stores and immutable intent/config helpers across workforce, cultivation, device, sensor, irrigation, and economy pipelines so SEC §2 tick snapshots stay deterministic and lint no-dynamic-delete guards remain green.

--- a/docs/DD.md
+++ b/docs/DD.md
@@ -337,6 +337,7 @@ costing and scheduling remain aligned with SEC §7.5 and §10.
 
 - **Engine:** pure, deterministic, no network/time syscalls; advances tick and returns state + events.
 - **Façade:** validates intents, resolves tariffs, computes read‑models, orchestrates tick, exposes telemetry (read‑only) over adapter.
+  - Read-model HTTP surface (`packages/facade/src/server/http.ts`) wraps Fastify routes for `/api/companyTree`, `/api/structureTariffs`, and `/api/workforceView`, validating every payload with the shared Zod schemas before replying and logging schema mismatches as 500s.
 - **Transport Adapter:** Socket.IO default; SSE supported; **never accept inbound writes on telemetry**.
 
 ---

--- a/packages/facade/package.json
+++ b/packages/facade/package.json
@@ -9,6 +9,7 @@
   ],
   "dependencies": {
     "@wb/transport-sio": "workspace:*",
+    "fastify": "4.28.1",
     "zod": "3.24.0"
   },
   "devDependencies": {
@@ -20,6 +21,7 @@
     "lint": "eslint --max-warnings=0 \"src/**/*.ts\" \"tests/**/*.ts\"",
     "format": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\"",
     "dev": "tsx watch src/index.ts",
+    "dev:server": "tsx src/server/devServer.ts",
     "transport:dev": "tsx src/transport/devServer.ts"
   },
   "engines": {

--- a/packages/facade/src/index.ts
+++ b/packages/facade/src/index.ts
@@ -49,6 +49,13 @@ export {
   type TransportServer,
   type TransportServerOptions,
 } from './transport/server.ts';
+export {
+  createReadModelHttpServer,
+  type ReadModelHttpLogger,
+  type ReadModelHttpServer,
+  type ReadModelHttpServerOptions,
+  type ReadModelProviders,
+} from './server/http.ts';
 
 /**
  * Parameters required to initialise the façade layer that brokers between the engine and clients.

--- a/packages/facade/src/server/devServer.ts
+++ b/packages/facade/src/server/devServer.ts
@@ -1,0 +1,98 @@
+import {
+  COMPANY_TREE_SCHEMA_VERSION,
+  STRUCTURE_TARIFFS_SCHEMA_VERSION,
+  WORKFORCE_VIEW_SCHEMA_VERSION,
+  type CompanyTreeReadModel,
+  type StructureTariffsReadModel,
+  type WorkforceViewReadModel
+} from '../readModels/api/schemas.ts';
+import { createReadModelHttpServer } from './http.ts';
+
+const DEFAULT_SIM_TIME_HOURS = 0;
+const DEMO_ZONE_AREA_M2 = 48;
+const DEMO_ZONE_VOLUME_M3 = 144;
+const DEMO_ELECTRICITY_PRICE_PER_KWH = 0.35;
+const DEMO_WATER_PRICE_PER_M3 = 3.8;
+const DEMO_CO2_PRICE_PER_KG = 0.92;
+const DEMO_HEADCOUNT = 4;
+const DEMO_GARDENER_COUNT = 2;
+const DEMO_TECHNICIAN_COUNT = 1;
+const DEMO_JANITOR_COUNT = 1;
+const DEMO_UTILIZATION = 0.68;
+const DEFAULT_HTTP_PORT = 3333;
+const DECIMAL_RADIX = 10;
+
+const SAMPLE_COMPANY_TREE: CompanyTreeReadModel = {
+  schemaVersion: COMPANY_TREE_SCHEMA_VERSION,
+  simTime: DEFAULT_SIM_TIME_HOURS,
+  companyId: '00000000-0000-0000-0000-000000100000',
+  name: 'Weed Breed Demo GmbH',
+  structures: [
+    {
+      id: '00000000-0000-0000-0000-000000100001',
+      name: 'Demo Campus',
+      rooms: [
+        {
+          id: '00000000-0000-0000-0000-000000100002',
+          name: 'Propagation Room',
+          zones: [
+            {
+              id: '00000000-0000-0000-0000-000000100003',
+              name: 'Zone Alpha',
+              area_m2: DEMO_ZONE_AREA_M2,
+              volume_m3: DEMO_ZONE_VOLUME_M3
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+
+const SAMPLE_STRUCTURE_TARIFFS: StructureTariffsReadModel = {
+  schemaVersion: STRUCTURE_TARIFFS_SCHEMA_VERSION,
+  simTime: DEFAULT_SIM_TIME_HOURS,
+  electricity_kwh_price: DEMO_ELECTRICITY_PRICE_PER_KWH,
+  water_m3_price: DEMO_WATER_PRICE_PER_M3,
+  co2_kg_price: DEMO_CO2_PRICE_PER_KG,
+  currency: null
+};
+
+const SAMPLE_WORKFORCE_VIEW: WorkforceViewReadModel = {
+  schemaVersion: WORKFORCE_VIEW_SCHEMA_VERSION,
+  simTime: DEFAULT_SIM_TIME_HOURS,
+  headcount: DEMO_HEADCOUNT,
+  roles: {
+    gardener: DEMO_GARDENER_COUNT,
+    technician: DEMO_TECHNICIAN_COUNT,
+    janitor: DEMO_JANITOR_COUNT
+  },
+  kpis: {
+    utilization: DEMO_UTILIZATION,
+    warnings: []
+  }
+};
+
+const port = Number.parseInt(
+  process.env.FACADE_HTTP_PORT ?? DEFAULT_HTTP_PORT.toString(),
+  DECIMAL_RADIX
+);
+
+const server = createReadModelHttpServer({
+  providers: {
+    companyTree: () => SAMPLE_COMPANY_TREE,
+    structureTariffs: () => SAMPLE_STRUCTURE_TARIFFS,
+    workforceView: () => SAMPLE_WORKFORCE_VIEW
+  }
+});
+
+await server
+  .listen({ port, host: '0.0.0.0' })
+  .then(() => {
+    console.log(`Read-model HTTP server listening on http://localhost:${String(port)}`);
+  })
+  .catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('Failed to start read-model HTTP server', message);
+    process.exitCode = 1;
+  });

--- a/packages/facade/tests/integration/readModels/httpEndpoints.spec.ts
+++ b/packages/facade/tests/integration/readModels/httpEndpoints.spec.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  COMPANY_TREE_SCHEMA_VERSION,
+  STRUCTURE_TARIFFS_SCHEMA_VERSION,
+  WORKFORCE_VIEW_SCHEMA_VERSION,
+  companyTreeSchema,
+  structureTariffsSchema,
+  workforceViewSchema,
+  type CompanyTreeReadModel,
+  type StructureTariffsReadModel,
+  type WorkforceViewReadModel
+} from '../../../src/readModels/api/schemas.ts';
+import { createReadModelHttpServer, type ReadModelHttpServer } from '../../../src/server/http.ts';
+
+const COMPANY_TREE_PAYLOAD: CompanyTreeReadModel = {
+  schemaVersion: COMPANY_TREE_SCHEMA_VERSION,
+  simTime: 12,
+  companyId: '00000000-0000-0000-0000-000000000200',
+  name: 'Integration Company',
+  structures: [
+    {
+      id: '00000000-0000-0000-0000-000000000201',
+      name: 'HQ Facility',
+      rooms: [
+        {
+          id: '00000000-0000-0000-0000-000000000202',
+          name: 'Flower Room',
+          zones: [
+            {
+              id: '00000000-0000-0000-0000-000000000203',
+              name: 'Zone One',
+              area_m2: 36,
+              volume_m3: 108
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+
+const STRUCTURE_TARIFFS_PAYLOAD: StructureTariffsReadModel = {
+  schemaVersion: STRUCTURE_TARIFFS_SCHEMA_VERSION,
+  simTime: 12,
+  electricity_kwh_price: 0.42,
+  water_m3_price: 3.4,
+  co2_kg_price: 1.05,
+  currency: null
+};
+
+const WORKFORCE_VIEW_PAYLOAD: WorkforceViewReadModel = {
+  schemaVersion: WORKFORCE_VIEW_SCHEMA_VERSION,
+  simTime: 12,
+  headcount: 7,
+  roles: {
+    gardener: 4,
+    technician: 2,
+    janitor: 1
+  },
+  kpis: {
+    utilization: 0.71,
+    warnings: []
+  }
+};
+
+const activeServers: ReadModelHttpServer[] = [];
+
+afterEach(async () => {
+  while (activeServers.length > 0) {
+    const server = activeServers.pop();
+    if (!server) {
+      break;
+    }
+
+    await server.close();
+  }
+});
+
+describe('read-model HTTP endpoints', () => {
+  it('responds with 200 and validated payloads for each endpoint', async () => {
+    const server = createReadModelHttpServer({
+      providers: {
+        companyTree: () => COMPANY_TREE_PAYLOAD,
+        structureTariffs: () => STRUCTURE_TARIFFS_PAYLOAD,
+        workforceView: () => WORKFORCE_VIEW_PAYLOAD
+      }
+    });
+    activeServers.push(server);
+
+    const companyTreeResponse = await server.inject({ method: 'GET', url: '/api/companyTree' });
+    expect(companyTreeResponse.statusCode).toBe(200);
+    const companyTreeBody = companyTreeSchema.parse(companyTreeResponse.json());
+    expect(companyTreeBody).toEqual(COMPANY_TREE_PAYLOAD);
+
+    const structureTariffsResponse = await server.inject({ method: 'GET', url: '/api/structureTariffs' });
+    expect(structureTariffsResponse.statusCode).toBe(200);
+    const structureTariffsBody = structureTariffsSchema.parse(structureTariffsResponse.json());
+    expect(structureTariffsBody).toEqual(STRUCTURE_TARIFFS_PAYLOAD);
+
+    const workforceViewResponse = await server.inject({ method: 'GET', url: '/api/workforceView' });
+    expect(workforceViewResponse.statusCode).toBe(200);
+    const workforceViewBody = workforceViewSchema.parse(workforceViewResponse.json());
+    expect(workforceViewBody).toEqual(WORKFORCE_VIEW_PAYLOAD);
+  });
+
+  it('returns 500 and logs an error when a payload fails validation', async () => {
+    const logger = {
+      error: vi.fn<[string, Record<string, unknown>?], undefined>()
+    };
+    const invalidPayload = {
+      ...COMPANY_TREE_PAYLOAD,
+      simTime: -1
+    } as unknown as CompanyTreeReadModel;
+
+    const server = createReadModelHttpServer({
+      logger,
+      providers: {
+        companyTree: () => invalidPayload,
+        structureTariffs: () => STRUCTURE_TARIFFS_PAYLOAD,
+        workforceView: () => WORKFORCE_VIEW_PAYLOAD
+      }
+    });
+    activeServers.push(server);
+
+    const response = await server.inject({ method: 'GET', url: '/api/companyTree' });
+    expect(response.statusCode).toBe(500);
+    expect(response.json()).toEqual({ error: 'Failed to compose read-model.' });
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    const [[message, details]] = logger.error.mock.calls as [
+      [string, Record<string, unknown>]
+    ];
+    expect(message).toBe('Failed to compose companyTree read-model');
+    const errorDetail = details.error;
+    expect(typeof errorDetail).toBe('string');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@wb/transport-sio':
         specifier: workspace:*
         version: link:../transport-sio
+      fastify:
+        specifier: 4.28.1
+        version: 4.28.1
       zod:
         specifier: 3.24.0
         version: 3.24.0
@@ -492,6 +495,18 @@ packages:
     resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@fastify/ajv-compiler@3.6.0':
+    resolution: {integrity: sha512-LwdXQJjmMD+GwLOkP7TVC68qa+pSSogeWWmznRJ/coyTcfe9qA05AHFSe1eZFwK6q+xVRpChnvFUkf1iYaSZsQ==}
+
+  '@fastify/error@3.4.1':
+    resolution: {integrity: sha512-wWSvph+29GR783IhmvdwWnN4bUxTD01Vm5Xad4i7i1VuAOItLvbPAb69sb0IQ2N57yprvhNIwAP5B6xfKTmjmQ==}
+
+  '@fastify/fast-json-stringify-compiler@4.3.0':
+    resolution: {integrity: sha512-aZAXGYo6m22Fk1zZzEUKBvut/CIIQe/BapEORnxiD5Qr0kPHqqI69NtEMCme74h+at72sPhbkb4ZrLd1W3KRLA==}
+
+  '@fastify/merge-json-schemas@0.1.1':
+    resolution: {integrity: sha512-fERDVz7topgNjtXsJTTW1JKLy0rhuLRcquYqNR9rF7OcVpCa2OVW49ZPDIhaRRCaUuvVxI+N416xUoF76HNSXA==}
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -787,6 +802,9 @@ packages:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
 
+  abstract-logging@2.0.1:
+    resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
+
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -801,8 +819,27 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ajv-formats@2.1.1:
+    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ajv@8.17.1:
+    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -833,6 +870,9 @@ packages:
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
+
+  avvio@8.4.0:
+    resolution: {integrity: sha512-CDSwaxINFy59iNwhYnkvALBwZiTydGkOecZyPkqBpABYR1KqGEsET0VOOYDwtleZSUIdeY36DC2bSZ24CO1igA==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -1042,8 +1082,14 @@ packages:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
     engines: {node: '>=8.0.0'}
 
+  fast-content-type-parse@1.1.0:
+    resolution: {integrity: sha512-fBHHqSTFLVnR61C+gltJuE5GkVQMV0S2nqUO8TJ+5Z3qAKG8vAx4FKai1s5jq/inV1+sREynIWSuQ6HgoSXpDQ==}
+
   fast-copy@3.0.2:
     resolution: {integrity: sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==}
+
+  fast-decode-uri-component@1.0.1:
+    resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1055,11 +1101,26 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
+  fast-json-stringify@5.16.1:
+    resolution: {integrity: sha512-KAdnLvy1yu/XrRtP+LJnxbBGrhN+xXu+gt3EUvZhYGKCr3lFHq/7UFJHHFgmJKoqlh6B40bZLEv7w46B0mqn1g==}
+
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-querystring@1.1.2:
+    resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
+
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
+  fast-uri@2.4.0:
+    resolution: {integrity: sha512-ypuAmmMKInk5q7XcepxlnUWDLWv4GFtaJqAzWKqn62IpQ3pejtr5dTVbt3vwqVaMKmkNR55sTT+CqUKIaT21BA==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fastify@4.28.1:
+    resolution: {integrity: sha512-kFWUtpNr4i7t5vY2EJPCN2KgMVpuqfU4NjnJNCgiNB900oiDeYqaNDRcAfeBbOF5hGixixxcKnOU4KN9z6QncQ==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -1081,6 +1142,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  find-my-way@8.2.2:
+    resolution: {integrity: sha512-Dobi7gcTEq8yszimcfp/R7+owiT4WncAJ7VTTgFH1jYJ5GaG1FbhjwDG820hptN0QDFvzVY3RfCzdInvGPGzjA==}
+    engines: {node: '>=14'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -1095,6 +1160,10 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1156,6 +1225,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -1208,8 +1281,14 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-schema-ref-resolver@1.0.1:
+    resolution: {integrity: sha512-EJAj1pgHc1hxF6vo2Z3s69fMjO1INq6eGHXZ8Z6wCQeldCuwxGK9Sxf4/cScGn3FZubCVUehfWtcDM/PLteCQw==}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -1220,6 +1299,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  light-my-request@5.14.0:
+    resolution: {integrity: sha512-aORPWntbpH5esaYpGOOmri0OHDOe3wC5M2MQxZ9dvMLZm6DnaAn0kJlcbU9hwsQgLzmZyReKwFwwPkR+nHu5kA==}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -1388,12 +1470,19 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  process-warning@3.0.0:
+    resolution: {integrity: sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==}
+
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
 
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
@@ -1419,6 +1508,10 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -1426,9 +1519,16 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  ret@0.4.3:
+    resolution: {integrity: sha512-0f4Memo5QP7WQyUEAYUO3esD/XjOc3Zjjg5CPsAq1p8sIu0XPeMbHJemKA0BO7tV0X7+A0FoEpbmHXWxPyD3wQ==}
+    engines: {node: '>=10'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
   rollup@4.52.3:
     resolution: {integrity: sha512-RIDh866U8agLgiIcdpB+COKnlCreHJLfIhWC3LVflku5YHfpnsIKigRZeFfMfCc4dVcqNVfQQ5gO/afOck064A==}
@@ -1441,6 +1541,9 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
+  safe-regex2@3.1.0:
+    resolution: {integrity: sha512-RAAZAGbap2kBfbVhvmnTFv73NWLMvDGOITFYTZBAaY8eR+Ir4ef7Up/e7amo+y1+AH+3PtLkrt9mvcTsG9LXug==}
+
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
@@ -1452,6 +1555,9 @@ packages:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-cookie-parser@2.7.1:
+    resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1573,6 +1679,10 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  toad-cache@3.7.0:
+    resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
+    engines: {node: '>=12'}
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
@@ -1958,6 +2068,22 @@ snapshots:
       '@eslint/core': 0.15.2
       levn: 0.4.1
 
+  '@fastify/ajv-compiler@3.6.0':
+    dependencies:
+      ajv: 8.17.1
+      ajv-formats: 2.1.1(ajv@8.17.1)
+      fast-uri: 2.4.0
+
+  '@fastify/error@3.4.1': {}
+
+  '@fastify/fast-json-stringify-compiler@4.3.0':
+    dependencies:
+      fast-json-stringify: 5.16.1
+
+  '@fastify/merge-json-schemas@0.1.1':
+    dependencies:
+      fast-deep-equal: 3.1.3
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -2265,6 +2391,8 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
+  abstract-logging@2.0.1: {}
+
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
@@ -2276,12 +2404,27 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  ajv-formats@2.1.1(ajv@8.17.1):
+    optionalDependencies:
+      ajv: 8.17.1
+
+  ajv-formats@3.0.1(ajv@8.17.1):
+    optionalDependencies:
+      ajv: 8.17.1
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.17.1:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-regex@5.0.1: {}
 
@@ -2304,6 +2447,11 @@ snapshots:
       js-tokens: 9.0.1
 
   atomic-sleep@1.0.0: {}
+
+  avvio@8.4.0:
+    dependencies:
+      '@fastify/error': 3.4.1
+      fastq: 1.19.1
 
   balanced-match@1.0.2: {}
 
@@ -2575,7 +2723,11 @@ snapshots:
     dependencies:
       pure-rand: 6.1.0
 
+  fast-content-type-parse@1.1.0: {}
+
   fast-copy@3.0.2: {}
+
+  fast-decode-uri-component@1.0.1: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -2589,9 +2741,46 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
+  fast-json-stringify@5.16.1:
+    dependencies:
+      '@fastify/merge-json-schemas': 0.1.1
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      fast-deep-equal: 3.1.3
+      fast-uri: 2.4.0
+      json-schema-ref-resolver: 1.0.1
+      rfdc: 1.4.1
+
   fast-levenshtein@2.0.6: {}
 
+  fast-querystring@1.1.2:
+    dependencies:
+      fast-decode-uri-component: 1.0.1
+
   fast-safe-stringify@2.1.1: {}
+
+  fast-uri@2.4.0: {}
+
+  fast-uri@3.1.0: {}
+
+  fastify@4.28.1:
+    dependencies:
+      '@fastify/ajv-compiler': 3.6.0
+      '@fastify/error': 3.4.1
+      '@fastify/fast-json-stringify-compiler': 4.3.0
+      abstract-logging: 2.0.1
+      avvio: 8.4.0
+      fast-content-type-parse: 1.1.0
+      fast-json-stringify: 5.16.1
+      find-my-way: 8.2.2
+      light-my-request: 5.14.0
+      pino: 9.13.1
+      process-warning: 3.0.0
+      proxy-addr: 2.0.7
+      rfdc: 1.4.1
+      secure-json-parse: 2.7.0
+      semver: 7.7.2
+      toad-cache: 3.7.0
 
   fastq@1.19.1:
     dependencies:
@@ -2609,6 +2798,12 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  find-my-way@8.2.2:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-querystring: 1.1.2
+      safe-regex2: 3.1.0
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -2625,6 +2820,8 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  forwarded@0.2.0: {}
 
   fsevents@2.3.3:
     optional: true
@@ -2682,6 +2879,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  ipaddr.js@1.9.1: {}
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -2731,7 +2930,13 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-schema-ref-resolver@1.0.1:
+    dependencies:
+      fast-deep-equal: 3.1.3
+
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -2743,6 +2948,12 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  light-my-request@5.14.0:
+    dependencies:
+      cookie: 0.7.2
+      process-warning: 3.0.0
+      set-cookie-parser: 2.7.1
 
   locate-path@6.0.0:
     dependencies:
@@ -2904,9 +3115,16 @@ snapshots:
 
   prettier@3.6.2: {}
 
+  process-warning@3.0.0: {}
+
   process-warning@5.0.0: {}
 
   process@0.11.10: {}
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
 
   pump@3.0.3:
     dependencies:
@@ -2931,11 +3149,17 @@ snapshots:
 
   real-require@0.2.0: {}
 
+  require-from-string@2.0.2: {}
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
 
+  ret@0.4.3: {}
+
   reusify@1.1.0: {}
+
+  rfdc@1.4.1: {}
 
   rollup@4.52.3:
     dependencies:
@@ -2971,11 +3195,17 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
+  safe-regex2@3.1.0:
+    dependencies:
+      ret: 0.4.3
+
   safe-stable-stringify@2.5.0: {}
 
   secure-json-parse@2.7.0: {}
 
   semver@7.7.2: {}
+
+  set-cookie-parser@2.7.1: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -3108,6 +3338,8 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  toad-cache@3.7.0: {}
 
   ts-api-utils@2.1.0(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## Summary
- add a Fastify-backed façade HTTP server that exposes `/api/companyTree`, `/api/structureTariffs`, and `/api/workforceView` with schema validation and deterministic error handling
- wire a dev server stub plus package exports to simplify local pairing with the transport adapter and reuse the shared read-model schemas in integration coverage
- document the façade HTTP surface and changelog entry for task 0024

## Testing
- `pnpm -r test`
- `pnpm -r lint`
- `pnpm -r build` *(fails in @wb/tools, @wb/transport-sio, and @wb/facade because `tsc --project tsconfig.json` rejects `allowImportingTsExtensions` unless `noEmit` or `emitDeclarationOnly` is set; existing baseline issue)*

## References
- SEC §1 (deterministic façade surfaces)
- TDD §5 (read-model contracts)


------
https://chatgpt.com/codex/tasks/task_e_68eb3d7266e88325a4896c301edf6fe3