### PR TITLE
feat(task:0025): Read-model Client SDK

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Task 0023: Added façade read-model schema validators with versioned metadata, unit coverage for happy/negative paths, and documentation for the three schema identifiers to lock UI contracts to Proposal §6.
 - Task 0024: Introduced Fastify-backed façade HTTP endpoints for company tree, structure tariffs, and workforce view read-models with schema validation guards, integration coverage for success/error responses, and a dev server script for local pairing with the transport adapter.
+- Task 0025: Delivered façade read-model client SDK fetch helpers with typed error handling, unit coverage for network/schema failures, and REST client documentation for manual endpoint verification.
 - HOTFIX-043 (Task 0060): Replace perf harness device price lookups, workforce economy context fixtures, and telemetry integration assertions with schema-validated DTOs so `no-unsafe-*` lint guards stay green and SEC §1 determinism stays enforced.
 - HOTFIX-043 (Task 0061): Remove redundant optional chains, adopt `??` defaults, and document invariants across workforce/pipeline modules to satisfy nullish guardrails and SEC §5 contracts.
 - HOTFIX-043 (Task 0062): Replaced dynamic deletes with WeakMap-backed runtime stores and immutable intent/config helpers across workforce, cultivation, device, sensor, irrigation, and economy pipelines so SEC §2 tick snapshots stay deterministic and lint no-dynamic-delete guards remain green.

