### PR TITLE
docs: decompose UI task 5000

### DIFF
--- a/docs/tasks/ui/5000-lighting-and-climate-control-cards.md
+++ b/docs/tasks/ui/5000-lighting-and-climate-control-cards.md
@@ -36,3 +36,9 @@ These cards enforce the 24-hour light schedule constraint and centralize device 
 ## References
 - docs/proposals/20251013-ui-plan.md §2, §11.6
 - AGENTS.md (root) — device placement & heat coupling guidance
+
+## Execution Order Checklist
+- [ ] 5100 — Control Card Foundation
+- [ ] 5200 — Lighting Control Card & Schedule Validation
+- [ ] 5300 — Climate Control Card Device Tiles
+- [ ] 5400 — Control Card Integration & Documentation

--- a/docs/tasks/ui/5100-control-card-foundation.md
+++ b/docs/tasks/ui/5100-control-card-foundation.md
@@ -1,0 +1,33 @@
+# Control Card Foundation
+
+**ID:** 5100
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** ui, controls
+
+## Rationale
+Establish the reusable control card scaffolding so lighting and climate surfaces share consistent layout, header semantics, and ghost states before feature-specific logic is layered on.
+
+## Scope
+- In:
+  - Create shared control card layout primitives covering header, body sections, device tile grid, and ghost state placeholders.
+  - Provide deviation badge logic that highlights measured vs target variance without binding to specific metrics.
+  - Implement ghosted device-class callouts that emit a structured event for later CTA routing.
+- Out:
+  - Lighting-specific metrics, schedule editors, or DLI logic.
+  - Climate-specific metric rendering or throughput math.
+  - Final wiring of CTA navigation (handled once hooks are integrated).
+
+## Deliverables
+- Add shared card components under `packages/ui/src/components/controls` with props for measured value, target value, deviation badge, and child content slots.
+- Introduce ghosted device-class placeholders that can be slotted into lighting or climate cards, emitting an intent payload describing the missing class.
+- Create Vitest suites covering header rendering, deviation badge state changes, and ghost placeholder visibility.
+
+## Acceptance Criteria
+- Shared control card renders header with measured vs target values and shows a deviation badge when provided thresholds are exceeded.
+- Device tile grid supports both populated and empty states, displaying ghost placeholders for missing classes using the shared component.
+- Card emits a structured `onGhostAction` callback when a ghost placeholder is activated, enabling downstream CTA wiring.
+
+## Test Requirements
+- Vitest: `pnpm --filter ui vitest run --runInBand --config vitest.config.ts`

--- a/docs/tasks/ui/5200-lighting-control-card.md
+++ b/docs/tasks/ui/5200-lighting-control-card.md
@@ -1,0 +1,32 @@
+# Lighting Control Card & Schedule Validation
+
+**ID:** 5200
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** ui, controls, lighting
+
+## Rationale
+Deliver lighting-specific metrics and the schedule editor on top of the shared control card so cultivation teams can manage PPFD targets, review DLI previews, and enforce SEC light cycle constraints.
+
+## Scope
+- In:
+  - Implement lighting control card composition using the shared control card foundation.
+  - Build the 15-minute grid schedule editor with validation enforcing exactly 24 hours of total coverage and start-hour normalization.
+  - Calculate and display derived DLI values alongside PPFD targets using provided intensity and schedule data.
+- Out:
+  - Real-time telemetry sourcing (hooked in integration task).
+  - Device move/remove intent wiring beyond enabling/disabling toggles.
+
+## Deliverables
+- Add lighting control card component under `packages/ui/src/components/controls` rendering PPFD header, target input, DLI pill, and device tile slots.
+- Introduce schedule validation utilities under `packages/ui/src/lib` (or equivalent) covering 15-minute grid normalization, sum=24h enforcement, and error messaging.
+- Provide Vitest suites for schedule validation edge cases and component rendering (including DLI preview and disable/enable toggles).
+
+## Acceptance Criteria
+- Lighting card displays current PPFD, editable target PPFD, and a DLI preview pill sourced from schedule data.
+- Schedule editor prevents submission of schedules whose on/off totals deviate from 24 hours and snaps entries to 15-minute increments.
+- Device tiles within the lighting card expose enable/disable affordances and reflect contribution percentages based on provided props.
+
+## Test Requirements
+- Vitest: `pnpm --filter ui vitest run --runInBand --config vitest.config.ts`

