### PR TITLE
Add lighting control card and schedule validation utilities

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,13 @@
   `packages/ui/src/components/controls`, added ghost device-class placeholders
   that emit structured `onGhostAction` payloads, and shipped Vitest coverage
   for header rendering, deviation states, and ghost activation callbacks.
+- Task 5200: Composed the lighting control card atop the shared scaffold with
+  target PPFD editing, a schedule editor that enforces the SEC 15-minute grid,
+  DLI preview pill, and device contribution toggles, added reusable
+  light-schedule validation utilities under `packages/ui/src/lib`, and covered
+  PPFD/DLI rendering, schedule submission guards, grid snapping, and device
+  toggle behaviour via Vitest suites in `packages/ui/src/components/controls`
+  and `packages/ui/src/lib`.
 - Task 0000: Introduced the global workspace shell with a responsive left rail
   (Company → Structures → HR → Strains), a sticky simulation control bar with
   play/pause/step and deterministic speed chips, locale-aware balance and tick

--- a/packages/ui/src/components/controls/LightingControlCard.tsx
+++ b/packages/ui/src/components/controls/LightingControlCard.tsx
@@ -1,0 +1,407 @@
+import { useEffect, useId, useMemo, useState, type ChangeEvent, type FormEvent, type ReactElement } from "react";
+import {
+  ControlCard,
+  type ControlCardGhostActionPayload,
+  type ControlCardGhostPlaceholderDefinition
+} from "@ui/components/controls/ControlCard";
+import {
+  normalizeLightSchedule,
+  type LightScheduleInput,
+  type LightScheduleValidationMessages,
+  validateLightScheduleInput
+} from "@ui/lib/lightScheduleValidation";
+import en from "@ui/intl/en.json" assert { type: "json" };
+import { cn } from "@ui/lib/cn";
+import { MICROMOLES_PER_MOLE } from "@engine/constants/lighting.ts";
+import { HOURS_PER_DAY, LIGHT_SCHEDULE_GRID_HOURS, SECONDS_PER_HOUR } from "@engine/constants/simConstants.ts";
+
+const targetFormatter = new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 });
+const dliFormatter = new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 });
+const percentFormatter = new Intl.NumberFormat("en-US", { style: "percent", maximumFractionDigits: 0 });
+
+const copy = {
+  targetLabel: "Target PPFD",
+  targetHelp: "Set the desired PPFD for this zone.",
+  dliLabel: "Daily light integral",
+  dliUnit: "mol/m²/day",
+  scheduleTitle: "Photoperiod schedule",
+  submitLabel: "Save schedule",
+  toggleEnable: "Enable",
+  toggleDisable: "Disable",
+  statusEnabled: "Enabled",
+  statusDisabled: "Disabled"
+} as const;
+
+const defaultValidationMessages: LightScheduleValidationMessages = {
+  sum: en.intents.setLightSchedule.validation.sum,
+  grid: en.intents.setLightSchedule.validation.quarter,
+  start: en.intents.setLightSchedule.validation.start
+};
+
+interface ScheduleInputsState {
+  readonly onHours: string;
+  readonly offHours: string;
+  readonly startHour: string;
+}
+
+export interface LightingDeviceTileProps {
+  readonly id: string;
+  readonly name: string;
+  readonly contributionFraction01: number;
+  readonly isEnabled: boolean;
+  readonly onToggle: (nextEnabled: boolean) => void;
+  readonly description?: string;
+}
+
+export interface LightingControlCardProps {
+  readonly title?: string;
+  readonly description?: string;
+  readonly measuredPpfd: number;
+  readonly targetPpfd: number;
+  readonly schedule: LightScheduleInput;
+  readonly onTargetPpfdChange?: (nextValue: number) => void;
+  readonly onScheduleSubmit?: (schedule: LightScheduleInput) => void;
+  readonly isScheduleSubmitting?: boolean;
+  readonly scheduleMessages?: Partial<LightScheduleValidationMessages>;
+  readonly scheduleSubmitLabel?: string;
+  readonly deviceTiles?: readonly LightingDeviceTileProps[];
+  readonly ghostPlaceholders?: readonly ControlCardGhostPlaceholderDefinition[];
+  readonly deviceSectionEmptyLabel?: string;
+  readonly onGhostAction?: (payload: ControlCardGhostActionPayload) => void;
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(Math.max(value, minimum), maximum);
+}
+
+function snapToGrid(value: number): number {
+  return Math.round(value / LIGHT_SCHEDULE_GRID_HOURS) * LIGHT_SCHEDULE_GRID_HOURS;
+}
+
+function formatHours(value: number): string {
+  if (Number.isInteger(value)) {
+    return value.toString();
+  }
+  return value.toFixed(2).replace(/\.00$/, "");
+}
+
+function parseHours(value: string): number | null {
+  if (value.trim().length === 0) {
+    return null;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+  return parsed;
+}
+
+function computeDliMolPerM2Day(ppfd: number, onHours: number): number {
+  return (ppfd * onHours * SECONDS_PER_HOUR) / MICROMOLES_PER_MOLE;
+}
+
+export function LightingControlCard({
+  title = "Lighting controls",
+  description,
+  measuredPpfd,
+  targetPpfd,
+  schedule,
+  onTargetPpfdChange,
+  onScheduleSubmit,
+  isScheduleSubmitting = false,
+  scheduleMessages,
+  scheduleSubmitLabel,
+  deviceTiles = [],
+  ghostPlaceholders,
+  deviceSectionEmptyLabel,
+  onGhostAction
+}: LightingControlCardProps): ReactElement {
+  const targetInputId = useId();
+  const scheduleFormTitleId = useId();
+
+  const [targetInput, setTargetInput] = useState(() => targetFormatter.format(targetPpfd));
+  const [targetValue, setTargetValue] = useState(targetPpfd);
+
+  useEffect(() => {
+    setTargetValue(targetPpfd);
+    setTargetInput(targetFormatter.format(targetPpfd));
+  }, [targetPpfd]);
+
+  const handleTargetChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { value } = event.target;
+    setTargetInput(value);
+    if (value.trim().length === 0) {
+      return;
+    }
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) {
+      return;
+    }
+    setTargetValue(parsed);
+    onTargetPpfdChange?.(parsed);
+  };
+
+  const handleTargetBlur = () => {
+    setTargetInput(targetFormatter.format(targetValue));
+  };
+
+  const resolvedMessages = useMemo<LightScheduleValidationMessages>(
+    () => ({
+      ...defaultValidationMessages,
+      ...scheduleMessages
+    }),
+    [scheduleMessages]
+  );
+
+  const [scheduleInputs, setScheduleInputs] = useState<ScheduleInputsState>(() => ({
+    onHours: formatHours(schedule.onHours),
+    offHours: formatHours(schedule.offHours),
+    startHour: formatHours(schedule.startHour)
+  }));
+
+  useEffect(() => {
+    const normalized = normalizeLightSchedule(schedule);
+    setScheduleInputs({
+      onHours: formatHours(normalized.onHours),
+      offHours: formatHours(normalized.offHours),
+      startHour: formatHours(normalized.startHour)
+    });
+  }, [schedule.onHours, schedule.offHours, schedule.startHour]);
+
+  const handleScheduleChange = (field: keyof ScheduleInputsState) => (event: ChangeEvent<HTMLInputElement>) => {
+    const { value } = event.target;
+    if (value.trim().length === 0) {
+      setScheduleInputs((previous) => ({
+        ...previous,
+        [field]: ""
+      }));
+      return;
+    }
+
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) {
+      return;
+    }
+
+    const maximum = field === "startHour" ? HOURS_PER_DAY - LIGHT_SCHEDULE_GRID_HOURS : HOURS_PER_DAY;
+    const clamped = clamp(parsed, 0, maximum);
+
+    const snapped = snapToGrid(clamped);
+    setScheduleInputs((previous) => ({
+      ...previous,
+      [field]: formatHours(snapped)
+    }));
+  };
+
+  const validationResult = useMemo(() => {
+    return validateLightScheduleInput(
+      {
+        onHours: parseHours(scheduleInputs.onHours),
+        offHours: parseHours(scheduleInputs.offHours),
+        startHour: parseHours(scheduleInputs.startHour)
+      },
+      resolvedMessages
+    );
+  }, [scheduleInputs.offHours, scheduleInputs.onHours, scheduleInputs.startHour, resolvedMessages]);
+
+  const normalizedSchedule = useMemo(() => normalizeLightSchedule(schedule), [schedule.offHours, schedule.onHours, schedule.startHour]);
+  const previewSchedule = validationResult.schedule ?? normalizedSchedule;
+  const dliPreview = Number.isFinite(targetValue) ? computeDliMolPerM2Day(targetValue, previewSchedule.onHours) : null;
+
+  const handleScheduleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!validationResult.isValid || !validationResult.schedule) {
+      return;
+    }
+
+    const normalized = validationResult.schedule;
+    setScheduleInputs({
+      onHours: formatHours(normalized.onHours),
+      offHours: formatHours(normalized.offHours),
+      startHour: formatHours(normalized.startHour)
+    });
+    onScheduleSubmit?.(normalized);
+  };
+
+  const scheduleErrors = validationResult.errors;
+
+  return (
+    <ControlCard
+      title={title}
+      description={description}
+      measured={{ label: "Measured PPFD", displayValue: `${targetFormatter.format(measuredPpfd)} µmol`, numericValue: measuredPpfd }}
+      target={{ label: copy.targetLabel, displayValue: `${targetFormatter.format(targetValue)} µmol`, numericValue: targetValue }}
+      deviceSection={{
+        children: deviceTiles.map((tile) => <LightingDeviceTile key={tile.id} {...tile} />),
+        ghostPlaceholders,
+        emptyLabel: deviceSectionEmptyLabel
+      }}
+      onGhostAction={onGhostAction}
+    >
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-wrap items-center gap-4">
+          <label className="flex flex-col gap-2" htmlFor={targetInputId}>
+            <span className="text-sm font-medium text-text-primary">{copy.targetLabel}</span>
+            <input
+              id={targetInputId}
+              className="w-32 rounded-lg border border-border-base bg-canvas-subtle px-3 py-2 text-sm text-text-primary"
+              inputMode="decimal"
+              min={0}
+              name="targetPpfd"
+              onBlur={handleTargetBlur}
+              onChange={handleTargetChange}
+              step={25}
+              type="number"
+              value={targetInput}
+            />
+            <span className="text-xs text-text-muted">{copy.targetHelp}</span>
+          </label>
+          <div
+            className="inline-flex items-center gap-2 rounded-full border border-accent-primary/50 bg-accent-primary/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-accent-primary"
+            aria-label={`${copy.dliLabel}: ${dliPreview === null ? "Unavailable" : dliFormatter.format(dliPreview)} ${copy.dliUnit}`}
+          >
+            <span>{copy.dliLabel}</span>
+            <span className="text-sm normal-case tracking-normal">
+              {dliPreview === null ? "--" : `${dliFormatter.format(dliPreview)} ${copy.dliUnit}`}
+            </span>
+          </div>
+        </div>
+
+        <form aria-labelledby={scheduleFormTitleId} className="space-y-4" onSubmit={handleScheduleSubmit}>
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-semibold text-text-primary" id={scheduleFormTitleId}>
+              {copy.scheduleTitle}
+            </h3>
+            <span className="text-xs uppercase tracking-[0.18em] text-accent-muted">24h total required</span>
+          </div>
+          <div className="grid gap-4 md:grid-cols-3">
+            <label className="flex flex-col gap-2">
+              <span className="text-sm font-medium text-text-primary">{en.intents.setLightSchedule.fields.onHours.label}</span>
+              <input
+                aria-label={en.intents.setLightSchedule.fields.onHours.label}
+                className="rounded-lg border border-border-base bg-canvas-subtle px-3 py-2 text-sm text-text-primary"
+                inputMode="decimal"
+                min={0}
+                max={HOURS_PER_DAY}
+                name="onHours"
+                onChange={handleScheduleChange("onHours")}
+                step={LIGHT_SCHEDULE_GRID_HOURS}
+                type="number"
+                value={scheduleInputs.onHours}
+              />
+              <span className="text-xs text-text-muted">{en.intents.setLightSchedule.fields.onHours.help}</span>
+            </label>
+
+            <label className="flex flex-col gap-2">
+              <span className="text-sm font-medium text-text-primary">{en.intents.setLightSchedule.fields.offHours.label}</span>
+              <input
+                aria-label={en.intents.setLightSchedule.fields.offHours.label}
+                className="rounded-lg border border-border-base bg-canvas-subtle px-3 py-2 text-sm text-text-primary"
+                inputMode="decimal"
+                min={0}
+                max={HOURS_PER_DAY}
+                name="offHours"
+                onChange={handleScheduleChange("offHours")}
+                step={LIGHT_SCHEDULE_GRID_HOURS}
+                type="number"
+                value={scheduleInputs.offHours}
+              />
+              <span className="text-xs text-text-muted">{en.intents.setLightSchedule.fields.offHours.help}</span>
+            </label>
+
+            <label className="flex flex-col gap-2">
+              <span className="text-sm font-medium text-text-primary">{en.intents.setLightSchedule.fields.startHour.label}</span>
+              <input
+                aria-label={en.intents.setLightSchedule.fields.startHour.label}
+                className="rounded-lg border border-border-base bg-canvas-subtle px-3 py-2 text-sm text-text-primary"
+                inputMode="decimal"
+                min={0}
+                max={HOURS_PER_DAY}
+                name="startHour"
+                onChange={handleScheduleChange("startHour")}
+                step={LIGHT_SCHEDULE_GRID_HOURS}
+                type="number"
+                value={scheduleInputs.startHour}
+              />
+              <span className="text-xs text-text-muted">{en.intents.setLightSchedule.fields.startHour.help}</span>
+            </label>
+          </div>
+
+          {scheduleErrors.length > 0 ? (
+            <div className="rounded-lg border border-border-strong bg-surface-critical/10 p-4" role="alert">
+              <ul className="list-disc space-y-1 pl-5 text-sm text-text-critical">
+                {scheduleErrors.map((message) => (
+                  <li key={message}>{message}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          <div className="flex items-center justify-end gap-3">
+            <button
+              className="inline-flex items-center gap-2 rounded-lg bg-accent-primary px-4 py-2 text-sm font-semibold text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
+              disabled={isScheduleSubmitting || !validationResult.isValid}
+              type="submit"
+            >
+              {isScheduleSubmitting ? (
+                <>
+                  <span
+                    aria-hidden="true"
+                    className="inline-flex size-4 animate-spin rounded-full border-2 border-white/40 border-t-white"
+                  />
+                  <span>Saving…</span>
+                </>
+              ) : (
+                scheduleSubmitLabel ?? copy.submitLabel
+              )}
+            </button>
+          </div>
+        </form>
+      </div>
+    </ControlCard>
+  );
+}
+
+function LightingDeviceTile({
+  name,
+  contributionFraction01,
+  isEnabled,
+  onToggle,
+  description
+}: LightingDeviceTileProps): ReactElement {
+  const contribution = clamp(contributionFraction01, 0, 1);
+  const percentLabel = percentFormatter.format(contribution);
+  const statusLabel = isEnabled ? copy.statusEnabled : copy.statusDisabled;
+
+  return (
+    <div className="flex h-full flex-col justify-between gap-4 p-4">
+      <div className="space-y-2">
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-sm font-semibold text-text-primary">{name}</p>
+          <span className="text-xs font-medium uppercase tracking-[0.18em] text-accent-muted">{statusLabel}</span>
+        </div>
+        {description ? <p className="text-xs text-text-muted">{description}</p> : null}
+        <span className="inline-flex items-center gap-2 rounded-full border border-border-base/70 bg-canvas-subtle/60 px-3 py-1 text-xs font-semibold text-text-primary">
+          {percentLabel} of output
+        </span>
+      </div>
+      <button
+        type="button"
+        className={cn(
+          "inline-flex items-center justify-center rounded-lg border px-3 py-2 text-sm font-medium transition",
+          isEnabled
+            ? "border-border-strong bg-surface-critical/10 text-text-critical hover:bg-surface-critical/20"
+            : "border-accent-primary/60 bg-accent-primary/10 text-accent-primary hover:bg-accent-primary/20"
+        )}
+        onClick={() => {
+          onToggle(!isEnabled);
+        }}
+        aria-pressed={isEnabled}
+      >
+        {isEnabled ? copy.toggleDisable : copy.toggleEnable}
+      </button>
+    </div>
+  );
+}
+

--- a/packages/ui/src/components/controls/__tests__/LightingControlCard.test.tsx
+++ b/packages/ui/src/components/controls/__tests__/LightingControlCard.test.tsx
@@ -1,0 +1,135 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { LightingControlCard, type LightingDeviceTileProps } from "@ui/components/controls";
+import { type LightScheduleInput } from "@ui/lib/lightScheduleValidation";
+import { MICROMOLES_PER_MOLE } from "@engine/constants/lighting.ts";
+import { SECONDS_PER_HOUR } from "@engine/constants/simConstants.ts";
+
+const baseSchedule: LightScheduleInput = {
+  onHours: 18,
+  offHours: 6,
+  startHour: 0
+};
+
+const baseTargetPpfd = 500;
+const measuredPpfd = 480;
+const measuredPpfdSecondary = 450;
+const invalidOffHours = 5;
+const updatedTargetPpfd = 520;
+const deviceContribution = 0.5;
+const snappedOnHours = 17.25;
+const snappedOffHours = 6.75;
+const snappedStartHour = 1.25;
+const rawOnHours = 17.3;
+const rawOffHours = 6.7;
+const rawStartHour = 1.2;
+
+function createDeviceTile(overrides: Partial<LightingDeviceTileProps> = {}): LightingDeviceTileProps {
+  return {
+    id: "device-1",
+    name: "Array A",
+    contributionFraction01: deviceContribution,
+    isEnabled: true,
+    onToggle: vi.fn(),
+    ...overrides
+  } satisfies LightingDeviceTileProps;
+}
+
+describe("LightingControlCard", () => {
+  it("renders PPFD metrics, updates the target value, and shows a DLI preview", () => {
+    const handleTargetChange = vi.fn();
+
+    render(
+      <LightingControlCard
+        measuredPpfd={measuredPpfd}
+        targetPpfd={baseTargetPpfd}
+        schedule={baseSchedule}
+        onTargetPpfdChange={handleTargetChange}
+      />
+    );
+
+    expect(screen.getByText(/Measured PPFD/i)).toBeInTheDocument();
+    expect(screen.getByText(`${baseTargetPpfd.toString()} µmol`)).toBeInTheDocument();
+    const expectedDli = ((baseTargetPpfd * baseSchedule.onHours * SECONDS_PER_HOUR) / MICROMOLES_PER_MOLE).toFixed(1);
+    expect(
+      screen.getByLabelText(`Daily light integral: ${expectedDli} mol/m²/day`)
+    ).toBeInTheDocument();
+
+    const targetInput = screen.getByLabelText(/Target PPFD/i);
+    fireEvent.change(targetInput, { target: { value: updatedTargetPpfd.toString() } });
+
+    expect(handleTargetChange).toHaveBeenCalledWith(updatedTargetPpfd);
+    expect(screen.getByText(`${updatedTargetPpfd.toString()} µmol`)).toBeInTheDocument();
+  });
+
+  it("prevents submitting invalid schedules and surfaces validation messaging", async () => {
+    const handleScheduleSubmit = vi.fn();
+
+    render(
+      <LightingControlCard
+        measuredPpfd={measuredPpfdSecondary}
+        targetPpfd={measuredPpfdSecondary}
+        schedule={baseSchedule}
+        onScheduleSubmit={handleScheduleSubmit}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText(/Lights off/i), { target: { value: invalidOffHours.toString() } });
+    fireEvent.click(screen.getByRole("button", { name: /Save schedule/i }));
+
+    await waitFor(() => {
+      expect(handleScheduleSubmit).not.toHaveBeenCalled();
+    });
+    expect(
+      await screen.findByText(/Light cycle hours must total 24 per SEC §4.2./i)
+    ).toBeInTheDocument();
+  });
+
+  it("normalizes to the 15-minute grid when submitting a schedule", () => {
+    const handleScheduleSubmit = vi.fn();
+
+    render(
+      <LightingControlCard
+        measuredPpfd={measuredPpfdSecondary}
+        targetPpfd={measuredPpfdSecondary}
+        schedule={baseSchedule}
+        onScheduleSubmit={handleScheduleSubmit}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText(/Lights on/i), { target: { value: rawOnHours.toString() } });
+    fireEvent.change(screen.getByLabelText(/Lights off/i), { target: { value: rawOffHours.toString() } });
+    fireEvent.change(screen.getByLabelText(/Start hour/i), { target: { value: rawStartHour.toString() } });
+
+    fireEvent.click(screen.getByRole("button", { name: /Save schedule/i }));
+
+    expect(handleScheduleSubmit).toHaveBeenCalledTimes(1);
+    expect(handleScheduleSubmit).toHaveBeenCalledWith({
+      onHours: snappedOnHours,
+      offHours: snappedOffHours,
+      startHour: snappedStartHour
+    });
+  });
+
+  it("renders device tiles with toggle affordances and contribution percentages", () => {
+    const handleToggle = vi.fn();
+    const device = createDeviceTile({ onToggle: handleToggle });
+
+    render(
+      <LightingControlCard
+        measuredPpfd={measuredPpfdSecondary}
+        targetPpfd={measuredPpfdSecondary}
+        schedule={baseSchedule}
+        deviceTiles={[device]}
+      />
+    );
+
+    const tile = screen.getByText(device.name);
+    expect(tile).toBeInTheDocument();
+    expect(screen.getByText(`${(deviceContribution * 100).toFixed(0)}% of output`)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Disable/i }));
+    expect(handleToggle).toHaveBeenCalledWith(false);
+  });
+});
+

--- a/packages/ui/src/components/controls/index.ts
+++ b/packages/ui/src/components/controls/index.ts
@@ -8,3 +8,5 @@ export type {
 } from "./ControlCard";
 
 export { ControlCard } from "./ControlCard";
+export type { LightingControlCardProps, LightingDeviceTileProps } from "./LightingControlCard";
+export { LightingControlCard } from "./LightingControlCard";

--- a/packages/ui/src/lib/__tests__/lightScheduleValidation.test.ts
+++ b/packages/ui/src/lib/__tests__/lightScheduleValidation.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { HOURS_PER_DAY, LIGHT_SCHEDULE_GRID_HOURS } from "@engine/constants/simConstants.ts";
+import {
+  normalizeLightSchedule,
+  type LightScheduleInput,
+  type LightScheduleValidationMessages,
+  validateLightScheduleInput
+} from "@ui/lib/lightScheduleValidation";
+
+const messages: LightScheduleValidationMessages = {
+  sum: "Sum must be 24 hours.",
+  grid: "Values must align to the 15-minute grid.",
+  start: "Start hour must be within range."
+};
+
+const fractionalOnHours = 17.33;
+const fractionalOffHours = 6.9;
+const fractionalStartHour = -0.12;
+const overflowStartHour = 26.5;
+const invalidOnHours = 12.1;
+const invalidOffHours = 11.5;
+const outOfRangeStartHour = 25;
+const validStartHour = 1.5;
+
+describe("lightScheduleValidation", () => {
+  it("normalizes values to the 15-minute grid and enforces a 24 hour total", () => {
+    const schedule: LightScheduleInput = {
+      onHours: fractionalOnHours,
+      offHours: fractionalOffHours,
+      startHour: fractionalStartHour
+    };
+
+    const result = normalizeLightSchedule(schedule);
+    expect(result.onHours % LIGHT_SCHEDULE_GRID_HOURS).toBe(0);
+    expect(result.offHours % LIGHT_SCHEDULE_GRID_HOURS).toBe(0);
+    expect(result.onHours + result.offHours).toBeCloseTo(HOURS_PER_DAY, 6);
+    expect(result.startHour).toBeGreaterThanOrEqual(0);
+    expect(result.startHour).toBeLessThan(HOURS_PER_DAY);
+  });
+
+  it("wraps start hours beyond the daily range", () => {
+    const schedule: LightScheduleInput = {
+      onHours: 12,
+      offHours: 12,
+      startHour: overflowStartHour
+    };
+
+    const result = normalizeLightSchedule(schedule);
+    expect(result.startHour).toBeGreaterThanOrEqual(0);
+    expect(result.startHour).toBeLessThan(HOURS_PER_DAY);
+  });
+
+  it("rejects schedules missing required values", () => {
+    const result = validateLightScheduleInput(
+      { onHours: null, offHours: 6, startHour: 0 },
+      messages
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.schedule).toBeNull();
+    expect(result.errors).toContain(messages.sum);
+  });
+
+  it("surfaces grid and range errors when values drift off the contract", () => {
+    const result = validateLightScheduleInput(
+      { onHours: invalidOnHours, offHours: invalidOffHours, startHour: outOfRangeStartHour },
+      messages
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toEqual(expect.arrayContaining([messages.grid, messages.start]));
+  });
+
+  it("returns a normalized schedule when the inputs satisfy validation", () => {
+    const result = validateLightScheduleInput(
+      { onHours: 18, offHours: 6, startHour: validStartHour },
+      messages
+    );
+
+    expect(result.isValid).toBe(true);
+    expect(result.schedule).toEqual({ onHours: 18, offHours: 6, startHour: validStartHour });
+    expect(result.errors).toHaveLength(0);
+  });
+});
+

--- a/packages/ui/src/lib/lightScheduleValidation.ts
+++ b/packages/ui/src/lib/lightScheduleValidation.ts
@@ -1,0 +1,155 @@
+import { HOURS_PER_DAY, LIGHT_SCHEDULE_GRID_HOURS } from "@engine/constants/simConstants.ts";
+
+export interface LightScheduleInput {
+  readonly onHours: number;
+  readonly offHours: number;
+  readonly startHour: number;
+}
+
+export interface LightScheduleValidationMessages {
+  readonly sum: string;
+  readonly grid: string;
+  readonly start: string;
+}
+
+export interface LightScheduleValidationInput {
+  readonly onHours: number | null | undefined;
+  readonly offHours: number | null | undefined;
+  readonly startHour: number | null | undefined;
+}
+
+export interface LightScheduleValidationResult {
+  readonly isValid: boolean;
+  readonly errors: readonly string[];
+  readonly schedule: LightScheduleInput | null;
+}
+
+const EPSILON = 1e-6;
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(Math.max(value, minimum), maximum);
+}
+
+function snapToGrid(value: number): number {
+  return Math.round(value / LIGHT_SCHEDULE_GRID_HOURS) * LIGHT_SCHEDULE_GRID_HOURS;
+}
+
+function normaliseStartHour(value: number): number {
+  const wrapped = ((value % HOURS_PER_DAY) + HOURS_PER_DAY) % HOURS_PER_DAY;
+  const snapped = snapToGrid(wrapped);
+  if (snapped >= HOURS_PER_DAY - EPSILON) {
+    return 0;
+  }
+  return snapped;
+}
+
+export function normalizeLightSchedule(input: LightScheduleInput): LightScheduleInput {
+  const clampedOn = clamp(input.onHours, 0, HOURS_PER_DAY);
+  const clampedOff = clamp(input.offHours, 0, HOURS_PER_DAY);
+
+  const onHours = snapToGrid(clampedOn);
+  let offHours = snapToGrid(clampedOff);
+
+  if (Math.abs(onHours + offHours - HOURS_PER_DAY) > EPSILON) {
+    offHours = snapToGrid(clamp(HOURS_PER_DAY - onHours, 0, HOURS_PER_DAY));
+  }
+
+  if (Math.abs(onHours + offHours - HOURS_PER_DAY) > EPSILON) {
+    const adjustedOn = snapToGrid(clamp(HOURS_PER_DAY - offHours, 0, HOURS_PER_DAY));
+    return {
+      onHours: adjustedOn,
+      offHours,
+      startHour: normaliseStartHour(input.startHour)
+    };
+  }
+
+  return {
+    onHours,
+    offHours,
+    startHour: normaliseStartHour(input.startHour)
+  };
+}
+
+function isMultipleOfGrid(value: number): boolean {
+  return Math.abs(value / LIGHT_SCHEDULE_GRID_HOURS - Math.round(value / LIGHT_SCHEDULE_GRID_HOURS)) < EPSILON;
+}
+
+function isFiniteNumber(value: number | null | undefined): value is number {
+  return value !== null && value !== undefined && Number.isFinite(value);
+}
+
+export function validateLightScheduleInput(
+  input: LightScheduleValidationInput,
+  messages: LightScheduleValidationMessages
+): LightScheduleValidationResult {
+  const errors: string[] = [];
+
+  const pushError = (message: string) => {
+    if (!errors.includes(message)) {
+      errors.push(message);
+    }
+  };
+
+  const { onHours, offHours, startHour } = input;
+
+  const hasFiniteOn = isFiniteNumber(onHours);
+  const hasFiniteOff = isFiniteNumber(offHours);
+  const hasFiniteStart = isFiniteNumber(startHour);
+
+  if (!hasFiniteOn || !hasFiniteOff) {
+    pushError(messages.sum);
+  }
+
+  if (hasFiniteOn && hasFiniteOff) {
+    const totalHours = onHours + offHours;
+    if (Math.abs(totalHours - HOURS_PER_DAY) > EPSILON) {
+      pushError(messages.sum);
+    }
+  }
+
+  if (hasFiniteOn && !isMultipleOfGrid(onHours)) {
+    pushError(messages.grid);
+  }
+
+  if (hasFiniteOff && !isMultipleOfGrid(offHours)) {
+    pushError(messages.grid);
+  }
+
+  if (hasFiniteStart) {
+    if (!isMultipleOfGrid(startHour)) {
+      pushError(messages.grid);
+    }
+    if (startHour < 0 - EPSILON || startHour > HOURS_PER_DAY - LIGHT_SCHEDULE_GRID_HOURS + EPSILON) {
+      pushError(messages.start);
+    }
+  } else {
+    pushError(messages.start);
+  }
+
+  if (!hasFiniteOn || !hasFiniteOff || !hasFiniteStart) {
+    return { isValid: false, errors, schedule: null };
+  }
+
+  if (errors.length > 0) {
+    return { isValid: false, errors, schedule: null };
+  }
+
+  const normalised = normalizeLightSchedule({
+    onHours,
+    offHours,
+    startHour
+  });
+
+  if (Math.abs(normalised.onHours + normalised.offHours - HOURS_PER_DAY) > EPSILON) {
+    pushError(messages.sum);
+    return { isValid: false, errors, schedule: null };
+  }
+
+  if (normalised.startHour < 0 || normalised.startHour >= HOURS_PER_DAY) {
+    pushError(messages.start);
+    return { isValid: false, errors, schedule: null };
+  }
+
+  return { isValid: errors.length === 0, errors, schedule: errors.length === 0 ? normalised : null };
+}
+


### PR DESCRIPTION
## Summary
- add a LightingControlCard component that composes the shared ControlCard header, surfaces PPFD metrics with a DLI preview, exposes the schedule editor, and renders device toggles
- introduce lightScheduleValidation utilities to normalize 15-minute grid input, enforce 24-hour totals, and report validation errors for the editor
- cover the new component and validation helpers with Vitest suites to verify rendering, normalization, and validation behaviour

## Testing
- pnpm --filter @wb/ui lint
- pnpm --filter @wb/ui test

------
https://chatgpt.com/codex/tasks/task_e_68f097b0edd88325a006dde9c77334ee