--- a/docs/tools/rest-client.md
+++ b/docs/tools/rest-client.md
@@ -1,0 +1,97 @@
+# Read-model REST Client Examples
+
+This guide provides ready-to-run REST snippets for the façade read-model endpoints.
+Each example aligns with the schema identifiers defined in [Task 0023](../tasks/frontend/0023-readmodel-schema-types.md)
+and the HTTP handlers introduced in [Task 0024](../tasks/frontend/0024-readmodel-http-endpoints.md).
+
+## Company Tree
+
+```http
+### companyTree.http
+GET {{baseUrl}}/api/companyTree
+Accept: application/json
+```
+
+```json
+{
+  "schemaVersion": "companyTree.v1",
+  "simTime": 4,
+  "companyId": "00000000-0000-0000-0000-000000000200",
+  "name": "Weed Breed GmbH",
+  "structures": [
+    {
+      "id": "00000000-0000-0000-0000-000000000201",
+      "name": "HQ Campus",
+      "rooms": [
+        {
+          "id": "00000000-0000-0000-0000-000000000202",
+          "name": "Flower Room",
+          "zones": [
+            {
+              "id": "00000000-0000-0000-0000-000000000203",
+              "name": "Zone A",
+              "area_m2": 24,
+              "volume_m3": 72
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Structure Tariffs
+
+```http
+### structureTariffs.http
+GET {{baseUrl}}/api/structureTariffs
+Accept: application/json
+```
+
+```json
+{
+  "schemaVersion": "structureTariffs.v1",
+  "simTime": 4,
+  "electricity_kwh_price": 0.42,
+  "water_m3_price": 3.8,
+  "co2_kg_price": 0.6,
+  "currency": null
+}
+```
+
+## Workforce View
+
+```http
+### workforceView.http
+GET {{baseUrl}}/api/workforceView
+Accept: application/json
+```
+
+```json
+{
+  "schemaVersion": "workforceView.v1",
+  "simTime": 4,
+  "headcount": 5,
+  "roles": {
+    "gardener": 2,
+    "technician": 2,
+    "janitor": 1
+  },
+  "kpis": {
+    "utilization": 0.78,
+    "warnings": []
+  }
+}
+```
+
+### cURL Example
+
+Replace `<BASE_URL>` with your façade server origin.
+
+```bash
+curl --fail --silent --show-error "<BASE_URL>/api/companyTree" \
+  --header 'Accept: application/json'
+```
+
+Use the same command against `/api/structureTariffs` or `/api/workforceView` for the other read models.

--- a/packages/facade/src/index.ts
+++ b/packages/facade/src/index.ts
@@ -42,6 +42,12 @@ export {
   type HiringMarketViewOptions,
 } from './readModels/hiringMarketView.js';
 export {
+  fetchCompanyTree,
+  fetchStructureTariffs,
+  fetchWorkforceView,
+  ReadModelClientError,
+} from './readModels/client.js';
+export {
   createHiringMarketHireIntent,
   createHiringMarketScanIntent,
 } from './intents/hiring.js';

--- a/packages/facade/src/readModels/client.ts
+++ b/packages/facade/src/readModels/client.ts
@@ -1,0 +1,119 @@
+/* eslint-disable wb-sim/no-ts-import-js-extension */
+
+import type { ZodIssue, ZodType, ZodTypeDef } from 'zod';
+import {
+  companyTreeSchema,
+  structureTariffsSchema,
+  workforceViewSchema,
+  type CompanyTreeReadModel,
+  type StructureTariffsReadModel,
+  type WorkforceViewReadModel
+} from './api/schemas.js';
+
+const READ_MODEL_ENDPOINT = {
+  companyTree: '/api/companyTree',
+  structureTariffs: '/api/structureTariffs',
+  workforceView: '/api/workforceView'
+} as const;
+
+type ReadModelKey = keyof typeof READ_MODEL_ENDPOINT;
+
+type ReadModelClientErrorReason = 'network' | 'http' | 'schema';
+
+interface ReadModelClientErrorInit extends ErrorOptions {
+  readonly status?: number;
+  readonly issues?: readonly ZodIssue[];
+}
+
+/**
+ * Represents a failure encountered while fetching a read-model payload.
+ */
+export class ReadModelClientError extends Error {
+  /**
+   * Category describing why the client call failed.
+   */
+  public readonly reason: ReadModelClientErrorReason;
+
+  /**
+   * HTTP status code reported by the backend when {@link reason} equals `"http"`.
+   */
+  public readonly status?: number;
+
+  /**
+   * Zod issues describing the schema mismatches when {@link reason} equals `"schema"`.
+   */
+  public readonly issues?: readonly ZodIssue[];
+
+  constructor(reason: ReadModelClientErrorReason, message: string, init: ReadModelClientErrorInit = {}) {
+    super(message, init);
+    this.name = 'ReadModelClientError';
+    this.reason = reason;
+    this.status = init.status;
+    this.issues = init.issues;
+  }
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+}
+
+async function requestReadModel<TOutput>(
+  baseUrl: string,
+  key: ReadModelKey,
+  schema: ZodType<TOutput, ZodTypeDef, unknown>
+): Promise<TOutput> {
+  const url = `${normalizeBaseUrl(baseUrl)}${READ_MODEL_ENDPOINT[key]}`;
+
+  let response: Response;
+  try {
+    response = await fetch(url);
+  } catch (error) {
+    throw new ReadModelClientError('network', `Failed to fetch ${key} read model.`, { cause: error });
+  }
+
+  if (!response.ok) {
+    throw new ReadModelClientError(
+      'http',
+      `Request for ${key} read model failed with status ${String(response.status)}.`,
+      { status: response.status }
+    );
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    throw new ReadModelClientError('network', `Unable to parse ${key} read model response as JSON.`, { cause: error });
+  }
+
+  const parsed = schema.safeParse(payload);
+  if (!parsed.success) {
+    throw new ReadModelClientError('schema', `Response for ${key} read model failed validation.`, {
+      cause: parsed.error,
+      issues: parsed.error.issues
+    });
+  }
+
+  return parsed.data;
+}
+
+/**
+ * Fetches and validates the company hierarchy read model from the façade backend.
+ */
+export async function fetchCompanyTree(baseUrl: string): Promise<CompanyTreeReadModel> {
+  return requestReadModel<CompanyTreeReadModel>(baseUrl, 'companyTree', companyTreeSchema);
+}
+
+/**
+ * Fetches and validates the structure tariff read model from the façade backend.
+ */
+export async function fetchStructureTariffs(baseUrl: string): Promise<StructureTariffsReadModel> {
+  return requestReadModel<StructureTariffsReadModel>(baseUrl, 'structureTariffs', structureTariffsSchema);
+}
+
+/**
+ * Fetches and validates the workforce summary read model from the façade backend.
+ */
+export async function fetchWorkforceView(baseUrl: string): Promise<WorkforceViewReadModel> {
+  return requestReadModel<WorkforceViewReadModel>(baseUrl, 'workforceView', workforceViewSchema);
+}

--- a/packages/facade/tests/unit/readModels/client.spec.ts
+++ b/packages/facade/tests/unit/readModels/client.spec.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  COMPANY_TREE_SCHEMA_VERSION,
+  WORKFORCE_VIEW_SCHEMA_VERSION,
+  type CompanyTreeReadModel,
+  type WorkforceViewReadModel
+} from '../../../src/readModels/api/schemas.ts';
+import {
+  ReadModelClientError,
+  fetchCompanyTree,
+  fetchStructureTariffs,
+  fetchWorkforceView
+} from '../../../src/readModels/client.ts';
+
+const BASE_URL = 'https://facade.example.test';
+
+const COMPANY_ID = '00000000-0000-0000-0000-000000000200';
+const STRUCTURE_ID = '00000000-0000-0000-0000-000000000201';
+const ROOM_ID = '00000000-0000-0000-0000-000000000202';
+const ZONE_ID = '00000000-0000-0000-0000-000000000203';
+
+const COMPANY_TREE_PAYLOAD: CompanyTreeReadModel = {
+  schemaVersion: COMPANY_TREE_SCHEMA_VERSION,
+  simTime: 4,
+  companyId: COMPANY_ID,
+  name: 'Weed Breed GmbH',
+  structures: [
+    {
+      id: STRUCTURE_ID,
+      name: 'HQ Campus',
+      rooms: [
+        {
+          id: ROOM_ID,
+          name: 'Flower Room',
+          zones: [
+            {
+              id: ZONE_ID,
+              name: 'Zone A',
+              area_m2: 24,
+              volume_m3: 72
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+
+const WORKFORCE_VIEW_PAYLOAD: WorkforceViewReadModel = {
+  schemaVersion: WORKFORCE_VIEW_SCHEMA_VERSION,
+  simTime: 4,
+  headcount: 5,
+  roles: {
+    gardener: 2,
+    technician: 2,
+    janitor: 1
+  },
+  kpis: {
+    utilization: 0.78,
+    warnings: []
+  }
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('fetchCompanyTree', () => {
+  it('returns the parsed payload when the backend responds with valid data', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(COMPANY_TREE_PAYLOAD)
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const payload = await fetchCompanyTree(`${BASE_URL}/`);
+
+    expect(payload).toEqual(COMPANY_TREE_PAYLOAD);
+    expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/api/companyTree`);
+  });
+
+  it('wraps network failures with a ReadModelClientError carrying the network reason', async () => {
+    const failure = new TypeError('Network down');
+    const fetchMock = vi.fn().mockRejectedValue(failure);
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchCompanyTree(BASE_URL)).rejects.toMatchObject({
+      name: 'ReadModelClientError',
+      reason: 'network'
+    });
+  });
+});
+
+describe('fetchStructureTariffs', () => {
+  it('throws a typed error when the backend responds with a non-2xx status code', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: () => Promise.resolve({})
+    }));
+
+    await expect(fetchStructureTariffs(BASE_URL)).rejects.toMatchObject({
+      name: 'ReadModelClientError',
+      reason: 'http',
+      status: 503
+    });
+  });
+});
+
+describe('fetchWorkforceView', () => {
+  it('surfaces schema validation issues with the typed error helper', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          ...WORKFORCE_VIEW_PAYLOAD,
+          roles: {
+            ...WORKFORCE_VIEW_PAYLOAD.roles,
+            gardener: -1
+          }
+        })
+    }));
+
+    await expect(fetchWorkforceView(BASE_URL)).rejects.toSatisfy((error: unknown) => {
+      if (!(error instanceof ReadModelClientError)) {
+        return false;
+      }
+      expect(error.reason).toBe('schema');
+      expect(error.issues?.[0]?.path).toEqual(['roles', 'gardener']);
+      return true;
+    });
+  });
+
+  it('returns the validated workforce payload', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(WORKFORCE_VIEW_PAYLOAD)
+    }));
+
+    const payload = await fetchWorkforceView(BASE_URL);
+
+    expect(payload).toEqual(WORKFORCE_VIEW_PAYLOAD);
+  });
+});


### PR DESCRIPTION
## Summary
- add a façade read-model client module that normalises base URLs, throws a unified `ReadModelClientError`, and parses payloads with the shared schemas (TDD §5)
- export the new helpers for SDK consumers and document REST examples for the three read-model endpoints
- cover success, network, HTTP failure, and schema mismatch flows with unit tests and note the addition in the changelog

## Testing
- pnpm i
- pnpm -r test
- pnpm --filter @wb/facade test
- pnpm exec eslint packages/facade/src/readModels/client.ts packages/facade/tests/unit/readModels/client.spec.ts
- pnpm --filter @wb/facade build
- pnpm -r lint *(fails: existing type-safety violations across façade/tools-monitor packages outside this change)*
- pnpm -r build *(fails: TypeScript 5.9 rejects workspace configs using `allowImportingTsExtensions` without `noEmit` / `emitDeclarationOnly`)*

------
https://chatgpt.com/codex/tasks/task_e_68eb4b2a517c83259d2e60675f42dfb0