### PR TITLE
Fix workspace root route path to prevent blank UI

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### Unreleased — Hotfix Batch 03
 
+- HOTFIX-044: Patched the workspace router to declare the `/` layout route
+  explicitly, preventing `No routes matched location "/"` crashes that
+  manifested as a blank page when visiting the Vite dev server root, and added
+  regression coverage for the root-path redirect to the dashboard.
+
 - HOTFIX-043 (Task 0070): Swapped the `pnpm run dev:stack` script's `concurrently`
   argument quoting to double quotes so Windows shells stop forwarding literal
   `'` characters, unblocking the façade read-model, transport, and UI dev stack

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1,19 +1,7 @@
 import type { ReactElement } from "react";
-import {
-  Navigate,
-  Outlet,
-  Route,
-  RouterProvider,
-  createBrowserRouter,
-  createRoutesFromElements
-} from "react-router-dom";
-import { LeftRail } from "@ui/components/layout/LeftRail";
-import { WorkspaceLayout } from "@ui/layout/WorkspaceLayout";
-import { workspaceTopLevelRoutes } from "@ui/lib/navigation";
-import { DashboardRoute } from "@ui/routes/DashboardRoute";
-import { WorkforceRoute } from "@ui/routes/WorkforceRoute";
-import { ZoneDetailRoute } from "@ui/routes/ZoneDetailRoute";
+import { RouterProvider, createBrowserRouter } from "react-router-dom";
 import { createTelemetryBinder } from "@ui/transport";
+import { workspaceRoutes } from "@ui/routes/workspaceRoutes";
 
 const runtimeBaseUrl = (() => {
   const configured = import.meta.env.VITE_TRANSPORT_BASE_URL as string | undefined;
@@ -39,25 +27,7 @@ if (telemetryBinder) {
   console.warn("Telemetry binder initialisation skipped: transport base URL was not configured.");
 }
 
-const router = createBrowserRouter(
-  createRoutesFromElements(
-    <Route
-      element={
-        <WorkspaceLayout
-          leftRail={<LeftRail />}
-          main={<Outlet />}
-          footer={<p className="text-xs">Built with Node.js 22 · Deterministic engine scaffold (SEC v0.2.1)</p>}
-        />
-      }
-    >
-      <Route index element={<Navigate to={workspaceTopLevelRoutes.dashboard.path} replace />} />
-      <Route path={workspaceTopLevelRoutes.dashboard.path} element={<DashboardRoute />} />
-      <Route path="structures/:structureId/zones/:zoneId" element={<ZoneDetailRoute />} />
-      <Route path={workspaceTopLevelRoutes.workforce.path} element={<WorkforceRoute />} />
-      <Route path="*" element={<Navigate to={workspaceTopLevelRoutes.dashboard.path} replace />} />
-    </Route>
-  )
-);
+const router = createBrowserRouter(workspaceRoutes);
 
 function App(): ReactElement {
   return <RouterProvider router={router} />;

--- a/packages/ui/src/routes/workspaceRoutes.tsx
+++ b/packages/ui/src/routes/workspaceRoutes.tsx
@@ -1,0 +1,30 @@
+import { Navigate, Outlet, Route, createRoutesFromElements } from "react-router-dom";
+import { LeftRail } from "@ui/components/layout/LeftRail";
+import { WorkspaceLayout } from "@ui/layout/WorkspaceLayout";
+import { workspaceTopLevelRoutes } from "@ui/lib/navigation";
+import { DashboardRoute } from "@ui/routes/DashboardRoute";
+import { WorkforceRoute } from "@ui/routes/WorkforceRoute";
+import { ZoneDetailRoute } from "@ui/routes/ZoneDetailRoute";
+
+export const workspaceRoutes = createRoutesFromElements(
+  <Route
+    path="/"
+    element={
+      <WorkspaceLayout
+        leftRail={<LeftRail />}
+        main={<Outlet />}
+        footer={
+          <p className="text-xs">
+            Built with Node.js 22 · Deterministic engine scaffold (SEC v0.2.1)
+          </p>
+        }
+      />
+    }
+  >
+    <Route index element={<Navigate to={workspaceTopLevelRoutes.dashboard.path} replace />} />
+    <Route path={workspaceTopLevelRoutes.dashboard.path} element={<DashboardRoute />} />
+    <Route path="structures/:structureId/zones/:zoneId" element={<ZoneDetailRoute />} />
+    <Route path={workspaceTopLevelRoutes.workforce.path} element={<WorkforceRoute />} />
+    <Route path="*" element={<Navigate to={workspaceTopLevelRoutes.dashboard.path} replace />} />
+  </Route>
+);

--- a/packages/ui/tests/routing.test.tsx
+++ b/packages/ui/tests/routing.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { RouterProvider, createMemoryRouter } from "react-router-dom";
+import { workspaceRoutes } from "@ui/routes/workspaceRoutes";
+
+describe("workspaceRoutes", () => {
+  it("renders the dashboard when navigating to the root path", () => {
+    const router = createMemoryRouter(workspaceRoutes, { initialEntries: ["/"] });
+
+    render(<RouterProvider router={router} />);
+
+    expect(
+      screen.getByRole("heading", { level: 2, name: /operations dashboard/i })
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add an explicit `/` layout route for the workspace shell and share the route configuration from a dedicated module
- update the app shell to consume the shared routes and add coverage that the root path renders the dashboard
- document the hotfix in the changelog

## Testing
- pnpm --filter ui lint
- pnpm --filter ui test -- routing.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ec58699e20832589881f11ca2d1375