### PR TITLE
chore: split lint scripts for ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         run: pnpm typecheck
 
       - name: Lint
-        run: pnpm lint
+        run: pnpm lint:ci
 
       - name: Test
         run: pnpm test

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **Status:** Active • **Runtime:** Node.js 22 LTS • **Package manager:** pnpm ≥ 10.17 • **Language:** TypeScript (ESM) • **Test:** Vitest • **Repo style:** pnpm workspaces
 
-> **CI coverage:** `pnpm install` → `pnpm lint` → `pnpm test` → `pnpm --filter @wb/facade test:contract` on every push/PR (Node.js 22).
+> **CI coverage:** `pnpm install` → `pnpm lint:ci` → `pnpm test` → `pnpm --filter @wb/facade test:contract` on every push/PR (Node.js 22).
 
 Weed Breed (Re‑Reboot) is a deterministic, tick‑based simulation about controlled‑environment cultivation, resources, and economics. The project emphasizes **reproducibility**, **testability** (Golden Master / Conformance), and **contract‑driven development** via living documents (**SEC**, **TDD**, **DD**, **VISION_SCOPE**).
 
@@ -71,7 +71,12 @@ pnpm --filter @wb/engine test
 ### Lint & Format
 
 ```sh
+# Local eslint run keeps warnings visible without failing the run
 pnpm -r lint
+
+# CI/strict linting fails on any warning
+pnpm lint:ci
+
 pnpm -r format
 ```
 
@@ -148,7 +153,8 @@ pnpm --filter @wb/engine sim:run
 
 * `build` — typecheck & compile
 * `test` — unit/integration tests (Vitest)
-* `lint` — ESLint rules (includes custom rules, e.g., forbid `Math.random`)
+* `lint` — ESLint rules with warnings surfaced but non-blocking for local workflows
+* `lint:ci` — Strict ESLint run (`--max-warnings 0`) for pre-push/CI guardrails
 * `perf:ci` — run performance checks for ms/tick regressions
 
 Run in all workspaces: `pnpm -r <script>`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### Unreleased — Hotfix Batch 03
 
+- Task 0069: Split the workspace lint workflow into a warning-tolerant local
+  script and a strict `lint:ci` variant, updated the pre-push hook/CI pipeline
+  to gate on the strict run, and refreshed the README and contributing guide to
+  document the distinction.
+
 - Task 0068: Wired a root `pnpm run dev:stack` helper (via `concurrently`) that
   boots the façade read-model server, façade Socket.IO transport, and Vite UI
   dev server together, and documented the workflow in the README to align with

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -5,6 +5,7 @@
 - TypeScript sources **must not** import local files with a trailing `.js` extension. Use extensionless specifiers (`import './foo'`) so the build output can append `.js` while source tooling resolves `.ts`.
 - JSON modules continue to use import attributes (`import data from './foo.json' with { type: 'json' }`). Those remain allowed by the ESLint rule `wb-sim/no-ts-import-js-extension`.
 - Run `pnpm lint:imports` to execute the ESLint rule across the workspace. The rule auto-fixes offending specifiers by removing the trailing `.js` segment.
+- Use `pnpm lint` for day-to-day ESLint runs (warnings are surfaced but do not fail the command) and `pnpm lint:ci` before publishing to ensure warning-free pipelines.
 
 ## Runtime import resolution spec
 
@@ -14,6 +15,7 @@
 ## Pre-commit hooks
 
 - The repo uses [`simple-git-hooks`](https://github.com/toplenboren/simple-git-hooks). `pnpm install` (or `pnpm prepare`) wires up a `pre-commit` hook that runs `pnpm lint:imports` and `pnpm test:imports` before every commit.
+- The `pre-push` hook delegates to `pnpm prepush`, which now chains `pnpm typecheck`, `pnpm lint:ci`, and `pnpm test` so warning-free ESLint output is still enforced before sharing work.
 - If you need to skip the hook temporarily (e.g. for WIP commits), pass `HUSKY=0`/`SKIP=...` environment overrides intentionally and rerun the checks before pushing.
 - Hook output mirrors CI, so fixes applied locally keep the pipeline green.
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "dev:stack": "pnpm exec concurrently --kill-others --restart-tries 0 --names 'facade-rm,facade-transport,ui' --prefix-colors 'cyan.bold,magenta.bold,green.bold' \"pnpm --filter @wb/facade dev:server\" \"pnpm --filter @wb/facade transport:dev\" \"pnpm --filter @wb/ui dev\"",
     "build": "pnpm -r build",
     "typecheck": "pnpm -w tsc -p packages/engine/tsconfig.spec.json --noEmit",
-    "lint": "pnpm exec eslint --max-warnings 0 \"packages/**/*.{ts,tsx}\"",
+    "lint": "pnpm exec eslint \"packages/**/*.{ts,tsx}\"",
+    "lint:ci": "pnpm exec eslint --max-warnings 0 \"packages/**/*.{ts,tsx}\"",
     "lint:strict": "node ./tools/check-warn-budget.mjs --budget 30 -- pnpm -r --workspace-concurrency=1 lint -- --max-warnings=2147483647 --format json",
     "test": "pnpm -r test",
     "test:imports": "pnpm --filter @wb/engine test:imports",
@@ -34,7 +35,7 @@
     "tasks:write": "tsx tools/tasks/renumberTasks.mts --write",
     "tasks:check": "tsx tools/tasks/renumberTasks.mts --dry --verify",
     "scan:magic": "node ./tools/scripts/scan-magic-numbers.mjs",
-    "prepush": "pnpm typecheck && pnpm lint && pnpm test"
+    "prepush": "pnpm typecheck && pnpm lint:ci && pnpm test"
   },
   "devDependencies": {
     "@eslint/js": "^9.5.0",


### PR DESCRIPTION
## Summary
- update the root lint scripts so the default run allows warnings and the new lint:ci script keeps the strict budget
- switch the pre-push hook and CI workflow to invoke lint:ci while keeping local linting lenient by default
- refresh the README, contributing guide, and changelog to document the workflow split

## Testing
- `pnpm lint` *(fails: existing @typescript-eslint/no-unsafe-* errors in packages/ui tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ec5473e1388325bdfac587564df4d2