### PR TITLE
feat(task:0037): Contract Test Harness

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### Unreleased — Hotfix Batch 03
 
+- Task 0037: Added a façade contract test harness that boots the read-model HTTP
+  server and Socket.IO transport, exercised telemetry read-only rejections and
+  intent acknowledgement contracts under `tests/contract/**`, and wired a
+  dedicated `test:contract` script so the suite can run in isolation via
+  `pnpm --filter @wb/facade test:contract`.
 - Task 0023: Added façade read-model schema validators with versioned metadata, unit coverage for happy/negative paths, and documentation for the three schema identifiers to lock UI contracts to Proposal §6.
 - Task 0024: Introduced Fastify-backed façade HTTP endpoints for company tree, structure tariffs, and workforce view read-models with schema validation guards, integration coverage for success/error responses, and a dev server script for local pairing with the transport adapter.
 - Task 0025: Delivered façade read-model client SDK fetch helpers with typed error handling, unit coverage for network/schema failures, and REST client documentation for manual endpoint verification.

--- a/packages/facade/package.json
+++ b/packages/facade/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
     "test": "vitest run",
+    "test:contract": "vitest run tests/contract",
     "lint": "eslint --max-warnings=0 \"src/**/*.ts\" \"tests/**/*.ts\"",
     "format": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\"",
     "dev": "tsx watch src/index.ts",

