### PR TITLE
feat(task:0038): CI Pipeline Integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,22 +10,35 @@ on:
 jobs:
   quality:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 10.18.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22.x'
           cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Restore Vite build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            packages/ui/node_modules/.vite
+            packages/ui/dist
+          key: ${{ runner.os }}-vite-${{ hashFiles('pnpm-lock.yaml', 'packages/ui/package.json', 'packages/ui/vite.config.*') }}
+          restore-keys: |
+            ${{ runner.os }}-vite-
 
       - name: Typecheck
         run: pnpm typecheck
@@ -35,6 +48,9 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+      - name: Contract tests
+        run: pnpm --filter @wb/facade test:contract
 
   perf-budget:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > **Status:** Active • **Runtime:** Node.js 22 LTS • **Package manager:** pnpm ≥ 10.17 • **Language:** TypeScript (ESM) • **Test:** Vitest • **Repo style:** pnpm workspaces
 
+> **CI coverage:** `pnpm install` → `pnpm lint` → `pnpm test` → `pnpm --filter @wb/facade test:contract` on every push/PR (Node.js 22).
+
 Weed Breed (Re‑Reboot) is a deterministic, tick‑based simulation about controlled‑environment cultivation, resources, and economics. The project emphasizes **reproducibility**, **testability** (Golden Master / Conformance), and **contract‑driven development** via living documents (**SEC**, **TDD**, **DD**, **VISION_SCOPE**).
 
 ---

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Unreleased — Hotfix Batch 03
 
+- Task 0038: Hardened the CI workflow with Node.js 22 + pnpm 10.18.1 setup,
+  pnpm/Vite caching, an explicit façade contract test gate, and refreshed the
+  README and dev-stack docs to surface the new lint/test coverage expectations.
 - Task 0037: Added a façade contract test harness that boots the read-model HTTP
   server and Socket.IO transport, exercised telemetry read-only rejections and
   intent acknowledgement contracts under `tests/contract/**`, and wired a

--- a/docs/tools/dev-stack.md
+++ b/docs/tools/dev-stack.md
@@ -1,5 +1,20 @@
 # Dev Stack Notes
 
+## Continuous Integration expectations
+
+Frontend and transport contributions must remain green in CI. Every push and
+pull request runs on Node.js 22 with pnpm 10.18.1 and executes:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm lint
+pnpm test
+pnpm --filter @wb/facade test:contract
+```
+
+Keep workspace scripts aligned with these commands so CI matches the workflow
+documented in TDD §2.
+
 ## Façade Transport Server Bootstrap
 
 The façade exposes a Socket.IO transport server that brokers telemetry and intent


### PR DESCRIPTION
## Summary
- extend the CI workflow to pin pnpm 10.18.1, cache the UI Vite build artefacts, and gate pulls on the façade contract test suite alongside lint/typecheck/test
- surface the CI command coverage in the README and dev-stack guide so frontend contributors know the required checks
- record Task 0038 in the changelog

## SEC/TDD References
- TDD §2 — tooling workflow expectations
- AGENTS §1 — Node 22 + pnpm workspace conventions

## Testing
- `pnpm install`
- `pnpm -r test`
- `pnpm -r lint` *(fails: existing @typescript-eslint `error`-typed safety violations in @wb/facade)*
- `pnpm -r build` *(fails: TypeScript TS5096 on packages/engine tsconfig requiring noEmit/emitDeclarationOnly)*

## Deviations
- Lint/build failures are pre-existing repository issues (facade ESLint safety rules and engine tsconfig). No changes were made to those packages in this task; the new CI step surfaces the contract tests despite these outstanding items.

------
https://chatgpt.com/codex/tasks/task_e_68ec0fa1d0148325acd2a0545699bdca