### PR TITLE
docs(ui): renumber UI task docs to thousand-series IDs

### DIFF
--- a/docs/tasks/ui/0000-global-shell-and-sim-control-bar.md
+++ b/docs/tasks/ui/0000-global-shell-and-sim-control-bar.md
@@ -1,6 +1,6 @@
 # Global Shell & Sim Control Bar
 
-**ID:** 0100
+**ID:** 0000
 **Status:** Planned
 **Owner:** unassigned
 **Priority:** P1

--- a/docs/tasks/ui/1000-read-model-aggregation-layer.md
+++ b/docs/tasks/ui/1000-read-model-aggregation-layer.md
@@ -1,6 +1,6 @@
 # Read-Model Aggregation Layer
 
-**ID:** 0101
+**ID:** 1000
 **Status:** Planned
 **Owner:** unassigned
 **Priority:** P1

--- a/docs/tasks/ui/2000-structure-overview-module.md
+++ b/docs/tasks/ui/2000-structure-overview-module.md
@@ -1,6 +1,6 @@
 # Structure Overview Module
 
-**ID:** 0102
+**ID:** 2000
 **Status:** Planned
 **Owner:** unassigned
 **Priority:** P1
@@ -17,7 +17,7 @@ This view provides entry points for duplicate/move/capacity advisor flows and al
   - Display rooms grid with purpose, area/volume, free capacity, zone count, warning badges, and workforce snapshot panel.
   - Surface buttons/links that launch duplicate room, device move, and capacity advisor flows provided by sibling tasks.
 - Out:
-  - Implementing the duplicate/move/capacity advisor internals (handled by Tasks 0107 and 0108).
+  - Implementing the duplicate/move/capacity advisor internals (handled by Tasks 7000 and 8000).
   - Editing tariffs or other global economy configuration (read-only per plan).
 
 ## Deliverables
@@ -33,7 +33,7 @@ This view provides entry points for duplicate/move/capacity advisor flows and al
 - Capacity/coverage tiles visualize lighting coverage vs demand, HVAC/ACH vs room volume, and hourly power draw with warning badges when limits are breached.
 - Rooms grid lists each room with purpose, area/volume, free capacity, zone counts, and warning badges while exposing duplicate/move entry points.
 - Workforce snapshot highlights latest actions scoped to the structure using read-model data.
-- Buttons for duplicate room and device move trigger the flows defined in Tasks 0107/0108 (stubbing while those tasks are pending is acceptable).
+- Buttons for duplicate room and device move trigger the flows defined in Tasks 7000/8000 (stubbing while those tasks are pending is acceptable).
 
 ## References
 - docs/proposals/20251013-ui-plan.md §1.1, §11.3

--- a/docs/tasks/ui/3000-room-detail-module.md
+++ b/docs/tasks/ui/3000-room-detail-module.md
@@ -1,6 +1,6 @@
 # Room Detail Module
 
-**ID:** 0103
+**ID:** 3000
 **Status:** Planned
 **Owner:** unassigned
 **Priority:** P1
@@ -18,7 +18,7 @@ Delivering this module ensures room diagnostics, baselines, and movement afforda
   - Display device tiles by class with condition %, contribution, eligibility, and workforce timeline entries for the room.
   - Provide UI triggers for create/duplicate zone, move zones, set baselines, and device move/remove/replace flows provided by sibling tasks.
 - Out:
-  - Implementing the zone creation/duplication and movement internals (handled by Task 0107/0108).
+  - Implementing the zone creation/duplication and movement internals (handled by Task 7000/8000).
   - Editing device firmware or automation beyond baseline target adjustments.
 
 ## Deliverables

--- a/docs/tasks/ui/4000-zone-detail-module.md
+++ b/docs/tasks/ui/4000-zone-detail-module.md
@@ -1,6 +1,6 @@
 # Zone Detail Module
 
-**ID:** 0104
+**ID:** 4000
 **Status:** Planned
 **Owner:** unassigned
 **Priority:** P1

--- a/docs/tasks/ui/5000-lighting-and-climate-control-cards.md
+++ b/docs/tasks/ui/5000-lighting-and-climate-control-cards.md
@@ -1,6 +1,6 @@
 # Lighting & Climate Control Cards
 
-**ID:** 0105
+**ID:** 5000
 **Status:** Planned
 **Owner:** unassigned
 **Priority:** P1

--- a/docs/tasks/ui/6000-hr-directory-and-tasking-surface.md
+++ b/docs/tasks/ui/6000-hr-directory-and-tasking-surface.md
@@ -1,6 +1,6 @@
 # HR Directory & Tasking Surface
 
-**ID:** 0106
+**ID:** 6000
 **Status:** Planned
 **Owner:** unassigned
 **Priority:** P1

--- a/docs/tasks/ui/7000-room-and-zone-create-duplicate-flows.md
+++ b/docs/tasks/ui/7000-room-and-zone-create-duplicate-flows.md
@@ -1,6 +1,6 @@
 # Room & Zone Create/Duplicate Flows
 
-**ID:** 0107
+**ID:** 7000
 **Status:** Planned
 **Owner:** unassigned
 **Priority:** P1

--- a/docs/tasks/ui/8000-inline-rename-and-movement-flows.md
+++ b/docs/tasks/ui/8000-inline-rename-and-movement-flows.md
@@ -1,6 +1,6 @@
 # Inline Rename & Movement Flows
 
-**ID:** 0108
+**ID:** 8000
 **Status:** Planned
 **Owner:** unassigned
 **Priority:** P1

--- a/docs/tasks/ui/9000-ui-validation-and-test-harness.md
+++ b/docs/tasks/ui/9000-ui-validation-and-test-harness.md
@@ -1,6 +1,6 @@
 # UI Validation & Test Harness
 
-**ID:** 0109
+**ID:** 9000
 **Status:** Planned
 **Owner:** unassigned
 **Priority:** P1


### PR DESCRIPTION
## Summary
- rename the UI task specifications to the 0000/1000/… thousand-series numbering scheme without altering their basenames
- update each task document to use the new IDs internally and refresh cross-task references to the matching thousand IDs

## Testing
- pnpm -w typecheck *(fails: existing zod schema typing errors in engine packages)*
- pnpm -w lint *(fails: existing widespread @typescript-eslint/no-unsafe-* violations across packages)*
- pnpm -w test *(fails: @wb/transport-sio vitest suite exits with status 1)*

------
https://chatgpt.com/codex/tasks/task_e_68ecee693be48325b5621033a0ae2593