### PR TITLE
Add health endpoints for facade dev stack

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Unreleased — Hotfix Batch 03
 
+- Task 0069: Added deterministic `/healthz` endpoints to the façade read-model
+  Fastify server and Socket.IO transport so `pnpm run dev:stack` exposes ready
+  signals for browsers and automated health checks (GET/HEAD), aligning with the
+  dev-stack pairing workflow.
 - Task 0068: Wired a root `pnpm run dev:stack` helper (via `concurrently`) that
   boots the façade read-model server, façade Socket.IO transport, and Vite UI
   dev server together, and documented the workflow in the README to align with

--- a/packages/facade/src/transport/server.ts
+++ b/packages/facade/src/transport/server.ts
@@ -186,10 +186,17 @@ function createHealthHandler(statusBody: string, cors?: TransportCorsOptions): H
 
     const { method, url } = request;
 
-    if (method === 'GET' && new URL(url, 'http://localhost').pathname === '/healthz') {
+    if ((method === 'GET' || method === 'HEAD') && new URL(url, 'http://localhost').pathname === '/healthz') {
       applyCorsHeaders(request, response, cors);
       response.statusCode = HTTP_STATUS_OK;
       response.setHeader('content-type', 'application/json; charset=utf-8');
+      response.setHeader('content-length', String(Buffer.byteLength(statusBody)));
+
+      if (method === 'HEAD') {
+        response.end();
+        return;
+      }
+
       response.end(statusBody);
       return;
     }

--- a/packages/facade/tests/integration/transport/serverNamespaces.spec.ts
+++ b/packages/facade/tests/integration/transport/serverNamespaces.spec.ts
@@ -75,6 +75,19 @@ describe('transport server bootstrap', () => {
     expect(healthResponse.headers.get('access-control-allow-origin')).toBe(
       'http://localhost:5173'
     );
+
+    const headResponse = await fetch(`${server.url}/healthz`, {
+      method: 'HEAD',
+      headers: { Origin: 'http://localhost:5173' },
+    });
+
+    expect(headResponse.status).toBe(200);
+    expect(headResponse.headers.get('access-control-allow-origin')).toBe(
+      'http://localhost:5173'
+    );
+    expect(headResponse.headers.get('content-type')).toBe(
+      'application/json; charset=utf-8'
+    );
   });
 
   it('rejects telemetry writes when no handler is registered', async () => {

--- a/packages/facade/tests/unit/server/http.test.ts
+++ b/packages/facade/tests/unit/server/http.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+import {
+  COMPANY_TREE_SCHEMA_VERSION,
+  STRUCTURE_TARIFFS_SCHEMA_VERSION,
+  WORKFORCE_VIEW_SCHEMA_VERSION,
+  uuidSchema,
+  type CompanyTreeReadModel,
+  type StructureTariffsReadModel,
+  type WorkforceViewReadModel,
+} from '../../../src/readModels/api/schemas.ts';
+import { createReadModelHttpServer } from '../../../src/server/http.ts';
+
+type Providers = Parameters<typeof createReadModelHttpServer>[0]['providers'];
+
+const STUB_COMPANY_TREE: CompanyTreeReadModel = {
+  schemaVersion: COMPANY_TREE_SCHEMA_VERSION,
+  simTime: 0,
+  companyId: uuidSchema.parse('00000000-0000-0000-0000-000000000000'),
+  name: 'Stub Company',
+  structures: [
+    {
+      id: uuidSchema.parse('00000000-0000-0000-0000-000000000001'),
+      name: 'Stub Structure',
+      rooms: [
+        {
+          id: uuidSchema.parse('00000000-0000-0000-0000-000000000002'),
+          name: 'Stub Room',
+          zones: [
+            {
+              id: uuidSchema.parse('00000000-0000-0000-0000-000000000003'),
+              name: 'Stub Zone',
+              area_m2: 1,
+              volume_m3: 3,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const STUB_STRUCTURE_TARIFFS: StructureTariffsReadModel = {
+  schemaVersion: STRUCTURE_TARIFFS_SCHEMA_VERSION,
+  simTime: 0,
+  electricity_kwh_price: 0.2,
+  water_m3_price: 1.1,
+  co2_kg_price: 0.5,
+  currency: null,
+};
+
+const STUB_WORKFORCE_VIEW: WorkforceViewReadModel = {
+  schemaVersion: WORKFORCE_VIEW_SCHEMA_VERSION,
+  simTime: 0,
+  headcount: 1,
+  roles: {
+    gardener: 1,
+    technician: 0,
+    janitor: 0,
+  },
+  kpis: {
+    utilization: 0.5,
+    warnings: [],
+  },
+};
+
+describe('createReadModelHttpServer', () => {
+  let server: FastifyInstance | null = null;
+
+  afterEach(async () => {
+    if (server) {
+      await server.close();
+      server = null;
+    }
+  });
+
+  it('exposes a /healthz endpoint for GET and HEAD requests', async () => {
+    const providers: Providers = {
+      companyTree: () => STUB_COMPANY_TREE,
+      structureTariffs: () => STUB_STRUCTURE_TARIFFS,
+      workforceView: () => STUB_WORKFORCE_VIEW,
+    };
+
+    server = createReadModelHttpServer({ providers });
+
+    const getResponse = await server.inject({ method: 'GET', url: '/healthz' });
+    expect(getResponse.statusCode).toBe(200);
+    expect(getResponse.headers['content-type']).toBe('application/json; charset=utf-8');
+    expect(getResponse.json()).toStrictEqual({ status: 'ok' });
+
+    const headResponse = await server.inject({ method: 'HEAD', url: '/healthz' });
+    expect(headResponse.statusCode).toBe(200);
+    expect(headResponse.headers['content-type']).toBe('application/json; charset=utf-8');
+    expect(headResponse.body).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- expose a Fastify /healthz route in the façade read-model dev server that supports GET and HEAD
- respond to HEAD checks from the façade transport health handler and extend coverage for both servers
- document the new health endpoints in the changelog for the current hotfix batch

## Testing
- pnpm --filter @wb/facade test
- pnpm run dev:stack

------
https://chatgpt.com/codex/tasks/task_e_68ec52d219e08325b97efb9ef3414cc5