### PR TITLE
feat(ui): add climate control card

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,13 @@
   PPFD/DLI rendering, schedule submission guards, grid snapping, and device
   toggle behaviour via Vitest suites in `packages/ui/src/components/controls`
   and `packages/ui/src/lib`.
+- Task 5300: Delivered the climate control card with per-metric temperature,
+  humidity, CO₂, and ACH sections using the shared control scaffold, rendered
+  deviation badges driven by numeric tolerances, added climate device class
+  tiles exposing throughput/capacity percentages plus enable/move/remove
+  affordances, filtered ghost placeholders for missing classes, and added
+  deterministic Vitest coverage alongside shared percentage formatting
+  utilities under `packages/ui/src/lib`.
 - Task 0000: Introduced the global workspace shell with a responsive left rail
   (Company → Structures → HR → Strains), a sticky simulation control bar with
   play/pause/step and deterministic speed chips, locale-aware balance and tick

--- a/packages/ui/src/components/controls/ClimateControlCard.tsx
+++ b/packages/ui/src/components/controls/ClimateControlCard.tsx
@@ -1,0 +1,315 @@
+import { useId, type ReactElement } from "react";
+import {
+  ControlCard,
+  type ControlCardDeviationThresholds,
+  type ControlCardGhostActionPayload,
+  type ControlCardGhostPlaceholderDefinition,
+  type ControlCardMetricValue
+} from "@ui/components/controls/ControlCard";
+import { cn } from "@ui/lib/cn";
+import { formatCapacityPercentage, formatThroughputPercentage } from "@ui/lib/percentageFormatting";
+
+const defaultTitle = "Climate controls";
+const defaultDeviationFormatter = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 2,
+  signDisplay: "always"
+});
+
+interface DeviationBadgeDescriptor {
+  readonly severity: "warning" | "critical";
+  readonly valueLabel: string;
+}
+
+export interface ClimateControlMetricDefinition {
+  readonly label: string;
+  readonly measured: ControlCardMetricValue;
+  readonly target: ControlCardMetricValue;
+  readonly deviation?: ControlCardDeviationThresholds;
+  readonly toleranceLabel?: string;
+}
+
+export interface ClimateControlDeviceTileProps {
+  readonly id: string;
+  readonly name: string;
+  readonly throughputFraction01: number;
+  readonly capacityFraction01: number;
+  readonly isEnabled: boolean;
+  readonly onToggleEnabled: (nextEnabled: boolean) => void;
+  readonly onMove?: () => void;
+  readonly onRemove?: () => void;
+  readonly description?: string;
+}
+
+export interface ClimateControlDeviceClassSection {
+  readonly classId: string;
+  readonly label: string;
+  readonly devices: readonly ClimateControlDeviceTileProps[];
+}
+
+export interface ClimateControlCardProps {
+  readonly title?: string;
+  readonly description?: string;
+  readonly temperature: ClimateControlMetricDefinition;
+  readonly humidity: ClimateControlMetricDefinition;
+  readonly co2: ClimateControlMetricDefinition;
+  readonly ach: ClimateControlMetricDefinition;
+  readonly deviceClasses?: readonly ClimateControlDeviceClassSection[];
+  readonly ghostPlaceholders?: readonly ControlCardGhostPlaceholderDefinition[];
+  readonly deviceSectionEmptyLabel?: string;
+  readonly onGhostAction?: (payload: ControlCardGhostActionPayload) => void;
+}
+
+type MetricEntry = readonly [id: string, config: ClimateControlMetricDefinition];
+
+export function ClimateControlCard({
+  title = defaultTitle,
+  description,
+  temperature,
+  humidity,
+  co2,
+  ach,
+  deviceClasses = [],
+  ghostPlaceholders,
+  deviceSectionEmptyLabel,
+  onGhostAction
+}: ClimateControlCardProps): ReactElement {
+  const metricEntries: MetricEntry[] = [
+    ["temperature", temperature],
+    ["humidity", humidity],
+    ["co2", co2],
+    ["ach", ach]
+  ];
+
+  const deviceTiles = deviceClasses.flatMap((section) =>
+    section.devices.map((device) => (
+      <ClimateDeviceTile key={`${section.classId}-${device.id}`} classLabel={section.label} {...device} />
+    ))
+  );
+
+  const hasDevices = deviceTiles.length > 0;
+  const classHasDevices = new Map<string, boolean>();
+  for (const section of deviceClasses) {
+    classHasDevices.set(section.classId, section.devices.length > 0);
+  }
+
+  const resolvedGhosts = (ghostPlaceholders ?? []).filter((placeholder) => {
+    return !classHasDevices.get(placeholder.deviceClassId);
+  });
+
+  const hasDeviceSection =
+    hasDevices || resolvedGhosts.length > 0 || typeof deviceSectionEmptyLabel === "string";
+
+  return (
+    <ControlCard
+      title={title}
+      description={description}
+      measured={temperature.measured}
+      target={temperature.target}
+      deviation={temperature.deviation}
+      deviceSection={
+        hasDeviceSection
+          ? {
+              children: deviceTiles,
+              ghostPlaceholders: resolvedGhosts.length > 0 ? resolvedGhosts : undefined,
+              emptyLabel: deviceSectionEmptyLabel
+            }
+          : undefined
+      }
+      onGhostAction={onGhostAction}
+    >
+      <ClimateMetricGrid entries={metricEntries} />
+    </ControlCard>
+  );
+}
+
+function ClimateMetricGrid({ entries }: { readonly entries: readonly MetricEntry[] }): ReactElement {
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      {entries.map(([id, metric]) => (
+        <ClimateMetricSection key={id} id={id} {...metric} />
+      ))}
+    </div>
+  );
+}
+
+interface ClimateMetricSectionProps extends ClimateControlMetricDefinition {
+  readonly id: string;
+}
+
+function ClimateMetricSection({
+  id,
+  label,
+  measured,
+  target,
+  deviation,
+  toleranceLabel
+}: ClimateMetricSectionProps): ReactElement {
+  const headingId = useId();
+  const toleranceId = useId();
+  const deviationBadge = resolveDeviationBadge(measured, target, deviation);
+
+  return (
+    <section
+      aria-labelledby={headingId}
+      className="flex flex-col gap-4 rounded-xl border border-border-base/60 bg-canvas-subtle/40 p-4"
+      data-metric-id={id}
+      role="region"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="space-y-1">
+          <h3 className="text-sm font-semibold text-text-primary" id={headingId}>
+            {label}
+          </h3>
+          {toleranceLabel ? (
+            <p className="text-xs text-text-muted" id={toleranceId}>
+              {toleranceLabel}
+            </p>
+          ) : null}
+        </div>
+        {deviationBadge ? (
+          <DeviationBadge
+            ariaLabel={`${label} deviation ${deviationBadge.valueLabel}`}
+            severity={deviationBadge.severity}
+            valueLabel={deviationBadge.valueLabel}
+          />
+        ) : null}
+      </div>
+      <dl className="grid gap-2 text-sm text-text-primary">
+        <div className="flex items-baseline justify-between gap-2">
+          <dt className="text-xs uppercase tracking-[0.18em] text-accent-muted">{measured.label}</dt>
+          <dd className="text-base font-semibold text-text-primary">{measured.displayValue}</dd>
+        </div>
+        <div className="flex items-baseline justify-between gap-2">
+          <dt className="text-xs uppercase tracking-[0.18em] text-accent-muted">{target.label}</dt>
+          <dd className="text-base font-semibold text-text-primary">{target.displayValue}</dd>
+        </div>
+      </dl>
+    </section>
+  );
+}
+
+function resolveDeviationBadge(
+  measured: ControlCardMetricValue,
+  target: ControlCardMetricValue,
+  thresholds: ControlCardDeviationThresholds | undefined
+): DeviationBadgeDescriptor | null {
+  if (!thresholds || measured.numericValue === undefined || target.numericValue === undefined) {
+    return null;
+  }
+
+  const delta = measured.numericValue - target.numericValue;
+  const absoluteDelta = Math.abs(delta);
+  if (absoluteDelta < thresholds.warningDelta) {
+    return null;
+  }
+
+  const severity: DeviationBadgeDescriptor["severity"] =
+    thresholds.criticalDelta !== undefined && absoluteDelta >= thresholds.criticalDelta ? "critical" : "warning";
+  const formatter = thresholds.formatDelta ?? ((value: number) => defaultDeviationFormatter.format(value));
+
+  return {
+    severity,
+    valueLabel: formatter(delta)
+  };
+}
+
+interface DeviationBadgeProps extends DeviationBadgeDescriptor {
+  readonly ariaLabel: string;
+}
+
+function DeviationBadge({ severity, valueLabel, ariaLabel }: DeviationBadgeProps): ReactElement {
+  const baseClass =
+    "inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em]";
+  const severityClass =
+    severity === "critical"
+      ? "border-accent-critical/70 bg-accent-critical/10 text-accent-critical"
+      : "border-accent-warning/60 bg-accent-warning/10 text-accent-warning";
+
+  return (
+    <span aria-label={ariaLabel} className={cn(baseClass, severityClass)} data-variant={severity} role="status">
+      <span aria-hidden="true">Δ</span>
+      <span>{valueLabel}</span>
+    </span>
+  );
+}
+
+interface ClimateDeviceTileInternalProps extends ClimateControlDeviceTileProps {
+  readonly classLabel: string;
+}
+
+function ClimateDeviceTile({
+  classLabel,
+  name,
+  description,
+  throughputFraction01,
+  capacityFraction01,
+  isEnabled,
+  onToggleEnabled,
+  onMove,
+  onRemove
+}: ClimateDeviceTileInternalProps): ReactElement {
+  const throughputLabel = formatThroughputPercentage(throughputFraction01);
+  const capacityLabel = formatCapacityPercentage(capacityFraction01);
+  const statusLabel = isEnabled ? "Enabled" : "Disabled";
+  const toggleLabel = isEnabled ? "Disable" : "Enable";
+
+  return (
+    <div className="flex h-full flex-col justify-between gap-4 p-4">
+      <div className="space-y-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="space-y-1">
+            <span className="inline-flex items-center rounded-full border border-border-base/60 bg-canvas-subtle px-2 py-0.5 text-[0.625rem] font-semibold uppercase tracking-[0.2em] text-accent-muted">
+              {classLabel}
+            </span>
+            <p className="text-sm font-semibold text-text-primary">{name}</p>
+          </div>
+          <span className="text-xs font-medium uppercase tracking-[0.18em] text-accent-muted">{statusLabel}</span>
+        </div>
+        {description ? <p className="text-xs text-text-muted">{description}</p> : null}
+        <dl className="space-y-2 text-sm text-text-primary">
+          <div className="flex items-center justify-between gap-2">
+            <dt className="text-xs uppercase tracking-[0.18em] text-accent-muted">Throughput</dt>
+            <dd className="font-semibold text-text-primary">{throughputLabel}</dd>
+          </div>
+          <div className="flex items-center justify-between gap-2">
+            <dt className="text-xs uppercase tracking-[0.18em] text-accent-muted">Capacity</dt>
+            <dd className="font-semibold text-text-primary">{capacityLabel}</dd>
+          </div>
+        </dl>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          className={cn(
+            "inline-flex flex-1 items-center justify-center rounded-lg border px-3 py-2 text-sm font-medium transition",
+            isEnabled
+              ? "border-border-strong bg-surface-critical/10 text-text-critical hover:bg-surface-critical/20"
+              : "border-accent-primary/60 bg-accent-primary/10 text-accent-primary hover:bg-accent-primary/20"
+          )}
+          onClick={() => {
+            onToggleEnabled(!isEnabled);
+          }}
+          aria-pressed={isEnabled}
+        >
+          {toggleLabel}
+        </button>
+        <button
+          type="button"
+          className="inline-flex items-center justify-center rounded-lg border border-border-base/60 bg-canvas-subtle px-3 py-2 text-sm font-medium text-text-primary transition hover:bg-canvas-subtle/80 disabled:cursor-not-allowed disabled:opacity-60"
+          onClick={onMove}
+          disabled={!onMove}
+        >
+          Move
+        </button>
+        <button
+          type="button"
+          className="inline-flex items-center justify-center rounded-lg border border-border-strong bg-surface-critical/10 px-3 py-2 text-sm font-medium text-text-critical transition hover:bg-surface-critical/20 disabled:cursor-not-allowed disabled:opacity-60"
+          onClick={onRemove}
+          disabled={!onRemove}
+        >
+          Remove
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/controls/__tests__/ClimateControlCard.test.tsx
+++ b/packages/ui/src/components/controls/__tests__/ClimateControlCard.test.tsx
@@ -1,0 +1,216 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  ClimateControlCard,
+  type ClimateControlCardProps,
+  type ClimateControlDeviceTileProps
+} from "@ui/components/controls/ClimateControlCard";
+
+const TEMPERATURE_MEASURED_DEFAULT = 25;
+const TEMPERATURE_TARGET_DEFAULT = 22;
+const TEMPERATURE_WARNING_DELTA = 1;
+const TEMPERATURE_CRITICAL_DELTA = 3;
+const HVAC_THROUGHPUT_FRACTION = 0.5;
+const HVAC_CAPACITY_FRACTION = 0.8;
+const HUMIDITY_MEASURED_WARNING = 72;
+const HUMIDITY_TARGET = 60;
+const HUMIDITY_WARNING_DELTA = 10;
+const HUMIDITY_CRITICAL_DELTA = 20;
+const TEMPERATURE_MEASURED_CRITICAL = 28;
+const CO2_MEASURED = 1400;
+const CO2_TARGET = 1000;
+const CO2_WARNING_DELTA = 200;
+const CO2_CRITICAL_DELTA = 400;
+const ACH_MEASURED = 0.8;
+const ACH_TARGET = 2;
+const ACH_WARNING_DELTA = 0.5;
+const ACH_CRITICAL_DELTA = 1;
+const numberFormatter = new Intl.NumberFormat("en-US");
+const TEMPERATURE_MEASURED_DISPLAY = String(TEMPERATURE_MEASURED_DEFAULT) + " °C";
+const TEMPERATURE_TARGET_DISPLAY = String(TEMPERATURE_TARGET_DEFAULT) + " °C";
+const TEMPERATURE_CRITICAL_DISPLAY = String(TEMPERATURE_MEASURED_CRITICAL) + " °C";
+const HUMIDITY_MEASURED_DISPLAY = String(HUMIDITY_MEASURED_WARNING) + "%";
+const HUMIDITY_TARGET_DISPLAY = String(HUMIDITY_TARGET) + "%";
+const CO2_MEASURED_DISPLAY = numberFormatter.format(CO2_MEASURED) + " ppm";
+const CO2_TARGET_DISPLAY = numberFormatter.format(CO2_TARGET) + " ppm";
+const ACH_MEASURED_DISPLAY = String(ACH_MEASURED) + " ACH";
+const ACH_TARGET_DISPLAY = String(ACH_TARGET) + " ACH";
+
+function createMetric(
+  overrides: Partial<ClimateControlCardProps["temperature"]> = {}
+): ClimateControlCardProps["temperature"] {
+  return {
+    label: "Temperature",
+    measured: {
+      label: "Measured",
+      displayValue: TEMPERATURE_MEASURED_DISPLAY,
+      numericValue: TEMPERATURE_MEASURED_DEFAULT
+    },
+    target: {
+      label: "Target",
+      displayValue: TEMPERATURE_TARGET_DISPLAY,
+      numericValue: TEMPERATURE_TARGET_DEFAULT
+    },
+    deviation: { warningDelta: TEMPERATURE_WARNING_DELTA, criticalDelta: TEMPERATURE_CRITICAL_DELTA },
+    toleranceLabel: "±1 °C allowed",
+    ...overrides
+  } satisfies ClimateControlCardProps["temperature"];
+}
+
+function createDevice(
+  overrides: Partial<ClimateControlDeviceTileProps> = {}
+): ClimateControlDeviceTileProps {
+  return {
+    id: "device-1",
+    name: "HVAC A",
+    throughputFraction01: HVAC_THROUGHPUT_FRACTION,
+    capacityFraction01: HVAC_CAPACITY_FRACTION,
+    isEnabled: true,
+    onToggleEnabled: vi.fn(),
+    onMove: vi.fn(),
+    onRemove: vi.fn(),
+    description: "Primary HVAC unit",
+    ...overrides
+  } satisfies ClimateControlDeviceTileProps;
+}
+
+describe("ClimateControlCard", () => {
+  it("renders each metric section with deviation badges when tolerances are exceeded", () => {
+    render(
+      <ClimateControlCard
+        temperature={createMetric({
+          measured: {
+            label: "Measured",
+            displayValue: TEMPERATURE_CRITICAL_DISPLAY,
+            numericValue: TEMPERATURE_MEASURED_CRITICAL
+          }
+        })}
+        humidity={{
+          label: "Relative humidity",
+          measured: {
+            label: "Measured",
+            displayValue: HUMIDITY_MEASURED_DISPLAY,
+            numericValue: HUMIDITY_MEASURED_WARNING
+          },
+          target: { label: "Target", displayValue: HUMIDITY_TARGET_DISPLAY, numericValue: HUMIDITY_TARGET },
+          deviation: { warningDelta: HUMIDITY_WARNING_DELTA, criticalDelta: HUMIDITY_CRITICAL_DELTA }
+        }}
+        co2={{
+          label: "CO₂",
+          measured: {
+            label: "Measured",
+            displayValue: CO2_MEASURED_DISPLAY,
+            numericValue: CO2_MEASURED
+          },
+          target: {
+            label: "Target",
+            displayValue: CO2_TARGET_DISPLAY,
+            numericValue: CO2_TARGET
+          },
+          deviation: { warningDelta: CO2_WARNING_DELTA, criticalDelta: CO2_CRITICAL_DELTA }
+        }}
+        ach={{
+          label: "Air changes per hour",
+          measured: { label: "Measured", displayValue: ACH_MEASURED_DISPLAY, numericValue: ACH_MEASURED },
+          target: { label: "Target", displayValue: ACH_TARGET_DISPLAY, numericValue: ACH_TARGET },
+          deviation: { warningDelta: ACH_WARNING_DELTA, criticalDelta: ACH_CRITICAL_DELTA }
+        }}
+      />
+    );
+
+    const temperatureSection = screen.getByRole("region", { name: "Temperature" });
+    expect(within(temperatureSection).getByText("28 °C")).toBeInTheDocument();
+    expect(within(temperatureSection).getByRole("status", { name: /Temperature deviation/ })).toHaveAttribute(
+      "data-variant",
+      "critical"
+    );
+
+    const humiditySection = screen.getByRole("region", { name: "Relative humidity" });
+    expect(within(humiditySection).getByRole("status", { name: /Relative humidity deviation/ })).toHaveAttribute(
+      "data-variant",
+      "warning"
+    );
+
+    const co2Section = screen.getByRole("region", { name: "CO₂" });
+    expect(within(co2Section).getByRole("status", { name: /CO₂ deviation/ })).toBeInTheDocument();
+
+    const achSection = screen.getByRole("region", { name: "Air changes per hour" });
+    expect(within(achSection).getByRole("status", { name: /Air changes per hour deviation/ })).toHaveAttribute(
+      "data-variant",
+      "critical"
+    );
+  });
+
+  it("renders device tiles per class with throughput and capacity percentages plus action affordances", () => {
+    const device = createDevice();
+    render(
+      <ClimateControlCard
+        temperature={createMetric()}
+        humidity={createMetric({ label: "Relative humidity" })}
+        co2={createMetric({ label: "CO₂" })}
+        ach={createMetric({ label: "Air changes per hour" })}
+        deviceClasses={[
+          {
+            classId: "hvac",
+            label: "HVAC",
+            devices: [device]
+          }
+        ]}
+      />
+    );
+
+    const list = screen.getByRole("list");
+    const tile = within(list).getByRole("listitem");
+
+    expect(within(tile).getByText("HVAC")).toBeInTheDocument();
+    expect(within(tile).getByText("HVAC A")).toBeInTheDocument();
+    expect(within(tile).getByText("50%")).toBeInTheDocument();
+    expect(within(tile).getByText("80%")).toBeInTheDocument();
+
+    const toggle = within(tile).getByRole("button", { name: "Disable" });
+    fireEvent.click(toggle);
+    expect(device.onToggleEnabled).toHaveBeenCalledWith(false);
+
+    const move = within(tile).getByRole("button", { name: "Move" });
+    fireEvent.click(move);
+    expect(device.onMove).toHaveBeenCalledTimes(1);
+
+    const remove = within(tile).getByRole("button", { name: "Remove" });
+    fireEvent.click(remove);
+    expect(device.onRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows ghost placeholders for device classes without tiles", () => {
+    render(
+      <ClimateControlCard
+        temperature={createMetric()}
+        humidity={createMetric({ label: "Relative humidity" })}
+        co2={createMetric({ label: "CO₂" })}
+        ach={createMetric({ label: "Air changes per hour" })}
+        deviceClasses={[
+          {
+            classId: "hvac",
+            label: "HVAC",
+            devices: [createDevice()]
+          }
+        ]}
+        ghostPlaceholders={[
+          {
+            deviceClassId: "fans",
+            label: "Air circulation",
+            description: "Add fans to circulate air"
+          },
+          {
+            deviceClassId: "hvac",
+            label: "HVAC",
+            description: "Add another HVAC"
+          }
+        ]}
+      />
+    );
+
+    const list = screen.getByRole("list");
+    expect(within(list).getByRole("button", { name: "Air circulation placeholder" })).toBeInTheDocument();
+    expect(within(list).queryByRole("button", { name: "HVAC placeholder" })).toBeNull();
+  });
+});

--- a/packages/ui/src/components/controls/index.ts
+++ b/packages/ui/src/components/controls/index.ts
@@ -10,3 +10,10 @@ export type {
 export { ControlCard } from "./ControlCard";
 export type { LightingControlCardProps, LightingDeviceTileProps } from "./LightingControlCard";
 export { LightingControlCard } from "./LightingControlCard";
+export type {
+  ClimateControlCardProps,
+  ClimateControlDeviceClassSection,
+  ClimateControlDeviceTileProps,
+  ClimateControlMetricDefinition
+} from "./ClimateControlCard";
+export { ClimateControlCard } from "./ClimateControlCard";

--- a/packages/ui/src/lib/__tests__/percentageFormatting.test.ts
+++ b/packages/ui/src/lib/__tests__/percentageFormatting.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { formatCapacityPercentage, formatThroughputPercentage } from "@ui/lib/percentageFormatting";
+
+const NEGATIVE_FRACTION = -0.4;
+const ABOVE_MAX_FRACTION = 1.6;
+const CAPACITY_FRACTION = 0.475;
+const HALF_FRACTION = 0.5;
+
+describe("percentageFormatting", () => {
+  it("clamps throughput fractions outside the [0,1] range", () => {
+    expect(formatThroughputPercentage(NEGATIVE_FRACTION)).toBe("0%");
+    expect(formatThroughputPercentage(ABOVE_MAX_FRACTION)).toBe("100%");
+  });
+
+  it("formats capacity fractions using percent style with no decimals", () => {
+    expect(formatCapacityPercentage(CAPACITY_FRACTION)).toBe("48%");
+    expect(formatCapacityPercentage(HALF_FRACTION)).toBe("50%");
+  });
+});

--- a/packages/ui/src/lib/percentageFormatting.ts
+++ b/packages/ui/src/lib/percentageFormatting.ts
@@ -1,0 +1,25 @@
+const percentFormatter = new Intl.NumberFormat("en-US", {
+  style: "percent",
+  maximumFractionDigits: 0
+});
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  if (value < 0) {
+    return 0;
+  }
+  if (value > 1) {
+    return 1;
+  }
+  return value;
+}
+
+export function formatThroughputPercentage(fraction01: number): string {
+  return percentFormatter.format(clamp01(fraction01));
+}
+
+export function formatCapacityPercentage(fraction01: number): string {
+  return percentFormatter.format(clamp01(fraction01));
+}


### PR DESCRIPTION
## Summary
- add a climate control card that composes metric sections and climate device tiles on top of the shared control scaffold
- introduce shared percentage formatting helpers for throughput and capacity values
- cover the new component and utilities with Vitest suites and document the addition in the changelog

## Testing
- pnpm --filter @wb/ui lint
- pnpm --filter @wb/ui test

------
https://chatgpt.com/codex/tasks/task_e_68f09d5f80f883259062cc6814aeb58a