### PR TITLE
Fix dev stack quoting for Windows shells

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### Unreleased — Hotfix Batch 03
 
+- HOTFIX-043 (Task 0070): Swapped the `pnpm run dev:stack` script's `concurrently`
+  argument quoting to double quotes so Windows shells stop forwarding literal
+  `'` characters, unblocking the façade read-model, transport, and UI dev stack
+  from boot failures on cmd and PowerShell.
+
 - Task 0069: Split the workspace lint workflow into a warning-tolerant local
   script and a strict `lint:ci` variant, updated the pre-push hook/CI pipeline
   to gate on the strict run, and refreshed the README and contributing guide to

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "dev": "pnpm -r --parallel dev",
-    "dev:stack": "pnpm exec concurrently --kill-others --restart-tries 0 --names 'facade-rm,facade-transport,ui' --prefix-colors 'cyan.bold,magenta.bold,green.bold' \"pnpm --filter @wb/facade dev:server\" \"pnpm --filter @wb/facade transport:dev\" \"pnpm --filter @wb/ui dev\"",
+    "dev:stack": "pnpm exec concurrently --kill-others --restart-tries 0 --names \"facade-rm,facade-transport,ui\" --prefix-colors \"cyan.bold,magenta.bold,green.bold\" \"pnpm --filter @wb/facade dev:server\" \"pnpm --filter @wb/facade transport:dev\" \"pnpm --filter @wb/ui dev\"",
     "build": "pnpm -r build",
     "typecheck": "pnpm -w tsc -p packages/engine/tsconfig.spec.json --noEmit",
     "lint": "pnpm exec eslint \"packages/**/*.{ts,tsx}\"",


### PR DESCRIPTION
## Summary
- quote the concurrently name and prefix arguments with double quotes so Windows shells stop passing literal apostrophes
- document the dev stack quoting fix in the changelog

## Testing
- pnpm run dev:stack


------
https://chatgpt.com/codex/tasks/task_e_68ec56e31f38832599b52e21a065888a