--- a/docs/tasks/ui/5300-climate-control-card.md
+++ b/docs/tasks/ui/5300-climate-control-card.md
@@ -1,0 +1,32 @@
+# Climate Control Card Device Tiles
+
+**ID:** 5300
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** ui, controls, climate
+
+## Rationale
+Provide the climate control presentation so operators can compare current vs target environmental metrics and manage device class throughput without overlapping schedule work already handled in lighting.
+
+## Scope
+- In:
+  - Compose the climate control card using the shared control foundation.
+  - Render temperature, relative humidity, CO₂, and ACH targets alongside measured values and deviation badges.
+  - Display device tiles per class (HVAC, fans, heaters, humidifiers/dehumidifiers, CO₂ delivery) showing throughput/capacity percentages and enable/disable/move/remove affordances.
+- Out:
+  - Capacity advisor routing and data sourcing (handled in integration task).
+  - Automation logic for balancing multi-device throughput.
+
+## Deliverables
+- Implement climate control card component under `packages/ui/src/components/controls` supporting per-metric sections and class-specific device grids.
+- Provide formatting utilities if needed for throughput and capacity percentages under `packages/ui/src/lib`.
+- Add Vitest suites covering rendering of all metric sections, device tile affordances, and throughput percentage calculations.
+
+## Acceptance Criteria
+- Climate control card surfaces current vs target temperature, RH, CO₂, and ACH values with deviation badges when tolerances are exceeded.
+- Device tiles list each climate device class, exposing enable/disable/move/remove affordances and displaying throughput and capacity percentages.
+- Empty states for missing classes render using the shared ghost placeholders.
+
+## Test Requirements
+- Vitest: `pnpm --filter ui vitest run --runInBand --config vitest.config.ts`

--- a/docs/tasks/ui/5400-control-card-integration.md
+++ b/docs/tasks/ui/5400-control-card-integration.md
@@ -1,0 +1,34 @@
+# Control Card Integration & Documentation
+
+**ID:** 5400
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** ui, controls, integration
+
+## Rationale
+Wire the lighting and climate control cards into live zone/room views with read-model data, ensuring CTA routing and documentation so operators receive a complete, actionable experience.
+
+## Scope
+- In:
+  - Extend read-model/state hooks to provide current vs target metrics, device tile data, and capacity advisor metadata consumed by both cards.
+  - Mount lighting and climate control cards in the zone and room detail views using the shared foundation.
+  - Implement the "Open Capacity Advisor" CTA wiring that navigates to the structure-level advisor entry point.
+  - Update documentation to record delivery of the control cards.
+- Out:
+  - Backend changes to emit new telemetry fields (assume required data already available or stubbed).
+  - Future automation or optimization logic beyond card rendering.
+
+## Deliverables
+- Update hooks under `packages/ui/src/hooks` (or equivalent read-model accessors) to expose measured vs target values, device tile payloads, and missing-class metadata for lighting and climate.
+- Integrate the lighting and climate control cards into the appropriate zone/room view components, ensuring layout alignment with existing modules.
+- Implement CTA routing for ghosted device classes via the shared `onGhostAction` callback, connecting to the structure-level capacity advisor route.
+- Append a CHANGELOG entry in `docs/CHANGELOG.md` capturing the introduction of the control cards.
+
+## Acceptance Criteria
+- Zone and room views render both lighting and climate control cards populated with live hook data, including deviation badges when readings breach thresholds.
+- Missing device classes trigger the shared CTA, navigating to the capacity advisor entry point when activated.
+- Documentation reflects the addition of the control cards, including any notable integration details.
+
+## Test Requirements
+- Vitest: `pnpm --filter ui vitest run --runInBand --config vitest.config.ts` (include React Testing Library integration tests covering hook wiring and CTA routing mocks).


### PR DESCRIPTION
## Summary
- break UI task 5000 into four focused follow-up task documents
- add execution order checklist referencing the new subtasks

## Testing
- `pnpm --filter @wb/engine test:imports`


------
https://chatgpt.com/codex/tasks/task_e_68f061a28d708325b64d82fa377f5359