--- a/packages/facade/tests/contract/readModels.contract.spec.ts
+++ b/packages/facade/tests/contract/readModels.contract.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  COMPANY_TREE_SCHEMA_VERSION,
+  STRUCTURE_TARIFFS_SCHEMA_VERSION,
+  WORKFORCE_VIEW_SCHEMA_VERSION,
+  companyTreeSchema,
+  structureTariffsSchema,
+  workforceViewSchema,
+  type CompanyTreeReadModel,
+  type StructureTariffsReadModel,
+  type WorkforceViewReadModel,
+} from '../../src/readModels/api/schemas.ts';
+import { createContractServerHarness } from './utils/server.ts';
+
+const COMPANY_TREE_FIXTURE: CompanyTreeReadModel = {
+  schemaVersion: COMPANY_TREE_SCHEMA_VERSION,
+  simTime: 8,
+  companyId: '00000000-0000-0000-0000-000000000310',
+  name: 'Contract Harness Company',
+  structures: [
+    {
+      id: '00000000-0000-0000-0000-000000000311',
+      name: 'Primary Campus',
+      rooms: [
+        {
+          id: '00000000-0000-0000-0000-000000000312',
+          name: 'Propagation Room',
+          zones: [
+            {
+              id: '00000000-0000-0000-0000-000000000313',
+              name: 'Zone Alpha',
+              area_m2: 42,
+              volume_m3: 126,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const STRUCTURE_TARIFFS_FIXTURE: StructureTariffsReadModel = {
+  schemaVersion: STRUCTURE_TARIFFS_SCHEMA_VERSION,
+  simTime: 8,
+  electricity_kwh_price: 0.38,
+  water_m3_price: 3.65,
+  co2_kg_price: 1.1,
+  currency: null,
+};
+
+const WORKFORCE_VIEW_FIXTURE: WorkforceViewReadModel = {
+  schemaVersion: WORKFORCE_VIEW_SCHEMA_VERSION,
+  simTime: 8,
+  headcount: 5,
+  roles: {
+    gardener: 3,
+    technician: 1,
+    janitor: 1,
+  },
+  kpis: {
+    utilization: 0.72,
+    warnings: [],
+  },
+};
+
+describe('contract — read-model HTTP endpoints', () => {
+  it('serve schema-compliant payloads for all endpoints', async () => {
+    const harness = await createContractServerHarness({
+      providers: {
+        companyTree: () => COMPANY_TREE_FIXTURE,
+        structureTariffs: () => STRUCTURE_TARIFFS_FIXTURE,
+        workforceView: () => WORKFORCE_VIEW_FIXTURE,
+      },
+    });
+
+    try {
+      const companyTreeResponse = await fetch(`${harness.http.url}/api/companyTree`);
+      expect(companyTreeResponse.status).toBe(200);
+      const companyTreeBody = companyTreeSchema.parse(await companyTreeResponse.json());
+      expect(companyTreeBody).toEqual(COMPANY_TREE_FIXTURE);
+
+      const structureTariffsResponse = await fetch(`${harness.http.url}/api/structureTariffs`);
+      expect(structureTariffsResponse.status).toBe(200);
+      const structureTariffsBody = structureTariffsSchema.parse(
+        await structureTariffsResponse.json(),
+      );
+      expect(structureTariffsBody).toEqual(STRUCTURE_TARIFFS_FIXTURE);
+
+      const workforceViewResponse = await fetch(`${harness.http.url}/api/workforceView`);
+      expect(workforceViewResponse.status).toBe(200);
+      const workforceViewBody = workforceViewSchema.parse(await workforceViewResponse.json());
+      expect(workforceViewBody).toEqual(WORKFORCE_VIEW_FIXTURE);
+    } finally {
+      await harness.close();
+    }
+  });
+});

--- a/packages/facade/tests/contract/transport.contract.spec.ts
+++ b/packages/facade/tests/contract/transport.contract.spec.ts
@@ -1,0 +1,217 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { io as createClient, type Socket } from 'socket.io-client';
+
+import {
+  INTENT_ERROR_EVENT,
+  INTENT_EVENT,
+  SOCKET_ERROR_CODES,
+  TELEMETRY_ERROR_EVENT,
+  assertTransportAck,
+  type TransportAck,
+} from '../../src/transport/adapter.ts';
+import {
+  COMPANY_TREE_SCHEMA_VERSION,
+  STRUCTURE_TARIFFS_SCHEMA_VERSION,
+  WORKFORCE_VIEW_SCHEMA_VERSION,
+} from '../../src/readModels/api/schemas.ts';
+import type { ReadModelProviders } from '../../src/server/http.ts';
+import { createContractServerHarness, type ContractServerHarness } from './utils/server.ts';
+
+const READ_MODEL_PROVIDERS: ReadModelProviders = {
+  companyTree: () => ({
+    schemaVersion: COMPANY_TREE_SCHEMA_VERSION,
+    simTime: 0,
+    companyId: '00000000-0000-0000-0000-000000000321',
+    name: 'Contract Harness Company',
+    structures: [
+      {
+        id: '00000000-0000-0000-0000-000000000322',
+        name: 'Main Campus',
+        rooms: [
+          {
+            id: '00000000-0000-0000-0000-000000000323',
+            name: 'Growroom A',
+            zones: [
+              {
+                id: '00000000-0000-0000-0000-000000000324',
+                name: 'Zone A1',
+                area_m2: 30,
+                volume_m3: 90,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  }),
+  structureTariffs: () => ({
+    schemaVersion: STRUCTURE_TARIFFS_SCHEMA_VERSION,
+    simTime: 0,
+    electricity_kwh_price: 0.4,
+    water_m3_price: 3.2,
+    currency: null,
+  }),
+  workforceView: () => ({
+    schemaVersion: WORKFORCE_VIEW_SCHEMA_VERSION,
+    simTime: 0,
+    headcount: 4,
+    roles: {
+      gardener: 2,
+      technician: 1,
+      janitor: 1,
+    },
+    kpis: {
+      utilization: 0.66,
+      warnings: [],
+    },
+  }),
+};
+
+const activeSockets = new Set<Socket>();
+const activeHarnesses = new Set<ContractServerHarness>();
+
+afterEach(async () => {
+  const socketClosures = Array.from(activeSockets, (socket) => disconnectClient(socket));
+  activeSockets.clear();
+
+  const harnessClosures = Array.from(activeHarnesses, (harness) => harness.close());
+  activeHarnesses.clear();
+
+  await Promise.all([...socketClosures, ...harnessClosures]);
+});
+
+async function connectToNamespace(
+  harness: ContractServerHarness,
+  namespace: '/telemetry' | '/intents',
+): Promise<Socket> {
+  const socket = createClient(`${harness.transport.url}${namespace}`, {
+    transports: ['websocket'],
+    forceNew: true,
+  });
+
+  activeSockets.add(socket);
+  await onceConnected(socket);
+  return socket;
+}
+
+function onceConnected(socket: Socket): Promise<void> {
+  if (socket.connected) {
+    return Promise.resolve();
+  }
+
+  return new Promise<void>((resolve, reject) => {
+    const handleError = (error: Error) => {
+      socket.off('connect', handleConnect);
+      reject(error);
+    };
+
+    const handleConnect = () => {
+      socket.off('connect_error', handleError);
+      resolve();
+    };
+
+    socket.once('connect_error', handleError);
+    socket.once('connect', handleConnect);
+  });
+}
+
+function disconnectClient(socket: Socket): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (!socket.connected) {
+      socket.disconnect();
+      resolve();
+      return;
+    }
+
+    socket.once('disconnect', () => {
+      resolve();
+    });
+    socket.disconnect();
+  });
+}
+
+describe('contract — transport server', () => {
+  it('rejects telemetry writes with deterministic acknowledgements', async () => {
+    const harness = await createContractServerHarness({ providers: READ_MODEL_PROVIDERS });
+    activeHarnesses.add(harness);
+
+    const telemetryClient = await connectToNamespace(harness, '/telemetry');
+
+    const ackPromise = new Promise<TransportAck>((resolve) => {
+      telemetryClient.emit('telemetry:rogue', { attempt: true }, (ack: TransportAck) => {
+        resolve(ack);
+      });
+    });
+
+    const errorEvent = new Promise<TransportAck>((resolve) => {
+      telemetryClient.once(TELEMETRY_ERROR_EVENT, (ack: TransportAck) => {
+        resolve(ack);
+      });
+    });
+
+    const ack = await ackPromise;
+    assertTransportAck(ack);
+    expect(ack.ok).toBe(false);
+    expect(ack.error?.code).toBe(SOCKET_ERROR_CODES.TELEMETRY_WRITE_REJECTED);
+
+    const mirroredAck = await errorEvent;
+    assertTransportAck(mirroredAck);
+    expect(mirroredAck.ok).toBe(false);
+    expect(mirroredAck.error?.code).toBe(SOCKET_ERROR_CODES.TELEMETRY_WRITE_REJECTED);
+  });
+
+  it('acknowledges valid intents with ok=true', async () => {
+    const onIntent = vi.fn(() => undefined);
+    const harness = await createContractServerHarness({
+      providers: READ_MODEL_PROVIDERS,
+      onIntent,
+    });
+    activeHarnesses.add(harness);
+
+    const intentsClient = await connectToNamespace(harness, '/intents');
+    const intentPayload = {
+      type: 'workforce.scan',
+      structureId: '00000000-0000-0000-0000-000000000400',
+    };
+
+    const ack = await new Promise<TransportAck>((resolve) => {
+      intentsClient.emit(INTENT_EVENT, intentPayload, (response: TransportAck) => {
+        resolve(response);
+      });
+    });
+
+    assertTransportAck(ack);
+    expect(ack).toEqual({ ok: true });
+    expect(onIntent).toHaveBeenCalledTimes(1);
+    expect(onIntent).toHaveBeenCalledWith(intentPayload);
+  });
+
+  it('rejects unexpected intent namespace events', async () => {
+    const harness = await createContractServerHarness({ providers: READ_MODEL_PROVIDERS });
+    activeHarnesses.add(harness);
+
+    const intentsClient = await connectToNamespace(harness, '/intents');
+
+    const ackPromise = new Promise<TransportAck>((resolve) => {
+      intentsClient.emit('intent:rogue', { attempt: true }, (ack: TransportAck) => {
+        resolve(ack);
+      });
+    });
+
+    const errorEvent = new Promise<TransportAck>((resolve) => {
+      intentsClient.once(INTENT_ERROR_EVENT, (ack: TransportAck) => {
+        resolve(ack);
+      });
+    });
+
+    const ack = await ackPromise;
+    assertTransportAck(ack);
+    expect(ack.ok).toBe(false);
+    expect(ack.error?.code).toBe(SOCKET_ERROR_CODES.INTENT_CHANNEL_INVALID);
+
+    const mirroredAck = await errorEvent;
+    assertTransportAck(mirroredAck);
+    expect(mirroredAck.ok).toBe(false);
+    expect(mirroredAck.error?.code).toBe(SOCKET_ERROR_CODES.INTENT_CHANNEL_INVALID);
+  });
+});

--- a/packages/facade/tests/contract/utils/server.ts
+++ b/packages/facade/tests/contract/utils/server.ts
@@ -1,0 +1,98 @@
+import type { TransportServerOptions } from '../../../src/transport/server.ts';
+import {
+  createTransportServer,
+  type TransportCorsOptions,
+  type TransportServer,
+} from '../../../src/transport/server.ts';
+import {
+  createReadModelHttpServer,
+  type ReadModelHttpServer,
+  type ReadModelProviders,
+} from '../../../src/server/http.ts';
+
+const LOOPBACK_HOST = '127.0.0.1';
+
+type OnIntentHandler = TransportServerOptions['onIntent'];
+
+function ensureError(candidate: unknown): Error {
+  return candidate instanceof Error ? candidate : new Error(String(candidate));
+}
+
+export interface ContractServerHarness {
+  readonly http: {
+    readonly server: ReadModelHttpServer;
+    readonly url: string;
+  };
+  readonly transport: TransportServer;
+  close(): Promise<void>;
+}
+
+export interface ContractServerHarnessOptions {
+  readonly providers: ReadModelProviders;
+  readonly onIntent?: OnIntentHandler;
+  readonly cors?: TransportCorsOptions;
+}
+
+export async function createContractServerHarness(
+  options: ContractServerHarnessOptions,
+): Promise<ContractServerHarness> {
+  const httpServer = createReadModelHttpServer({ providers: options.providers });
+
+  try {
+    await httpServer.listen({ port: 0, host: LOOPBACK_HOST });
+  } catch (error) {
+    await httpServer.close().catch(() => undefined);
+    throw ensureError(error);
+  }
+
+  const httpAddress = httpServer.server.address();
+
+  if (!httpAddress || typeof httpAddress === 'string') {
+    await httpServer.close().catch(() => undefined);
+    throw new Error('Read-model HTTP server failed to expose a TCP address.');
+  }
+
+  const httpPort = httpAddress.port;
+  const httpUrl = `http://${LOOPBACK_HOST}:${String(httpPort)}`;
+
+  let transportServer: TransportServer;
+
+  try {
+    transportServer = await createTransportServer({
+      host: LOOPBACK_HOST,
+      port: 0,
+      cors: options.cors,
+      onIntent: options.onIntent ?? (() => undefined),
+    });
+  } catch (error) {
+    await httpServer.close().catch(() => undefined);
+    throw ensureError(error);
+  }
+
+  return {
+    http: {
+      server: httpServer,
+      url: httpUrl,
+    },
+    transport: transportServer,
+    async close() {
+      const closeErrors: Error[] = [];
+
+      try {
+        await transportServer.close();
+      } catch (error) {
+        closeErrors.push(ensureError(error));
+      }
+
+      try {
+        await httpServer.close();
+      } catch (error) {
+        closeErrors.push(ensureError(error));
+      }
+
+      if (closeErrors.length > 0) {
+        throw closeErrors[0];
+      }
+    },
+  } satisfies ContractServerHarness;
+}


### PR DESCRIPTION
## Summary
- add a reusable contract test harness that boots the façade read-model HTTP server and Socket.IO transport to exercise SEC §11 / TDD §11 telemetry and intent contracts
- add read-model and transport contract specs plus a dedicated `test:contract` script for @wb/facade, updating the changelog for Task 0037

## Testing
- `pnpm i`
- `pnpm -r test`
- `pnpm --filter @wb/facade test`
- `pnpm --filter @wb/facade test:contract`
- `pnpm -r lint` *(fails: existing TypeScript brand/schema errors in @wb/engine and façade sources)*
- `pnpm -r build` *(fails: existing TypeScript compilation errors in @wb/engine)*

------
https://chatgpt.com/codex/tasks/task_e_68ebf8577f188325bceef03ce3efa761