### PR TITLE
feat(ui): implement room detail module

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -60,6 +60,15 @@
   capacity/coverage tiles, rooms grid actions, and a workforce snapshot, plus
   deterministic fixtures and Vitest coverage under
   `packages/ui/src/pages/__tests__/StructurePage.test.tsx`.
+- Task 3000: Delivered the room detail module with a dedicated
+  `structures/:structureId/rooms/:roomId` route, breadcrumb-aware navigation
+  helpers, read-model backed header metrics (purpose, capacity, ACH baselines)
+  with inline rename stub, zone health/pest summary cards, climate & airflow
+  target comparisons, device group panels with move/remove/replace stubs, a
+  timeline + actions rail for create/duplicate/move flows, router-aware
+  breadcrumbs/zone links with fallback copy when no router context is present,
+  and Vitest coverage validating rendering plus action entry points and link
+  behaviours (`packages/ui/src/pages/__tests__/RoomDetailPage.test.tsx`).
 - Task 0023: Added façade read-model schema validators with versioned metadata, unit coverage for happy/negative paths, and documentation for the three schema identifiers to lock UI contracts to Proposal §6.
 - Task 0024: Introduced Fastify-backed façade HTTP endpoints for company tree, structure tariffs, and workforce view read-models with schema validation guards, integration coverage for success/error responses, and a dev server script for local pairing with the transport adapter.
 - Task 0025: Delivered façade read-model client SDK fetch helpers with typed error handling, unit coverage for network/schema failures, and REST client documentation for manual endpoint verification.

