### PR TITLE
feat(task:0035): Intent: Set Light Schedule UX

### DIFF
--- a/packages/ui/src/components/intents/SetLightScheduleForm.tsx
+++ b/packages/ui/src/components/intents/SetLightScheduleForm.tsx
@@ -1,0 +1,361 @@
+import { useEffect, useMemo, useState, type ChangeEvent, type FormEvent, type ReactElement } from "react";
+import { type IntentClient, type IntentSubmissionHandlers, type SuccessfulIntentAck } from "@ui/transport";
+import type { IntentErrorDictionaryEntry } from "@ui/intl/intentErrors";
+import en from "@ui/intl/en.json" assert { type: "json" };
+import {
+  recordZoneLightSchedule,
+  useZoneLightSchedule,
+  type ZoneLightSchedule
+} from "@ui/state/intents";
+import { SOCKET_ERROR_CODES, type TransportAckErrorCode } from "@wb/transport-sio";
+import { HOURS_PER_DAY, LIGHT_SCHEDULE_GRID_HOURS } from "@engine/constants/simConstants.ts";
+
+const copy = en.intents.setLightSchedule;
+const START_HOUR_MAX = HOURS_PER_DAY - LIGHT_SCHEDULE_GRID_HOURS;
+const EPSILON = 1e-6;
+
+interface FormValues {
+  readonly onHours: string;
+  readonly offHours: string;
+  readonly startHour: string;
+}
+
+interface ValidationResult {
+  readonly isValid: boolean;
+  readonly messages: readonly string[];
+  readonly schedule: ZoneLightSchedule | null;
+}
+
+export interface SetLightScheduleFormProps {
+  readonly zoneId: string;
+  readonly intentClient: IntentClient;
+  readonly className?: string;
+}
+
+function parseHours(value: string): number | null {
+  if (value.trim().length === 0) {
+    return null;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+
+  return parsed;
+}
+
+function isWithinRange(value: number, min: number, max: number): boolean {
+  return value >= min - EPSILON && value <= max + EPSILON;
+}
+
+const LIGHT_SCHEDULE_PRECISION = 1 / LIGHT_SCHEDULE_GRID_HOURS;
+
+function isQuarterIncrement(value: number): boolean {
+  return Math.abs(value * LIGHT_SCHEDULE_PRECISION - Math.round(value * LIGHT_SCHEDULE_PRECISION)) < EPSILON;
+}
+
+function normaliseQuarter(value: number): number {
+  return Math.round(value * LIGHT_SCHEDULE_PRECISION) / LIGHT_SCHEDULE_PRECISION;
+}
+
+function validate(values: FormValues): ValidationResult {
+  const messages: string[] = [];
+  const parsedOn = parseHours(values.onHours);
+  const parsedOff = parseHours(values.offHours);
+  const parsedStart = parseHours(values.startHour);
+
+  const pushMessage = (message: string) => {
+    if (!messages.includes(message)) {
+      messages.push(message);
+    }
+  };
+
+  if (parsedOn === null || parsedOff === null) {
+    pushMessage(copy.validation.sum);
+  } else {
+    const onHours = parsedOn;
+    const offHours = parsedOff;
+
+    if (!isWithinRange(onHours, 0, HOURS_PER_DAY) || !isWithinRange(offHours, 0, HOURS_PER_DAY)) {
+      pushMessage(copy.validation.sum);
+    } else if (Math.abs(onHours + offHours - HOURS_PER_DAY) > EPSILON) {
+      pushMessage(copy.validation.sum);
+    }
+  }
+
+  if (parsedOn !== null && !isQuarterIncrement(parsedOn)) {
+    pushMessage(copy.validation.quarter);
+  }
+
+  if (parsedOff !== null && !isQuarterIncrement(parsedOff)) {
+    pushMessage(copy.validation.quarter);
+  }
+
+  if (parsedStart === null) {
+    pushMessage(copy.validation.start);
+  } else if (!isWithinRange(parsedStart, 0, START_HOUR_MAX)) {
+    pushMessage(copy.validation.start);
+  } else if (!isQuarterIncrement(parsedStart)) {
+    pushMessage(copy.validation.quarter);
+  }
+
+  if (messages.length > 0 || parsedOn === null || parsedOff === null || parsedStart === null) {
+    return { isValid: false, messages, schedule: null };
+  }
+
+  const schedule: ZoneLightSchedule = {
+    onHours: normaliseQuarter(parsedOn),
+    offHours: normaliseQuarter(parsedOff),
+    startHour: normaliseQuarter(parsedStart)
+  };
+
+  return { isValid: true, messages, schedule };
+}
+
+interface ToastMessage {
+  readonly title: string;
+  readonly description: string;
+}
+
+function deriveErrorEntry(
+  dictionary: IntentErrorDictionaryEntry | null,
+  code: TransportAckErrorCode,
+  message: string
+): IntentErrorDictionaryEntry {
+  if (dictionary) {
+    return dictionary;
+  }
+
+  return {
+    code,
+    title: copy.status.toastErrorTitle,
+    description: message,
+    action: "Retry the submission after checking your connection."
+  } satisfies IntentErrorDictionaryEntry;
+}
+
+function formatHours(value: number): string {
+  if (Number.isInteger(value)) {
+    return value.toString();
+  }
+
+  return value.toFixed(2).replace(/\.00$/, "");
+}
+
+export function SetLightScheduleForm({ zoneId, intentClient, className }: SetLightScheduleFormProps): ReactElement {
+  const schedule = useZoneLightSchedule(zoneId);
+  const [values, setValues] = useState<FormValues>(() => ({
+    onHours: formatHours(schedule.onHours),
+    offHours: formatHours(schedule.offHours),
+    startHour: formatHours(schedule.startHour)
+  }));
+  const [validationResult, setValidationResult] = useState<ValidationResult>(() => validate(values));
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [ackError, setAckError] = useState<IntentErrorDictionaryEntry | null>(null);
+  const [toast, setToast] = useState<ToastMessage | null>(null);
+  const [successAck, setSuccessAck] = useState<SuccessfulIntentAck | null>(null);
+
+  useEffect(() => {
+    setValues({
+      onHours: formatHours(schedule.onHours),
+      offHours: formatHours(schedule.offHours),
+      startHour: formatHours(schedule.startHour)
+    });
+  }, [schedule.onHours, schedule.offHours, schedule.startHour]);
+
+  useEffect(() => {
+    setValidationResult(validate(values));
+  }, [values]);
+
+  const validationMessages = useMemo(() => validationResult.messages, [validationResult.messages]);
+
+  const handleChange = (field: keyof FormValues) => (event: ChangeEvent<HTMLInputElement>) => {
+    setValues((previous) => ({
+      ...previous,
+      [field]: event.target.value
+    }));
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const result = validate(values);
+    setValidationResult(result);
+
+    if (!result.isValid || result.schedule === null) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setAckError(null);
+    setSuccessAck(null);
+    setToast(null);
+
+    const payload = {
+      type: "zone.light-schedule.set",
+      zoneId,
+      schedule: result.schedule
+    } satisfies Record<string, unknown>;
+
+    const handlers: IntentSubmissionHandlers = {
+      onResult: () => undefined
+    };
+
+    try {
+      const resultAck = await intentClient.submit(payload, handlers);
+      if (resultAck.ok) {
+        recordZoneLightSchedule(zoneId, result.schedule);
+        setSuccessAck(resultAck.ack);
+        setAckError(null);
+        setToast(null);
+      } else {
+        const errorEntry: IntentErrorDictionaryEntry = deriveErrorEntry(
+          resultAck.dictionary,
+          resultAck.ack.error.code,
+          resultAck.ack.error.message
+        );
+        setAckError(errorEntry);
+        setToast({
+          title: copy.status.toastErrorTitle,
+          description: errorEntry.title
+        });
+      }
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : "Unknown transport error.";
+      const errorEntry: IntentErrorDictionaryEntry = deriveErrorEntry(
+        null,
+        SOCKET_ERROR_CODES.INTENT_HANDLER_ERROR,
+        reason
+      );
+      setAckError(errorEntry);
+      setToast({
+        title: copy.status.toastErrorTitle,
+        description: errorEntry.title
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form
+      aria-describedby="set-light-schedule-description"
+      className={className ?? "space-y-6 rounded-xl border border-border-base bg-canvas-base p-6"}
+      onSubmit={(event) => {
+        void handleSubmit(event);
+      }}
+    >
+      <div className="space-y-1">
+        <h3 className="text-lg font-semibold text-text-primary">{copy.title}</h3>
+        <p className="text-sm text-text-muted" id="set-light-schedule-description">
+          {copy.description}
+        </p>
+      </div>
+
+      {toast && (
+        <div
+          aria-live="assertive"
+          className="rounded-lg border border-border-strong bg-surface-critical/10 p-4 text-sm text-text-primary"
+          role="alert"
+        >
+          <p className="font-semibold text-text-critical">{toast.title}</p>
+          <p className="text-text-muted">{toast.description}</p>
+        </div>
+      )}
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <label className="flex flex-col gap-2">
+          <span className="text-sm font-medium text-text-primary">{copy.fields.onHours.label}</span>
+          <input
+            aria-label={copy.fields.onHours.label}
+            className="rounded-lg border border-border-base bg-canvas-subtle px-3 py-2 text-sm text-text-primary"
+            inputMode="decimal"
+            min={0}
+            max={HOURS_PER_DAY}
+            name="onHours"
+            onChange={handleChange("onHours")}
+            step={LIGHT_SCHEDULE_GRID_HOURS}
+            type="number"
+            value={values.onHours}
+          />
+          <span className="text-xs text-text-muted">{copy.fields.onHours.help}</span>
+        </label>
+
+        <label className="flex flex-col gap-2">
+          <span className="text-sm font-medium text-text-primary">{copy.fields.offHours.label}</span>
+          <input
+            aria-label={copy.fields.offHours.label}
+            className="rounded-lg border border-border-base bg-canvas-subtle px-3 py-2 text-sm text-text-primary"
+            inputMode="decimal"
+            min={0}
+            max={HOURS_PER_DAY}
+            name="offHours"
+            onChange={handleChange("offHours")}
+            step={LIGHT_SCHEDULE_GRID_HOURS}
+            type="number"
+            value={values.offHours}
+          />
+          <span className="text-xs text-text-muted">{copy.fields.offHours.help}</span>
+        </label>
+
+        <label className="flex flex-col gap-2">
+          <span className="text-sm font-medium text-text-primary">{copy.fields.startHour.label}</span>
+          <input
+            aria-label={copy.fields.startHour.label}
+            className="rounded-lg border border-border-base bg-canvas-subtle px-3 py-2 text-sm text-text-primary"
+            inputMode="decimal"
+            min={0}
+            max={START_HOUR_MAX}
+            name="startHour"
+            onChange={handleChange("startHour")}
+            step={LIGHT_SCHEDULE_GRID_HOURS}
+            type="number"
+            value={values.startHour}
+          />
+          <span className="text-xs text-text-muted">{copy.fields.startHour.help}</span>
+        </label>
+      </div>
+
+      {validationMessages.length > 0 && (
+        <div className="rounded-lg border border-border-strong bg-surface-critical/10 p-4" role="alert">
+          <ul className="list-disc space-y-1 pl-5 text-sm text-text-critical">
+            {validationMessages.map((message) => (
+              <li key={message}>{message}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {ackError && (
+        <div className="space-y-2 rounded-lg border border-border-strong bg-surface-critical/10 p-4" role="alert">
+          <p className="text-sm font-semibold text-text-critical">{ackError.title}</p>
+          <p className="text-sm text-text-primary">{ackError.description}</p>
+          <p className="text-xs text-text-muted">{ackError.action}</p>
+        </div>
+      )}
+
+      {successAck && (
+        <div className="rounded-lg border border-border-success bg-surface-success/10 p-4" role="status">
+          <p className="text-sm font-medium text-text-success">{copy.status.success}</p>
+        </div>
+      )}
+
+      <div className="flex items-center justify-end">
+        <button
+          className="inline-flex items-center gap-2 rounded-lg bg-accent-primary px-4 py-2 text-sm font-semibold text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={!validationResult.isValid || isSubmitting}
+          type="submit"
+        >
+          {isSubmitting ? (
+            <>
+              <span className="inline-flex size-4 animate-spin rounded-full border-2 border-white/40 border-t-white" aria-hidden="true" />
+              <span>{copy.status.submitting}</span>
+            </>
+          ) : (
+            copy.actions.submit
+          )}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/packages/ui/src/components/intents/__tests__/SetLightScheduleForm.test.tsx
+++ b/packages/ui/src/components/intents/__tests__/SetLightScheduleForm.test.tsx
@@ -1,0 +1,196 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SOCKET_ERROR_CODES, type TransportAckErrorCode } from "@wb/transport-sio";
+
+import en from "@ui/intl/en.json" assert { type: "json" };
+import { resolveIntentError } from "@ui/intl/intentErrors";
+import type {
+  IntentClient,
+  IntentSubmissionHandlers,
+  IntentSubmissionResult,
+  IntentSubmissionSuccess
+} from "@ui/transport";
+import { getZoneLightSchedule, resetIntentState } from "@ui/state/intents";
+
+import { SetLightScheduleForm } from "../SetLightScheduleForm";
+
+const copy = en.intents.setLightSchedule;
+const ZONE_ID = "zone-test";
+const VALID_ON_HOURS = "12";
+const VALID_OFF_HOURS = "12";
+const VALID_START_HOUR = "6.5";
+const FAILURE_ON_HOURS = "16";
+const FAILURE_OFF_HOURS = "8";
+const EXPECTED_START_HOUR = 6.5;
+const EXPECTED_SCHEDULE = { onHours: 12, offHours: 12, startHour: EXPECTED_START_HOUR } as const;
+
+interface IntentClientStub {
+  readonly client: IntentClient;
+  readonly submit: ReturnType<typeof vi.fn>;
+  resolveSuccess(ack?: IntentSubmissionSuccess): void;
+  resolveFailure(code: TransportAckErrorCode, message?: string): void;
+  reject(reason: unknown): void;
+  getLastPayload(): Record<string, unknown> | null;
+}
+
+function createIntentClientStub(): IntentClientStub {
+  let handlers: IntentSubmissionHandlers | null = null;
+  let payload: Record<string, unknown> | null = null;
+  let resolvePromise: ((result: IntentSubmissionResult) => void) | null = null;
+
+  const submit = vi.fn(
+    async (intent: Record<string, unknown>, acknowledgementHandlers: IntentSubmissionHandlers) => {
+      handlers = acknowledgementHandlers;
+      payload = intent;
+      return await new Promise<IntentSubmissionResult>((resolve) => {
+        resolvePromise = resolve;
+      });
+    }
+  );
+
+  const disconnect = vi.fn(() => undefined);
+
+  const client: IntentClient = {
+    submit,
+    disconnect
+  } satisfies IntentClient;
+
+  return {
+    client,
+    submit,
+    resolveSuccess(ack?: IntentSubmissionSuccess) {
+      if (!handlers || !resolvePromise) {
+        throw new Error("No pending submission to resolve.");
+      }
+
+      const acknowledgement =
+        ack ??
+        ({
+          ok: true as const,
+          ack: { ok: true as const }
+        } satisfies IntentSubmissionSuccess);
+      handlers.onResult(acknowledgement);
+      resolvePromise(acknowledgement);
+    },
+    resolveFailure(code: TransportAckErrorCode, message?: string) {
+      if (!handlers || !resolvePromise) {
+        throw new Error("No pending submission to resolve.");
+      }
+
+      const ack = {
+        ok: false,
+        error: {
+          code,
+          message: message ?? "transport error"
+        }
+      } as const;
+      const dictionary = resolveIntentError(code);
+      const result = {
+        ok: false as const,
+        ack,
+        dictionary
+      };
+      handlers.onResult(result);
+      resolvePromise(result);
+    },
+    getLastPayload() {
+      return payload;
+    }
+  };
+}
+
+describe("SetLightScheduleForm", () => {
+  beforeEach(() => {
+    resetIntentState();
+  });
+
+  it("disables submit when the photoperiod does not sum to 24 hours", async () => {
+    const { client } = createIntentClientStub();
+    render(<SetLightScheduleForm intentClient={client} zoneId={ZONE_ID} />);
+
+    const submit = screen.getByRole("button", { name: copy.actions.submit });
+    expect(submit).toBeEnabled();
+
+    fireEvent.change(screen.getByLabelText(copy.fields.offHours.label), { target: { value: "5" } });
+
+    await waitFor(() => {
+      expect(submit).toBeDisabled();
+    });
+
+    expect(screen.getByText(copy.validation.sum)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(copy.fields.offHours.label), { target: { value: "6" } });
+
+    await waitFor(() => {
+      expect(submit).toBeEnabled();
+    });
+  });
+
+  it("submits a valid schedule, shows a spinner, and records success optimistically", async () => {
+    const stub = createIntentClientStub();
+    render(<SetLightScheduleForm intentClient={stub.client} zoneId={ZONE_ID} />);
+
+    fireEvent.change(screen.getByLabelText(copy.fields.onHours.label), { target: { value: VALID_ON_HOURS } });
+    fireEvent.change(screen.getByLabelText(copy.fields.offHours.label), { target: { value: VALID_OFF_HOURS } });
+    fireEvent.change(screen.getByLabelText(copy.fields.startHour.label), { target: { value: VALID_START_HOUR } });
+
+    fireEvent.click(screen.getByRole("button", { name: copy.actions.submit }));
+
+    await waitFor(() => {
+      expect(stub.submit).toHaveBeenCalledTimes(1);
+    });
+
+    const payload = stub.getLastPayload();
+    expect(payload).toEqual({
+      type: "zone.light-schedule.set",
+      zoneId: ZONE_ID,
+      schedule: {
+        onHours: EXPECTED_SCHEDULE.onHours,
+        offHours: EXPECTED_SCHEDULE.offHours,
+        startHour: EXPECTED_START_HOUR
+      }
+    });
+
+    expect(screen.getByText(copy.status.submitting)).toBeInTheDocument();
+
+    await act(() => {
+      stub.resolveSuccess();
+      return Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(copy.status.success)).toBeInTheDocument();
+    });
+
+    const recorded = getZoneLightSchedule(ZONE_ID);
+    expect(recorded).toEqual(EXPECTED_SCHEDULE);
+  });
+
+  it("surfaces transport dictionary errors as toast and inline message", async () => {
+    const stub = createIntentClientStub();
+    render(<SetLightScheduleForm intentClient={stub.client} zoneId={ZONE_ID} />);
+
+    fireEvent.change(screen.getByLabelText(copy.fields.offHours.label), { target: { value: FAILURE_OFF_HOURS } });
+    fireEvent.change(screen.getByLabelText(copy.fields.onHours.label), { target: { value: FAILURE_ON_HOURS } });
+
+    fireEvent.click(screen.getByRole("button", { name: copy.actions.submit }));
+
+    await waitFor(() => {
+      expect(stub.submit).toHaveBeenCalledTimes(1);
+    });
+
+    await act(() => {
+      stub.resolveFailure(SOCKET_ERROR_CODES.INTENT_INVALID, "validation failed");
+      return Promise.resolve();
+    });
+
+    const dictionary = resolveIntentError(SOCKET_ERROR_CODES.INTENT_INVALID);
+
+    await waitFor(() => {
+      expect(screen.getAllByText(dictionary.title)).toHaveLength(2);
+      expect(screen.getByText(dictionary.description)).toBeInTheDocument();
+      expect(screen.getByText(dictionary.action)).toBeInTheDocument();
+      expect(screen.getByText(copy.status.toastErrorTitle)).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/intl/en.json
+++ b/packages/ui/src/intl/en.json
@@ -1,0 +1,35 @@
+{
+  "intents": {
+    "setLightSchedule": {
+      "title": "Adjust light schedule",
+      "description": "Configure the daily photoperiod for this zone per SEC §4.2.",
+      "fields": {
+        "onHours": {
+          "label": "Lights on",
+          "help": "Hours per day that fixtures remain on."
+        },
+        "offHours": {
+          "label": "Lights off",
+          "help": "Hours per day that fixtures remain off."
+        },
+        "startHour": {
+          "label": "Start hour",
+          "help": "Hour of the day when the light cycle begins (0-23.75)."
+        }
+      },
+      "validation": {
+        "sum": "Light cycle hours must total 24 per SEC §4.2.",
+        "quarter": "Photoperiod values must use 15 minute (0.25h) increments.",
+        "start": "Start hour must be between 0 and 23.75 inclusive."
+      },
+      "actions": {
+        "submit": "Update schedule"
+      },
+      "status": {
+        "submitting": "Submitting intent…",
+        "success": "Light schedule updated. Awaiting telemetry confirmation.",
+        "toastErrorTitle": "Intent submission failed"
+      }
+    }
+  }
+}

--- a/packages/ui/src/state/intents.ts
+++ b/packages/ui/src/state/intents.ts
@@ -1,0 +1,64 @@
+import { create } from "zustand";
+
+export interface ZoneLightSchedule {
+  readonly onHours: number;
+  readonly offHours: number;
+  readonly startHour: number;
+}
+
+interface IntentState {
+  readonly zoneLightSchedules: Map<string, ZoneLightSchedule>;
+  readonly recordZoneLightSchedule: (zoneId: string, schedule: ZoneLightSchedule) => void;
+}
+
+const createInitialSchedules = () => new Map<string, ZoneLightSchedule>();
+
+const DEFAULT_LIGHT_SCHEDULE: ZoneLightSchedule = Object.freeze({
+  onHours: 18,
+  offHours: 6,
+  startHour: 0
+});
+
+const useIntentStore = create<IntentState>((set) => ({
+  zoneLightSchedules: createInitialSchedules(),
+  recordZoneLightSchedule: (zoneId, schedule) => {
+    set((state) => {
+      const nextSchedules = new Map(state.zoneLightSchedules);
+      nextSchedules.set(zoneId, { ...schedule });
+      return { zoneLightSchedules: nextSchedules };
+    });
+  }
+}));
+
+export function recordZoneLightSchedule(zoneId: string, schedule: ZoneLightSchedule): void {
+  useIntentStore.getState().recordZoneLightSchedule(zoneId, schedule);
+}
+
+export function useZoneLightSchedule(zoneId: string | null | undefined): ZoneLightSchedule {
+  return useIntentStore((state) => {
+    if (!zoneId) {
+      return DEFAULT_LIGHT_SCHEDULE;
+    }
+
+    const existing = state.zoneLightSchedules.get(zoneId);
+    if (!existing) {
+      return DEFAULT_LIGHT_SCHEDULE;
+    }
+
+    return existing;
+  });
+}
+
+export function getZoneLightSchedule(zoneId: string): ZoneLightSchedule {
+  const existing = useIntentStore.getState().zoneLightSchedules.get(zoneId);
+  return existing ?? DEFAULT_LIGHT_SCHEDULE;
+}
+
+export function resetIntentState(): void {
+  useIntentStore.setState({
+    zoneLightSchedules: createInitialSchedules(),
+    recordZoneLightSchedule: useIntentStore.getState().recordZoneLightSchedule
+  });
+}
+
+export { useIntentStore };

--- a/packages/ui/src/stories/intents/SetLightScheduleForm.stories.tsx
+++ b/packages/ui/src/stories/intents/SetLightScheduleForm.stories.tsx
@@ -1,0 +1,103 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { SOCKET_ERROR_CODES } from "@wb/transport-sio";
+
+import { resolveIntentError } from "@ui/intl/intentErrors";
+import type { IntentClient, IntentSubmissionHandlers, IntentSubmissionResult } from "@ui/transport";
+
+import { SetLightScheduleForm, type SetLightScheduleFormProps } from "@ui/components/intents/SetLightScheduleForm";
+
+function createMockIntentClient(mode: "success" | "error" | "loading"): IntentClient {
+  return {
+    async submit(_intent, handlers: IntentSubmissionHandlers): Promise<IntentSubmissionResult> {
+      switch (mode) {
+        case "loading":
+          return await new Promise<IntentSubmissionResult>((resolve) => {
+            // Intentionally keep the promise pending to demonstrate the loading state.
+            void resolve;
+          });
+        case "error": {
+          const ack = {
+            ok: false as const,
+            error: {
+              code: SOCKET_ERROR_CODES.INTENT_HANDLER_ERROR,
+              message: "Simulated handler failure"
+            }
+          };
+          const dictionary = resolveIntentError(ack.error.code);
+          const result = { ok: false as const, ack, dictionary };
+          handlers.onResult(result);
+          return result;
+        }
+        case "success":
+        default: {
+          const result = { ok: true as const, ack: { ok: true as const } };
+          handlers.onResult(result);
+          return result;
+        }
+      }
+    },
+    disconnect(): Promise<void> {
+      return Promise.resolve();
+    }
+  } satisfies IntentClient;
+}
+
+const meta: Meta<typeof SetLightScheduleForm> = {
+  title: "Intents/SetLightScheduleForm",
+  component: SetLightScheduleForm,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Interactive form wiring for the zone.light-schedule.set intent. Submit the form in each story to observe the acknowledgement states."
+      }
+    }
+  },
+  args: {
+    zoneId: "zone-story",
+    intentClient: createMockIntentClient("success")
+  } satisfies Partial<SetLightScheduleFormProps>
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SetLightScheduleForm>;
+
+export const Success: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: "Simulates a successful acknowledgement and updates the optimistic store state."
+      }
+    }
+  }
+};
+
+export const Loading: Story = {
+  args: {
+    intentClient: createMockIntentClient("loading"),
+    zoneId: "zone-story-loading"
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Acknowledgement never resolves to showcase the loading spinner state."
+      }
+    }
+  }
+};
+
+export const Error: Story = {
+  args: {
+    intentClient: createMockIntentClient("error"),
+    zoneId: "zone-story-error"
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Demonstrates mapping of transport acknowledgement errors to toast and inline messaging."
+      }
+    }
+  }
+};

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -9,8 +9,19 @@
     "types": ["node", "vite/client"],
     "baseUrl": "../../",
     "paths": {
-      "@ui/*": ["packages/ui/src/*"],
-      "@wb/transport-sio": ["packages/transport-sio/src/index.ts"]
+      "@wb/engine/*": ["packages/engine/src/*"],
+      "@wb/facade/*": ["packages/facade/src/*"],
+      "@wb/transport-sio/*": ["packages/transport-sio/src/*"],
+      "@wb/tools-monitor/*": ["packages/tools-monitor/src/*"],
+      "@wb/engine": ["packages/engine/src/index"],
+      "@wb/facade": ["packages/facade/src/index"],
+      "@wb/transport-sio": ["packages/transport-sio/src/index"],
+      "@wb/tools-monitor": ["packages/tools-monitor/src/index"],
+      "@engine/constants/*": ["packages/engine/src/backend/src/constants/*"],
+      "@/backend/*": ["packages/engine/src/backend/*"],
+      "@/shared/*": ["packages/engine/src/shared/*"],
+      "@/tests/*": ["packages/engine/tests/*"],
+      "@ui/*": ["packages/ui/src/*"]
     }
   },
   "include": [


### PR DESCRIPTION
## Summary
- add the SetLightScheduleForm with SEC-compliant light schedule validation, intent submission handling, and toast/status feedback
- wire a Zustand intent store plus English copy to support optimistic light schedule updates across the UI
- document the new component via Storybook stories and update the UI tsconfig paths to reuse engine constants directly

## Contracts
- SEC §4.2 – enforce quarter-hour light schedule validation (AGENTS Appendix A)
- TDD §2 – extend unit coverage for validation, success, and failure acknowledgement flows

## Testing
- `pnpm i`
- `pnpm -r test`
- `pnpm --filter @wb/ui lint`
- `pnpm -r lint` *(fails: `@wb/facade` existing unsafe-type lint errors)*
- `pnpm -r build` *(fails: `@wb/engine` TypeScript build errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ebc71765e883259dd15d720e24e6da