--- a/packages/ui/src/components/layout/__tests__/LeftRail.test.tsx
+++ b/packages/ui/src/components/layout/__tests__/LeftRail.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor, within } from "@testing-library/rea
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LeftRail } from "@ui/components/layout/LeftRail";
-import { buildZonePath, workspaceStructures, workspaceTopLevelRoutes } from "@ui/lib/navigation";
+import { buildRoomPath, buildZonePath, workspaceStructures, workspaceTopLevelRoutes } from "@ui/lib/navigation";
 import { workspaceCopy } from "@ui/design/tokens";
 
 describe("LeftRail navigation", () => {
@@ -88,6 +88,16 @@ describe("LeftRail navigation", () => {
 
     const zoneLink = screen.getByRole("link", { name: new RegExp(targetZone.name, "i") });
     expect(zoneLink).toHaveAttribute("aria-current", "page");
+  });
+
+  it("expands the active structure when visiting a room detail route", () => {
+    const targetStructure = workspaceStructures[0];
+    const targetRoom = targetStructure.rooms[0];
+
+    renderWithRouter(buildRoomPath(targetStructure.id, targetRoom.id));
+
+    const structureToggle = screen.getByRole("button", { name: new RegExp(`^${targetStructure.name}`, "i") });
+    expect(structureToggle).toHaveAttribute("aria-expanded", "true");
   });
 
   it("collapses into a condensed mini-rail on narrow viewports and expands when toggled", async () => {

--- a/packages/ui/src/components/rooms/RoomClimateSnapshot.tsx
+++ b/packages/ui/src/components/rooms/RoomClimateSnapshot.tsx
@@ -1,0 +1,42 @@
+import type { ReactElement } from "react";
+import { GaugeCircle } from "lucide-react";
+import type { RoomClimateOverview } from "@ui/pages/roomDetailHooks";
+
+export interface RoomClimateSnapshotProps {
+  readonly climate: RoomClimateOverview;
+}
+
+export function RoomClimateSnapshot({ climate }: RoomClimateSnapshotProps): ReactElement {
+  return (
+    <section aria-labelledby="room-climate-heading" className="space-y-4">
+      <div className="flex items-center gap-2">
+        <GaugeCircle aria-hidden="true" className="size-5 text-accent-primary" />
+        <h3 className="text-lg font-semibold text-text-primary" id="room-climate-heading">
+          Climate & airflow snapshot
+        </h3>
+      </div>
+      <p className="text-sm text-text-muted">
+        Baselines compare target environmental conditions against current readings. Status badges indicate whether telemetry is
+        within acceptable tolerances per SEC airflow and climate guidance.
+      </p>
+      {climate.notes ? <p className="rounded-xl border border-border-base bg-canvas-subtle/60 p-4 text-sm text-text-muted">{climate.notes}</p> : null}
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {climate.metrics.map((metric) => (
+          <article key={metric.id} className="rounded-xl border border-border-base bg-canvas-subtle/60 p-4" aria-label={metric.label}>
+            <header className="flex items-center justify-between gap-2">
+              <h4 className="text-sm font-semibold uppercase tracking-[0.2em] text-text-primary">{metric.label}</h4>
+              <span
+                className={`text-xs font-medium ${metric.status === "ok" ? "text-accent-primary" : "text-accent-critical"}`}
+              >
+                {metric.statusLabel}
+              </span>
+            </header>
+            <p className="mt-3 text-lg font-semibold text-text-primary">{metric.measuredLabel}</p>
+            <p className="text-xs text-text-muted">{metric.targetLabel}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+

--- a/packages/ui/src/components/rooms/RoomDevicesPanel.tsx
+++ b/packages/ui/src/components/rooms/RoomDevicesPanel.tsx
@@ -1,0 +1,73 @@
+import type { ReactElement } from "react";
+import { Wrench } from "lucide-react";
+import type { RoomDeviceGroup } from "@ui/pages/roomDetailHooks";
+
+export interface RoomDevicesPanelProps {
+  readonly groups: readonly RoomDeviceGroup[];
+}
+
+export function RoomDevicesPanel({ groups }: RoomDevicesPanelProps): ReactElement {
+  return (
+    <section aria-labelledby="room-devices-heading" className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Wrench aria-hidden="true" className="size-5 text-accent-primary" />
+        <h3 className="text-lg font-semibold text-text-primary" id="room-devices-heading">
+          Device allocations
+        </h3>
+      </div>
+      <p className="text-sm text-text-muted">
+        Devices are grouped by class with condition, contribution, and eligibility labels. Move, remove, and replace flows are
+        stubbed pending Task 8000-series orchestration.
+      </p>
+      {groups.length === 0 ? (
+        <p className="rounded-xl border border-border-base bg-canvas-subtle/60 p-4 text-sm text-text-muted">
+          No devices attached to this room yet.
+        </p>
+      ) : (
+        <div className="space-y-4">
+          {groups.map((group) => (
+            <article key={group.id} className="rounded-xl border border-border-base bg-canvas-subtle/60 p-4" aria-label={`${group.title} devices`}>
+              <header className="flex items-center justify-between gap-2">
+                <h4 className="text-sm font-semibold uppercase tracking-[0.2em] text-text-primary">{group.title}</h4>
+                <span className="text-xs text-text-muted">{group.devices.length} devices</span>
+              </header>
+              <ul className="mt-4 space-y-3">
+                {group.devices.map((device) => (
+                  <li key={device.id} className="rounded-lg border border-border-base bg-canvas-base p-3">
+                    <div className="flex flex-col gap-1 text-sm">
+                      <span className="text-text-primary font-medium">{device.name}</span>
+                      <span className="text-text-muted">{device.conditionLabel}</span>
+                      <span className="text-text-muted">{device.contributionLabel}</span>
+                      <span className="text-xs text-text-muted">{device.eligibilityLabel}</span>
+                      {device.warnings.length > 0 ? (
+                        <div className="mt-2 space-y-1 text-xs text-accent-critical">
+                          {device.warnings.map((warning) => (
+                            <p key={warning}>{warning}</p>
+                          ))}
+                        </div>
+                      ) : null}
+                    </div>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      {device.actions.map((action) => (
+                        <button
+                          key={action.id}
+                          type="button"
+                          className="inline-flex items-center gap-2 rounded-lg border border-border-base bg-canvas-subtle px-3 py-1 text-xs font-medium text-text-primary transition hover:border-accent-primary/40 hover:bg-canvas-subtle/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-canvas-raised"
+                          onClick={action.onSelect}
+                          title={action.disabledReason}
+                        >
+                          {action.label}
+                        </button>
+                      ))}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+

--- a/packages/ui/src/components/rooms/RoomHeader.tsx
+++ b/packages/ui/src/components/rooms/RoomHeader.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useState, type FormEvent, type ReactElement } from "react";
+import { DoorOpen, Pencil, X } from "lucide-react";
+import type { RoomDetailHeader } from "@ui/pages/roomDetailHooks";
+
+export interface RoomHeaderProps {
+  readonly header: RoomDetailHeader;
+  readonly onRename: (nextName: string) => void;
+  readonly renameDisabledReason?: string;
+}
+
+export function RoomHeader({ header, onRename, renameDisabledReason }: RoomHeaderProps): ReactElement {
+  const [isEditing, setIsEditing] = useState(false);
+  const [draftName, setDraftName] = useState(header.roomName);
+
+  useEffect(() => {
+    setDraftName(header.roomName);
+    setIsEditing(false);
+  }, [header.roomName]);
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault();
+    const trimmed = draftName.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    onRename(trimmed);
+    setIsEditing(false);
+  }
+
+  const achTarget = header.achTarget;
+  const achCurrent = header.achCurrent;
+  const achPercent = achTarget > 0 ? Math.min(100, Math.round((achCurrent / achTarget) * 100)) : 0;
+  const achStatus = achCurrent >= achTarget ? "ok" : "warn";
+
+  return (
+    <header className="space-y-4">
+      <p className="text-sm uppercase tracking-[0.25em] text-accent-muted">{header.structureName}</p>
+      <div className="flex flex-wrap items-center gap-4">
+        <div className="flex items-center gap-3">
+          <DoorOpen aria-hidden="true" className="size-6 text-accent-primary" />
+          <form onSubmit={handleSubmit} className="flex items-center gap-2" aria-label="Rename room">
+            <label htmlFor="room-name-input" className="sr-only">
+              Room name
+            </label>
+            <input
+              id="room-name-input"
+              className="rounded-lg border border-border-base bg-canvas-base px-3 py-1 text-3xl font-semibold text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-canvas-raised"
+              value={draftName}
+              onChange={(event) => {
+                setDraftName(event.target.value);
+              }}
+              readOnly={!isEditing}
+              aria-disabled={!isEditing}
+            />
+            {isEditing ? (
+              <div className="flex items-center gap-2">
+                <button
+                  type="submit"
+                  className="inline-flex items-center gap-2 rounded-lg border border-accent-primary/60 bg-accent-primary/10 px-3 py-1 text-sm font-medium text-text-primary transition hover:border-accent-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-canvas-raised"
+                >
+                  Save
+                </button>
+                <button
+                  type="button"
+                  className="inline-flex items-center gap-2 rounded-lg border border-border-base bg-canvas-base px-3 py-1 text-sm text-text-muted transition hover:border-border-strong hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-canvas-raised"
+                  onClick={() => {
+                    setIsEditing(false);
+                    setDraftName(header.roomName);
+                  }}
+                >
+                  <X aria-hidden="true" className="size-4" />
+                  Cancel
+                </button>
+              </div>
+            ) : (
+              <button
+                type="button"
+                className="inline-flex items-center gap-2 rounded-lg border border-border-base bg-canvas-base px-3 py-1 text-sm font-medium text-text-primary transition hover:border-accent-primary/40 hover:bg-canvas-subtle/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-canvas-raised"
+                onClick={() => {
+                  setIsEditing(true);
+                }}
+                title={renameDisabledReason}
+              >
+                <Pencil aria-hidden="true" className="size-4" />
+                Rename
+              </button>
+            )}
+          </form>
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <div className="rounded-xl border border-border-base bg-canvas-subtle/60 p-4">
+          <p className="text-xs uppercase tracking-[0.2em] text-accent-muted">Purpose</p>
+          <p className="text-lg font-semibold text-text-primary">{header.purposeLabel}</p>
+        </div>
+        <div className="rounded-xl border border-border-base bg-canvas-subtle/60 p-4">
+          <p className="text-xs uppercase tracking-[0.2em] text-accent-muted">Floor area</p>
+          <p className="text-lg font-semibold text-text-primary">{header.areaUsedLabel}</p>
+          <p className="text-xs text-text-muted">Free: {header.areaFreeLabel}</p>
+        </div>
+        <div className="rounded-xl border border-border-base bg-canvas-subtle/60 p-4">
+          <p className="text-xs uppercase tracking-[0.2em] text-accent-muted">Volume</p>
+          <p className="text-lg font-semibold text-text-primary">{header.volumeUsedLabel}</p>
+          <p className="text-xs text-text-muted">Free: {header.volumeFreeLabel}</p>
+        </div>
+        <div className="rounded-xl border border-border-base bg-canvas-subtle/60 p-4 space-y-2">
+          <p className="text-xs uppercase tracking-[0.2em] text-accent-muted">Baseline ACH</p>
+          <div className="flex items-baseline gap-2">
+            <span className="text-lg font-semibold text-text-primary">{achCurrent.toFixed(1)} ACH</span>
+            <span className="text-xs text-text-muted">Target {achTarget.toFixed(1)} ACH</span>
+          </div>
+          <div className="h-2 w-full overflow-hidden rounded-full bg-border-base/40" role="presentation">
+            <div
+              className={`h-full rounded-full ${achStatus === "ok" ? "bg-accent-primary" : "bg-accent-critical/80"}`}
+              style={{ width: `${achPercent.toFixed(0)}%` }}
+              role="progressbar"
+              aria-valuenow={Math.round(achCurrent)}
+              aria-valuemin={0}
+              aria-valuemax={Math.round(achTarget)}
+              aria-label="Air changes per hour vs target"
+            />
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}
+

--- a/packages/ui/src/components/rooms/RoomTimelinePanel.tsx
+++ b/packages/ui/src/components/rooms/RoomTimelinePanel.tsx
@@ -1,0 +1,64 @@
+import type { ReactElement } from "react";
+import { Clock } from "lucide-react";
+import type { RoomAction, RoomTimelineItem } from "@ui/pages/roomDetailHooks";
+
+export interface RoomTimelinePanelProps {
+  readonly timeline: readonly RoomTimelineItem[];
+  readonly actions: readonly RoomAction[];
+}
+
+export function RoomTimelinePanel({ timeline, actions }: RoomTimelinePanelProps): ReactElement {
+  return (
+    <section aria-labelledby="room-timeline-heading" className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Clock aria-hidden="true" className="size-5 text-accent-primary" />
+        <h3 className="text-lg font-semibold text-text-primary" id="room-timeline-heading">
+          Room activity & actions
+        </h3>
+      </div>
+      <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+        <div>
+          <h4 className="text-sm font-semibold uppercase tracking-[0.2em] text-text-primary">Recent activity</h4>
+          {timeline.length === 0 ? (
+            <p className="mt-3 rounded-xl border border-border-base bg-canvas-subtle/60 p-4 text-sm text-text-muted">
+              No timeline entries yet for this room.
+            </p>
+          ) : (
+            <ol className="mt-3 space-y-3">
+              {timeline.map((entry) => (
+                <li key={entry.id} className="rounded-xl border border-border-base bg-canvas-subtle/60 p-4">
+                  <div className="flex items-baseline justify-between gap-3">
+                    <p className="text-sm font-medium text-text-primary">{entry.title}</p>
+                    <span className="text-xs text-text-muted">{entry.timestampLabel}</span>
+                  </div>
+                  <p className="mt-1 text-xs text-accent-muted uppercase tracking-[0.2em]">{entry.statusLabel}</p>
+                  <p className="mt-2 text-sm text-text-muted">{entry.description}</p>
+                </li>
+              ))}
+            </ol>
+          )}
+        </div>
+        <div className="space-y-3">
+          <h4 className="text-sm font-semibold uppercase tracking-[0.2em] text-text-primary">Actions</h4>
+          <p className="text-xs text-text-muted">
+            Buttons trigger console stubs until Task 7000/8000 wire the orchestration flows.
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {actions.map((action) => (
+              <button
+                key={action.id}
+                type="button"
+                className="inline-flex items-center gap-2 rounded-lg border border-border-base bg-canvas-subtle px-3 py-2 text-xs font-medium text-text-primary transition hover:border-accent-primary/40 hover:bg-canvas-subtle/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-canvas-raised"
+                onClick={action.onSelect}
+                title={action.disabledReason}
+              >
+                {action.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/packages/ui/src/components/rooms/RoomZonesList.tsx
+++ b/packages/ui/src/components/rooms/RoomZonesList.tsx
@@ -1,0 +1,81 @@
+import type { ReactElement } from "react";
+import { AlertTriangle, CheckCircle2, Sprout } from "lucide-react";
+import { Link, useInRouterContext } from "react-router-dom";
+import type { RoomZoneListItem } from "@ui/pages/roomDetailHooks";
+
+export interface RoomZonesListProps {
+  readonly zones: readonly RoomZoneListItem[];
+}
+
+export function RoomZonesList({ zones }: RoomZonesListProps): ReactElement {
+  const hasRouterContext = useInRouterContext();
+
+  return (
+    <section aria-labelledby="room-zones-heading" className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Sprout aria-hidden="true" className="size-5 text-accent-primary" />
+        <h3 className="text-lg font-semibold text-text-primary" id="room-zones-heading">
+          Zones snapshot
+        </h3>
+      </div>
+      <p className="text-sm text-text-muted">
+        Health and readiness indicators highlight pest issues, harvest readiness, and device warnings for each zone within the
+        room.
+      </p>
+      {zones.length === 0 ? (
+        <p className="rounded-xl border border-border-base bg-canvas-subtle/60 p-4 text-sm text-text-muted">
+          No zones assigned yet. Use the action buttons below to create or duplicate a zone when the orchestration ships.
+        </p>
+      ) : (
+        <ul className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {zones.map((zone) => (
+            <li key={zone.id} className="rounded-xl border border-border-base bg-canvas-subtle/60 p-4">
+              <div className="flex items-center justify-between gap-3">
+                {hasRouterContext ? (
+                  <Link
+                    to={zone.link}
+                    className="text-lg font-semibold text-text-primary transition hover:text-accent-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-canvas-raised"
+                  >
+                    {zone.name}
+                  </Link>
+                ) : (
+                  <span className="text-lg font-semibold text-text-primary">{zone.name}</span>
+                )}
+                {zone.readyToHarvest ? (
+                  <span className="inline-flex items-center gap-1 rounded-full bg-accent-primary/10 px-3 py-1 text-xs font-medium text-accent-primary">
+                    <CheckCircle2 aria-hidden="true" className="size-3" /> Ready to harvest
+                  </span>
+                ) : null}
+              </div>
+              <p className="mt-2 text-sm text-text-muted">
+                Health: <span className="font-medium text-text-primary">{zone.healthPercent}%</span> · Quality:
+                <span className="ml-1 font-medium text-text-primary">{zone.qualityPercent}%</span>
+              </p>
+              {zone.pestBadges.length > 0 ? (
+                <ul className="mt-3 flex flex-wrap gap-2 text-xs text-accent-critical" aria-label="Pest indicators">
+                  {zone.pestBadges.map((badge) => (
+                    <li key={badge} className="inline-flex items-center gap-1 rounded-full bg-accent-critical/10 px-3 py-1">
+                      <AlertTriangle aria-hidden="true" className="size-3" /> {badge}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="mt-3 text-xs text-text-muted">No active pest issues detected.</p>
+              )}
+              {zone.deviceWarnings.length > 0 ? (
+                <div className="mt-3 space-y-1" aria-label="Device warnings">
+                  {zone.deviceWarnings.map((warning) => (
+                    <p key={warning} className="text-xs text-accent-critical">
+                      {warning}
+                    </p>
+                  ))}
+                </div>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+

--- a/packages/ui/src/components/structures/StructureRoomsGrid.tsx
+++ b/packages/ui/src/components/structures/StructureRoomsGrid.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from "react";
+import { Link, useInRouterContext } from "react-router-dom";
 import { AlertTriangle, Copy, MoveRight, Sparkles } from "lucide-react";
 
 export interface StructureRoomAction {
@@ -17,6 +18,7 @@ export interface StructureRoomWarning {
 export interface StructureRoomSummary {
   readonly id: string;
   readonly name: string;
+  readonly detailPath: string;
   readonly purposeLabel: string;
   readonly areaUsedLabel: string;
   readonly areaFreeLabel: string;
@@ -58,6 +60,8 @@ function resolveActionIcon(action: StructureRoomAction): ReactElement {
 }
 
 export function StructureRoomsGrid({ rooms }: StructureRoomsGridProps): ReactElement {
+  const hasRouterContext = useInRouterContext();
+
   return (
     <section aria-labelledby="structure-rooms-heading" className="space-y-4">
       <div className="flex items-center gap-2">
@@ -71,13 +75,22 @@ export function StructureRoomsGrid({ rooms }: StructureRoomsGridProps): ReactEle
         stubbed pending Task 7000/8000 flows but retain deterministic identifiers for wiring.
       </p>
       <div className="structure-rooms-grid">
-        {rooms.map((room) => (
-          <article key={room.id} className="structure-room-card" aria-label={`${room.name} room summary`}>
-            <div className="structure-room-card__header">
-              <h4 className="text-lg font-semibold text-text-primary">{room.name}</h4>
-              <p className="structure-room-card__meta">
-                {room.purposeLabel} · Zones: {room.zoneCount}
-              </p>
+          {rooms.map((room) => (
+            <article key={room.id} className="structure-room-card" aria-label={`${room.name} room summary`}>
+              <div className="structure-room-card__header">
+                {hasRouterContext ? (
+                  <Link
+                    to={room.detailPath}
+                    className="text-lg font-semibold text-text-primary transition hover:text-accent-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-canvas-raised"
+                  >
+                    {room.name}
+                  </Link>
+                ) : (
+                  <span className="text-lg font-semibold text-text-primary">{room.name}</span>
+                )}
+                <p className="structure-room-card__meta">
+                  {room.purposeLabel} · Zones: {room.zoneCount}
+                </p>
               <p className="text-sm text-text-primary">
                 {room.areaUsedLabel} used · {room.areaFreeLabel} free
               </p>

--- a/packages/ui/src/lib/navigation.ts
+++ b/packages/ui/src/lib/navigation.ts
@@ -4,10 +4,18 @@ export interface WorkspaceZoneNavItem {
   cultivationMethod: string;
 }
 
+export interface WorkspaceRoomNavItem {
+  id: string;
+  name: string;
+  purpose: string;
+  zones: WorkspaceZoneNavItem[];
+}
+
 export interface WorkspaceStructureNavItem {
   id: string;
   name: string;
   location: string;
+  rooms: WorkspaceRoomNavItem[];
   zones: WorkspaceZoneNavItem[];
 }
 
@@ -16,6 +24,23 @@ export const workspaceStructures: WorkspaceStructureNavItem[] = [
     id: "structure-green-harbor",
     name: "Green Harbor",
     location: "Hamburg",
+    rooms: [
+      {
+        id: "room-veg-a",
+        name: "Veg Room A",
+        purpose: "growroom",
+        zones: [
+          { id: "zone-veg-a-1", name: "Veg A-1", cultivationMethod: "cm-sea-of-green" },
+          { id: "zone-veg-a-2", name: "Veg A-2", cultivationMethod: "cm-screen-of-green" }
+        ]
+      },
+      {
+        id: "room-post-process",
+        name: "Post-Processing",
+        purpose: "storageroom",
+        zones: []
+      }
+    ],
     zones: [
       { id: "zone-veg-a-1", name: "Veg A-1", cultivationMethod: "cm-sea-of-green" },
       { id: "zone-veg-a-2", name: "Veg A-2", cultivationMethod: "cm-screen-of-green" }
@@ -25,6 +50,24 @@ export const workspaceStructures: WorkspaceStructureNavItem[] = [
     id: "structure-harvest-hall",
     name: "Harvest Hall",
     location: "North Annex",
+    rooms: [
+      {
+        id: "room-propagation",
+        name: "Propagation",
+        purpose: "growroom",
+        zones: [
+          { id: "zone-prop-1", name: "Propagation Bay", cultivationMethod: "basic-soil-pot" }
+        ]
+      },
+      {
+        id: "room-drying",
+        name: "Drying",
+        purpose: "storageroom",
+        zones: [
+          { id: "zone-drying", name: "Drying Suite", cultivationMethod: "post-harvest" }
+        ]
+      }
+    ],
     zones: [
       { id: "zone-prop-1", name: "Propagation Bay", cultivationMethod: "basic-soil-pot" },
       { id: "zone-drying", name: "Drying Suite", cultivationMethod: "post-harvest" }
@@ -41,6 +84,10 @@ export const workspaceTopLevelRoutes = {
 
 export function buildZonePath(structureId: string, zoneId: string): string {
   return `/structures/${structureId}/zones/${zoneId}`;
+}
+
+export function buildRoomPath(structureId: string, roomId: string): string {
+  return `/structures/${structureId}/rooms/${roomId}`;
 }
 
 export interface ResolvedZoneNavItem {
@@ -69,4 +116,51 @@ export function resolveZoneByParams(
   }
 
   return { structure, zone };
+}
+
+export interface ResolvedRoomNavItem {
+  structure: WorkspaceStructureNavItem;
+  room: WorkspaceRoomNavItem;
+}
+
+export function resolveRoomByParams(
+  structureId: string | undefined,
+  roomId: string | undefined
+): ResolvedRoomNavItem | undefined {
+  if (!structureId || !roomId) {
+    return undefined;
+  }
+
+  const structure = workspaceStructures.find((item) => item.id === structureId);
+
+  if (!structure) {
+    return undefined;
+  }
+
+  const room = structure.rooms.find((item) => item.id === roomId);
+
+  if (!room) {
+    return undefined;
+  }
+
+  return { structure, room };
+}
+
+export interface RoomBreadcrumbLink {
+  readonly id: string;
+  readonly label: string;
+  readonly path: string;
+}
+
+export function buildRoomBreadcrumbs(
+  structureId: string,
+  structureLabel: string,
+  roomId: string,
+  roomLabel: string
+): RoomBreadcrumbLink[] {
+  return [
+    { id: "structures", label: workspaceTopLevelRoutes.structures.label, path: workspaceTopLevelRoutes.structures.path },
+    { id: structureId, label: structureLabel, path: `/structures/${structureId}` },
+    { id: roomId, label: roomLabel, path: buildRoomPath(structureId, roomId) }
+  ];
 }

--- a/packages/ui/src/pages/RoomDetailPage.tsx
+++ b/packages/ui/src/pages/RoomDetailPage.tsx
@@ -1,0 +1,66 @@
+import type { ReactElement } from "react";
+import { Link, useInRouterContext } from "react-router-dom";
+import { RoomClimateSnapshot } from "@ui/components/rooms/RoomClimateSnapshot";
+import { RoomDevicesPanel } from "@ui/components/rooms/RoomDevicesPanel";
+import { RoomHeader } from "@ui/components/rooms/RoomHeader";
+import { RoomTimelinePanel } from "@ui/components/rooms/RoomTimelinePanel";
+import { RoomZonesList } from "@ui/components/rooms/RoomZonesList";
+import { buildRoomBreadcrumbs } from "@ui/lib/navigation";
+import { useRoomDetailView } from "@ui/pages/roomDetailHooks";
+
+export interface RoomDetailPageProps {
+  readonly structureId: string;
+  readonly roomId: string;
+}
+
+export function RoomDetailPage({ structureId, roomId }: RoomDetailPageProps): ReactElement {
+  const snapshot = useRoomDetailView(structureId, roomId);
+  const breadcrumbs = buildRoomBreadcrumbs(
+    structureId,
+    snapshot.header.structureName,
+    roomId,
+    snapshot.header.roomName
+  );
+  const hasRouterContext = useInRouterContext();
+
+  return (
+    <section aria-label={`Room detail for ${snapshot.header.roomName}`} className="flex flex-1 flex-col gap-6">
+      <nav aria-label="Breadcrumb" className="text-xs text-text-muted">
+        <ol className="flex flex-wrap items-center gap-2">
+          {breadcrumbs.map((crumb, index) => (
+            <li key={crumb.id} className="flex items-center gap-2">
+              {hasRouterContext ? (
+                <Link
+                  to={crumb.path}
+                  className="transition hover:text-accent-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-canvas-raised"
+                >
+                  {crumb.label}
+                </Link>
+              ) : (
+                <span className="text-text-muted">{crumb.label}</span>
+              )}
+              {index < breadcrumbs.length - 1 ? <span aria-hidden="true">/</span> : null}
+            </li>
+          ))}
+        </ol>
+      </nav>
+
+      <RoomHeader
+        header={snapshot.header}
+        onRename={(nextName) => {
+          console.info("[stub] rename room", { structureId, roomId, nextName });
+        }}
+        renameDisabledReason="Rename flows land with Task 7010."
+      />
+
+      <RoomZonesList zones={snapshot.zones} />
+
+      <RoomClimateSnapshot climate={snapshot.climate} />
+
+      <RoomDevicesPanel groups={snapshot.deviceGroups} />
+
+      <RoomTimelinePanel timeline={snapshot.timeline} actions={snapshot.actions} />
+    </section>
+  );
+}
+

--- a/packages/ui/src/pages/__tests__/RoomDetailPage.test.tsx
+++ b/packages/ui/src/pages/__tests__/RoomDetailPage.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it } from "vitest";
+import { RoomDetailPage } from "@ui/pages/RoomDetailPage";
+import { resetReadModelStore } from "@ui/state/readModels";
+
+const STRUCTURE_ID = "structure-green-harbor";
+const ROOM_ID = "room-veg-a";
+const SECTION_HEADING_LEVEL = 3;
+const EXPECTED_BREADCRUMB_COUNT = 3;
+
+describe("RoomDetailPage", () => {
+  beforeEach(() => {
+    resetReadModelStore();
+  });
+
+  it("renders header, zones list, climate snapshot, devices, and actions without router context", () => {
+    render(<RoomDetailPage structureId={STRUCTURE_ID} roomId={ROOM_ID} />);
+
+    const renameInput = screen.getByLabelText(/room name/i);
+    expect(renameInput).toHaveValue("Vegetative Bay A");
+    expect(screen.getByRole("button", { name: /rename/i })).toBeInTheDocument();
+    expect(screen.getByText(/Purpose/i)).toBeInTheDocument();
+    expect(screen.getByText(/Baseline ACH/i)).toBeInTheDocument();
+    const baselineTargets = screen.getAllByText(/Target 6\.0 ACH/i);
+    expect(baselineTargets.length).toBeGreaterThan(0);
+
+    const vegA1 = screen.getByText(/Veg A-1/i);
+    const vegA1Card = vegA1.closest("li");
+    if (!vegA1Card) {
+      throw new Error("Veg A-1 card not found");
+    }
+    expect(within(vegA1Card).getByText(/Ready to harvest/i)).toBeInTheDocument();
+    expect(within(vegA1Card).getByText(/Lighting coverage at 88%/i)).toBeInTheDocument();
+
+    const vegA2 = screen.getByText(/Veg A-2/i);
+    const vegA2Card = vegA2.closest("li");
+    if (!vegA2Card) {
+      throw new Error("Veg A-2 card not found");
+    }
+    expect(within(vegA2Card).getByText(/Active issues: 1/i)).toBeInTheDocument();
+    expect(within(vegA2Card).getByText(/Treatments scheduled: 1/i)).toBeInTheDocument();
+
+    const temperatureCard = screen.getByLabelText(/Air temperature/i);
+    expect(within(temperatureCard).getByText(/Within range/i)).toBeInTheDocument();
+
+    const achCard = screen.getByLabelText(/Air changes per hour$/i);
+    expect(within(achCard).getByText(/Needs attention/i)).toBeInTheDocument();
+    expect(within(achCard).getByText(/5\.2 ACH/i)).toBeInTheDocument();
+
+    const deviceSection = screen
+      .getByRole("heading", { level: SECTION_HEADING_LEVEL, name: /Device allocations/i })
+      .closest("section");
+    if (!deviceSection) {
+      throw new Error("Device section not rendered as section");
+    }
+    const deviceWithin = within(deviceSection);
+    expect(deviceWithin.getByText(/LumenMax 320/i)).toBeInTheDocument();
+    const moveDeviceButtons = deviceWithin.getAllByRole("button", { name: /^Move device$/i });
+    expect(moveDeviceButtons.length).toBeGreaterThan(0);
+    moveDeviceButtons.forEach((button) => {
+      expect(button).toHaveAttribute("title", expect.stringMatching(/Task 8000/i));
+    });
+    const removeDeviceButtons = deviceWithin.getAllByRole("button", { name: /^Remove device$/i });
+    expect(removeDeviceButtons.length).toBeGreaterThan(0);
+    removeDeviceButtons.forEach((button) => {
+      expect(button).toHaveAttribute("title", expect.stringMatching(/Task 8001/i));
+    });
+
+    const timelineSection = screen
+      .getByRole("heading", { level: SECTION_HEADING_LEVEL, name: /Room activity & actions/i })
+      .closest("section");
+    if (!timelineSection) {
+      throw new Error("Timeline section not rendered as section");
+    }
+    const timelineWithin = within(timelineSection);
+    expect(timelineWithin.getByText(/Drain-to-waste flush/i)).toBeInTheDocument();
+    const createZoneButton = timelineWithin.getByRole("button", { name: /Create zone/i });
+    expect(createZoneButton).toHaveAttribute("title", expect.stringMatching(/Task 7000/i));
+  });
+
+  it("renders breadcrumb and zone links when router context is available", () => {
+    render(
+      <MemoryRouter initialEntries={["/structures/structure-green-harbor/rooms/room-veg-a"]}>
+        <RoomDetailPage structureId={STRUCTURE_ID} roomId={ROOM_ID} />
+      </MemoryRouter>
+    );
+
+    const breadcrumbNav = screen.getByLabelText(/breadcrumb/i);
+    const breadcrumbLinks = within(breadcrumbNav).getAllByRole("link");
+    expect(breadcrumbLinks).toHaveLength(EXPECTED_BREADCRUMB_COUNT);
+    expect(breadcrumbLinks[0]).toHaveAttribute("href", "/structures");
+    expect(breadcrumbLinks[1]).toHaveAttribute("href", "/structures/structure-green-harbor");
+    expect(breadcrumbLinks[2]).toHaveAttribute("href", "/structures/structure-green-harbor/rooms/room-veg-a");
+
+    const zoneLink = screen.getByRole("link", { name: /Veg A-1/i });
+    expect(zoneLink).toHaveAttribute("href", "/structures/structure-green-harbor/zones/zone-veg-a-1");
+  });
+});
+

--- a/packages/ui/src/pages/roomDetailHooks.ts
+++ b/packages/ui/src/pages/roomDetailHooks.ts
@@ -1,0 +1,458 @@
+import { useMemo } from "react";
+import { buildZonePath } from "@ui/lib/navigation";
+import { useRoomReadModel, useStructureReadModel } from "@ui/lib/readModelHooks";
+import type {
+  DeviceSummary,
+  RoomReadModel,
+  TimelineEntry,
+  ZoneReadModel
+} from "@ui/state/readModels.types";
+
+export interface RoomDetailHeader {
+  readonly structureName: string;
+  readonly roomName: string;
+  readonly purposeLabel: string;
+  readonly areaUsedLabel: string;
+  readonly areaFreeLabel: string;
+  readonly volumeUsedLabel: string;
+  readonly volumeFreeLabel: string;
+  readonly achCurrent: number;
+  readonly achTarget: number;
+}
+
+export interface RoomZoneListItem {
+  readonly id: string;
+  readonly name: string;
+  readonly link: string;
+  readonly healthPercent: number;
+  readonly qualityPercent: number;
+  readonly readyToHarvest: boolean;
+  readonly pestBadges: readonly string[];
+  readonly deviceWarnings: readonly string[];
+}
+
+export interface RoomClimateMetric {
+  readonly id: string;
+  readonly label: string;
+  readonly measuredLabel: string;
+  readonly targetLabel: string;
+  readonly status: "ok" | "warn";
+  readonly statusLabel: string;
+}
+
+export interface RoomClimateOverview {
+  readonly notes: string | null;
+  readonly metrics: readonly RoomClimateMetric[];
+}
+
+export interface RoomDeviceAction {
+  readonly id: string;
+  readonly label: string;
+  readonly onSelect: () => void;
+  readonly disabledReason: string;
+}
+
+export interface RoomDeviceListItem {
+  readonly id: string;
+  readonly name: string;
+  readonly conditionLabel: string;
+  readonly contributionLabel: string;
+  readonly eligibilityLabel: string;
+  readonly warnings: readonly string[];
+  readonly actions: readonly RoomDeviceAction[];
+}
+
+export interface RoomDeviceGroup {
+  readonly id: string;
+  readonly title: string;
+  readonly devices: readonly RoomDeviceListItem[];
+}
+
+export interface RoomTimelineItem {
+  readonly id: string;
+  readonly title: string;
+  readonly description: string;
+  readonly statusLabel: string;
+  readonly timestampLabel: string;
+}
+
+export interface RoomAction {
+  readonly id: string;
+  readonly label: string;
+  readonly onSelect: () => void;
+  readonly disabledReason: string;
+}
+
+export interface RoomDetailSnapshot {
+  readonly header: RoomDetailHeader;
+  readonly zones: readonly RoomZoneListItem[];
+  readonly climate: RoomClimateOverview;
+  readonly deviceGroups: readonly RoomDeviceGroup[];
+  readonly timeline: readonly RoomTimelineItem[];
+  readonly actions: readonly RoomAction[];
+}
+
+const READY_HEALTH_THRESHOLD_PERCENT = 85;
+const READY_QUALITY_THRESHOLD_PERCENT = 85;
+const ACH_STATUS_TOLERANCE_ACH = 0.4;
+const CLIMATE_STATUS_WITHIN_RANGE = "Within range" as const;
+const CLIMATE_STATUS_NEEDS_ATTENTION = "Needs attention" as const;
+const CLIMATE_STATUS_PENDING = "Telemetry pending" as const;
+
+export function useRoomDetailView(structureId: string, roomId: string): RoomDetailSnapshot {
+  const structure = useStructureReadModel(structureId);
+  const room = useRoomReadModel(structureId, roomId);
+
+  return useMemo(() => {
+    if (!room) {
+      return DEFAULT_SNAPSHOT;
+    }
+
+    const header = toRoomHeader(structure?.name ?? "Structure", room);
+    const zones = room.zones.map((zone) => toZoneListItem(structureId, zone));
+    const climate = toClimateOverview(room);
+    const deviceGroups = groupDevicesByClass(room);
+    const timeline = room.timeline.map(toTimelineItem);
+    const actions = createRoomActions(structureId, room.id);
+
+    return {
+      header,
+      zones,
+      climate,
+      deviceGroups,
+      timeline,
+      actions
+    } satisfies RoomDetailSnapshot;
+  }, [room, structure?.name, structureId]);
+}
+
+interface RoomClimateBaseline {
+  readonly temperature_C: number;
+  readonly relativeHumidity_percent: number;
+  readonly co2_ppm: number;
+}
+
+/* eslint-disable @typescript-eslint/no-magic-numbers */
+const ROOM_CLIMATE_BASELINES: Record<string, RoomClimateBaseline> = Object.freeze({
+  growroom: Object.freeze({ temperature_C: 24, relativeHumidity_percent: 60, co2_ppm: 900 }),
+  storageroom: Object.freeze({ temperature_C: 18, relativeHumidity_percent: 50, co2_ppm: 450 }),
+  laboratory: Object.freeze({ temperature_C: 21, relativeHumidity_percent: 45, co2_ppm: 420 }),
+  breakroom: Object.freeze({ temperature_C: 21, relativeHumidity_percent: 40, co2_ppm: 420 }),
+  salesroom: Object.freeze({ temperature_C: 20, relativeHumidity_percent: 45, co2_ppm: 420 }),
+  workshop: Object.freeze({ temperature_C: 19, relativeHumidity_percent: 45, co2_ppm: 420 })
+});
+
+const FALLBACK_BASELINE: RoomClimateBaseline = Object.freeze({
+  temperature_C: 22,
+  relativeHumidity_percent: 55,
+  co2_ppm: 500
+});
+
+const TEMPERATURE_TOLERANCE_C = 1.2;
+const RH_TOLERANCE_PERCENT = 5;
+const CO2_TOLERANCE_PPM = 120;
+/* eslint-enable @typescript-eslint/no-magic-numbers */
+
+const formatterWhole = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 0,
+  minimumFractionDigits: 0
+});
+
+const formatterOneDecimal = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 1,
+  minimumFractionDigits: 1
+});
+
+function formatArea(value: number): string {
+  return `${formatterWhole.format(Math.round(value))} m²`;
+}
+
+function formatVolume(value: number): string {
+  return `${formatterWhole.format(Math.round(value))} m³`;
+}
+
+function toRoomHeader(structureName: string, room: RoomReadModel): RoomDetailHeader {
+  return {
+    structureName,
+    roomName: room.name,
+    purposeLabel: room.purpose,
+    areaUsedLabel: formatArea(room.capacity.areaUsed_m2),
+    areaFreeLabel: formatArea(room.capacity.areaFree_m2),
+    volumeUsedLabel: formatVolume(room.capacity.volumeUsed_m3),
+    volumeFreeLabel: formatVolume(room.capacity.volumeFree_m3),
+    achCurrent: room.coverage.achCurrent,
+    achTarget: room.coverage.achTarget
+  } satisfies RoomDetailHeader;
+}
+
+function toZoneListItem(structureId: string, zone: ZoneReadModel): RoomZoneListItem {
+  const pestBadges: string[] = [];
+
+  if (zone.pestStatus.activeIssues > 0) {
+    pestBadges.push(`Active issues: ${formatterWhole.format(zone.pestStatus.activeIssues)}`);
+  }
+
+  if (zone.pestStatus.dueInspections > 0) {
+    pestBadges.push(`Inspections due: ${formatterWhole.format(zone.pestStatus.dueInspections)}`);
+  }
+
+  if (zone.pestStatus.upcomingTreatments > 0) {
+    pestBadges.push(`Treatments scheduled: ${formatterWhole.format(zone.pestStatus.upcomingTreatments)}`);
+  }
+
+  const deviceWarnings = zone.coverageWarnings.map((warning) => warning.message);
+  const readyToHarvest = computeReadyToHarvest(zone);
+
+  return {
+    id: zone.id,
+    name: zone.name,
+    link: buildZonePath(structureId, zone.id),
+    healthPercent: zone.kpis.healthPercent,
+    qualityPercent: zone.kpis.qualityPercent,
+    readyToHarvest,
+    pestBadges,
+    deviceWarnings
+  } satisfies RoomZoneListItem;
+}
+
+function computeReadyToHarvest(zone: ZoneReadModel): boolean {
+  return (
+    zone.kpis.healthPercent >= READY_HEALTH_THRESHOLD_PERCENT &&
+    zone.kpis.qualityPercent >= READY_QUALITY_THRESHOLD_PERCENT &&
+    zone.pestStatus.upcomingTreatments === 0 &&
+    zone.pestStatus.activeIssues === 0
+  );
+}
+
+function toClimateOverview(room: RoomReadModel): RoomClimateOverview {
+  const baseline = ROOM_CLIMATE_BASELINES[room.purpose] ?? FALLBACK_BASELINE;
+  const notes = room.climateSnapshot.notes;
+
+  const metrics: RoomClimateMetric[] = [
+    {
+      id: "temperature",
+      label: "Air temperature",
+      measuredLabel: `${formatterOneDecimal.format(room.climateSnapshot.temperature_C)} °C`,
+      targetLabel: `Target ${formatterWhole.format(Math.round(baseline.temperature_C))} °C`,
+      ...resolveStatus(room.climateSnapshot.temperature_C, baseline.temperature_C, TEMPERATURE_TOLERANCE_C)
+    },
+    {
+      id: "relative-humidity",
+      label: "Relative humidity",
+      measuredLabel: `${formatterWhole.format(Math.round(room.climateSnapshot.relativeHumidity_percent))}%`,
+      targetLabel: `Target ${formatterWhole.format(Math.round(baseline.relativeHumidity_percent))}%`,
+      ...resolveStatus(
+        room.climateSnapshot.relativeHumidity_percent,
+        baseline.relativeHumidity_percent,
+        RH_TOLERANCE_PERCENT
+      )
+    },
+    {
+      id: "co2",
+      label: "CO₂ concentration",
+      measuredLabel: `${formatterWhole.format(Math.round(room.climateSnapshot.co2_ppm))} ppm`,
+      targetLabel: `Target ${formatterWhole.format(Math.round(baseline.co2_ppm))} ppm`,
+      ...resolveStatus(room.climateSnapshot.co2_ppm, baseline.co2_ppm, CO2_TOLERANCE_PPM)
+    },
+    {
+      id: "ach",
+      label: "Air changes per hour",
+      measuredLabel: `${formatterOneDecimal.format(room.coverage.achCurrent)} ACH`,
+      targetLabel: `Target ${formatterOneDecimal.format(room.coverage.achTarget)} ACH`,
+      ...resolveStatus(room.coverage.achCurrent, room.coverage.achTarget, ACH_STATUS_TOLERANCE_ACH)
+    }
+  ];
+
+  return {
+    notes,
+    metrics
+  } satisfies RoomClimateOverview;
+}
+
+function resolveStatus(
+  measured: number,
+  target: number,
+  tolerance: number
+): { status: "ok" | "warn"; statusLabel: string } {
+  if (!Number.isFinite(measured) || !Number.isFinite(target)) {
+    return { status: "warn", statusLabel: CLIMATE_STATUS_PENDING };
+  }
+
+  const difference = Math.abs(measured - target);
+  const withinRange = difference <= tolerance;
+
+  return withinRange
+    ? { status: "ok", statusLabel: CLIMATE_STATUS_WITHIN_RANGE }
+    : { status: "warn", statusLabel: CLIMATE_STATUS_NEEDS_ATTENTION };
+}
+
+function groupDevicesByClass(room: RoomReadModel): RoomDeviceGroup[] {
+  const grouped = new Map<string, RoomDeviceListItem[]>();
+
+  room.devices.forEach((device) => {
+    const existing = grouped.get(device.class) ?? [];
+    existing.push(toDeviceListItem(room, device));
+    grouped.set(device.class, existing);
+  });
+
+  return Array.from(grouped.entries())
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([deviceClass, devices]) => ({
+      id: deviceClass,
+      title: formatDeviceClass(deviceClass),
+      devices: devices.sort((a, b) => a.name.localeCompare(b.name))
+    } satisfies RoomDeviceGroup));
+}
+
+function toDeviceListItem(room: RoomReadModel, device: DeviceSummary): RoomDeviceListItem {
+  const eligibilityLabel = `Eligible for ${room.purpose}`;
+  const warnings = device.warnings.map((warning) => warning.message);
+  const actions = createDeviceActions(room.structureId, room.id, device.id);
+
+  return {
+    id: device.id,
+    name: device.name,
+    conditionLabel: `${formatterWhole.format(Math.round(device.conditionPercent))}% condition`,
+    contributionLabel: resolveContributionLabel(device),
+    eligibilityLabel,
+    warnings,
+    actions
+  } satisfies RoomDeviceListItem;
+}
+
+function resolveContributionLabel(device: DeviceSummary): string {
+  if (device.airflow_m3_per_hour > 0) {
+    return `${formatterWhole.format(Math.round(device.airflow_m3_per_hour))} m³/h airflow`;
+  }
+
+  if (device.coverageArea_m2 > 0) {
+    return `${formatterWhole.format(Math.round(device.coverageArea_m2))} m² coverage`;
+  }
+
+  if (device.powerDraw_kWh_per_hour > 0) {
+    return `${formatterOneDecimal.format(device.powerDraw_kWh_per_hour)} kWh/hour draw`;
+  }
+
+  return "Contribution pending telemetry";
+}
+
+const TIMELINE_STATUS_LABEL: Record<TimelineEntry["status"], string> = {
+  scheduled: "Scheduled",
+  "in-progress": "In progress",
+  completed: "Completed",
+  blocked: "Blocked"
+};
+
+function toTimelineItem(entry: TimelineEntry): RoomTimelineItem {
+  return {
+    id: entry.id,
+    title: entry.title,
+    description: entry.description,
+    statusLabel: TIMELINE_STATUS_LABEL[entry.status],
+    timestampLabel: `Tick ${formatterWhole.format(entry.timestamp)}`
+  } satisfies RoomTimelineItem;
+}
+
+function createRoomActions(structureId: string, roomId: string): RoomAction[] {
+  return [
+    {
+      id: "room-action-create-zone",
+      label: "Create zone",
+      onSelect: () => {
+        console.info("[stub] create zone", { structureId, roomId });
+      },
+      disabledReason: "Zone creation wiring lands with Task 7000."
+    },
+    {
+      id: "room-action-duplicate-zone",
+      label: "Duplicate zone",
+      onSelect: () => {
+        console.info("[stub] duplicate zone", { structureId, roomId });
+      },
+      disabledReason: "Zone duplication orchestration lands with Task 7000."
+    },
+    {
+      id: "room-action-set-baselines",
+      label: "Set climate baselines",
+      onSelect: () => {
+        console.info("[stub] set climate baseline", { structureId, roomId });
+      },
+      disabledReason: "Baseline editor arrives with Task 7100."
+    },
+    {
+      id: "room-action-move-zone",
+      label: "Move zone",
+      onSelect: () => {
+        console.info("[stub] move zone", { structureId, roomId });
+      },
+      disabledReason: "Zone move orchestration lands with Task 8000."
+    },
+    {
+      id: "room-action-move-device",
+      label: "Move devices",
+      onSelect: () => {
+        console.info("[stub] move devices", { structureId, roomId });
+      },
+      disabledReason: "Device move flow ships with Task 8000."
+    }
+  ];
+}
+
+function createDeviceActions(structureId: string, roomId: string, deviceId: string): RoomDeviceAction[] {
+  return [
+    {
+      id: "device-action-move",
+      label: "Move device",
+      onSelect: () => {
+        console.info("[stub] move device", { structureId, roomId, deviceId });
+      },
+      disabledReason: "Device move orchestration lands with Task 8000."
+    },
+    {
+      id: "device-action-remove",
+      label: "Remove device",
+      onSelect: () => {
+        console.info("[stub] remove device", { structureId, roomId, deviceId });
+      },
+      disabledReason: "Device removal UI ships with Task 8001."
+    },
+    {
+      id: "device-action-replace",
+      label: "Replace device",
+      onSelect: () => {
+        console.info("[stub] replace device", { structureId, roomId, deviceId });
+      },
+      disabledReason: "Device replacement planner lands with Task 8002."
+    }
+  ];
+}
+
+function formatDeviceClass(deviceClass: string): string {
+  return deviceClass
+    .split(/[.-]/)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+}
+
+const DEFAULT_SNAPSHOT: RoomDetailSnapshot = Object.freeze({
+  header: Object.freeze({
+    structureName: "Structure",
+    roomName: "Room",
+    purposeLabel: "purpose",
+    areaUsedLabel: "0 m²",
+    areaFreeLabel: "0 m²",
+    volumeUsedLabel: "0 m³",
+    volumeFreeLabel: "0 m³",
+    achCurrent: 0,
+    achTarget: 0
+  }),
+  zones: Object.freeze([]),
+  climate: Object.freeze({
+    notes: null,
+    metrics: Object.freeze([])
+  }),
+  deviceGroups: Object.freeze([]),
+  timeline: Object.freeze([]),
+  actions: Object.freeze([])
+});
+

--- a/packages/ui/src/pages/structureHooks.ts
+++ b/packages/ui/src/pages/structureHooks.ts
@@ -4,6 +4,7 @@ import { HOURS_PER_DAY } from "@engine/constants/simConstants.ts";
 import type { StructureRoomSummary } from "@ui/components/structures/StructureRoomsGrid";
 import type { StructureWorkforceAssignmentSummary } from "@ui/components/structures/StructureWorkforceSnapshot";
 import { useStructureReadModel } from "@ui/lib/readModelHooks";
+import { buildRoomPath } from "@ui/lib/navigation";
 import type {
   StructureReadModel,
   StructureWarning,
@@ -98,6 +99,7 @@ function toRoomSummary(structureId: string, room: StructureReadModel["rooms"][nu
   return {
     id: room.id,
     name: room.name,
+    detailPath: buildRoomPath(structureId, room.id),
     purposeLabel: room.purpose,
     areaUsedLabel: formatArea(room.capacity.areaUsed_m2),
     areaFreeLabel: formatArea(room.capacity.areaFree_m2),

--- a/packages/ui/src/routes/RoomDetailRoute.tsx
+++ b/packages/ui/src/routes/RoomDetailRoute.tsx
@@ -1,0 +1,27 @@
+import type { ReactElement } from "react";
+import { AlertTriangle } from "lucide-react";
+import { useParams } from "react-router-dom";
+import { RoomDetailPage } from "@ui/pages/RoomDetailPage";
+import { resolveRoomByParams } from "@ui/lib/navigation";
+
+export function RoomDetailRoute(): ReactElement {
+  const { structureId, roomId } = useParams();
+  const resolved = resolveRoomByParams(structureId, roomId);
+
+  if (!resolved) {
+    return (
+      <section className="flex flex-1 flex-col justify-center gap-4 text-center lg:text-left">
+        <AlertTriangle className="mx-auto size-10 text-accent-muted lg:mx-0" aria-hidden="true" />
+        <div className="space-y-1">
+          <h2 className="text-2xl font-semibold text-text-primary">Room not found</h2>
+          <p className="text-sm text-text-muted">
+            Select a room from the structures overview to inspect climate baselines, zones, and device allocations.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  return <RoomDetailPage structureId={resolved.structure.id} roomId={resolved.room.id} />;
+}
+

--- a/packages/ui/src/routes/workspaceRoutes.tsx
+++ b/packages/ui/src/routes/workspaceRoutes.tsx
@@ -9,6 +9,7 @@ import { ZoneDetailRoute } from "@ui/routes/ZoneDetailRoute";
 import { StrainsRoute } from "@ui/routes/StrainsRoute";
 import { StructuresRoute } from "@ui/routes/StructuresRoute";
 import { StructureRoute } from "@ui/routes/StructureRoute";
+import { RoomDetailRoute } from "@ui/routes/RoomDetailRoute";
 
 export const workspaceRoutes = createRoutesFromElements(
   <Route
@@ -30,6 +31,7 @@ export const workspaceRoutes = createRoutesFromElements(
     <Route path={workspaceTopLevelRoutes.company.path} element={<DashboardRoute />} />
     <Route path={workspaceTopLevelRoutes.structures.path} element={<StructuresRoute />} />
     <Route path="structures/:structureId" element={<StructureRoute />} />
+    <Route path="structures/:structureId/rooms/:roomId" element={<RoomDetailRoute />} />
     <Route path="structures/:structureId/zones/:zoneId" element={<ZoneDetailRoute />} />
     <Route path={workspaceTopLevelRoutes.hr.path} element={<WorkforceRoute />} />
     <Route path={workspaceTopLevelRoutes.strains.path} element={<StrainsRoute />} />


### PR DESCRIPTION
## Summary
- add RoomDetailPage composition with router-aware breadcrumbs, climate snapshot, device/timeline panels, and zone list components
- expose room-detail selectors for header/capacity metrics, climate targets, grouped devices, and timeline actions
- extend navigation/routes to support room URLs and update the structures grid and left rail tests to exercise the new path
- document the room module in the changelog

## Testing
- pnpm --filter @wb/ui lint
- CI=1 pnpm --filter @wb/ui test
- pnpm -w lint *(fails: existing facade/engine lint violations)*
- pnpm -w -r typecheck *(fails: existing engine schema errors)*
- CI=1 pnpm -w -r test
- pnpm -w -r build *(fails: existing engine build errors)*

------
https://chatgpt.com/codex/tasks/task_e_68f08030a0188325859c13f6c47c5764