### PR TITLE
Integrate zone and room control cards

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,11 @@
   affordances, filtered ghost placeholders for missing classes, and added
   deterministic Vitest coverage alongside shared percentage formatting
   utilities under `packages/ui/src/lib`.
+- Task 5400: Wired lighting and climate control cards into the zone and room
+  detail pages with stage-derived targets, ghost placeholders, and shared
+  "Open Capacity Advisor" routing, expanded the read-model hooks to surface
+  control snapshots, and added Vitest coverage for hook data assembly, page
+  rendering, and CTA navigation.
 - Task 0000: Introduced the global workspace shell with a responsive left rail
   (Company → Structures → HR → Strains), a sticky simulation control bar with
   play/pause/step and deterministic speed chips, locale-aware balance and tick

--- a/packages/ui/src/lib/navigation.ts
+++ b/packages/ui/src/lib/navigation.ts
@@ -90,6 +90,10 @@ export function buildRoomPath(structureId: string, roomId: string): string {
   return `/structures/${structureId}/rooms/${roomId}`;
 }
 
+export function buildStructureCapacityAdvisorPath(structureId: string): string {
+  return `/structures/${structureId}/capacity-advisor`;
+}
+
 export interface ResolvedZoneNavItem {
   structure: WorkspaceStructureNavItem;
   zone: WorkspaceZoneNavItem;

--- a/packages/ui/src/pages/RoomDetailPage.tsx
+++ b/packages/ui/src/pages/RoomDetailPage.tsx
@@ -1,11 +1,13 @@
-import type { ReactElement } from "react";
-import { Link, useInRouterContext } from "react-router-dom";
+import { useCallback, type ReactElement } from "react";
+import { Link, useInRouterContext, useNavigate, type NavigateFunction } from "react-router-dom";
+import { LightingControlCard, ClimateControlCard } from "@ui/components/controls";
+import type { ControlCardGhostActionPayload } from "@ui/components/controls/ControlCard";
 import { RoomClimateSnapshot } from "@ui/components/rooms/RoomClimateSnapshot";
 import { RoomDevicesPanel } from "@ui/components/rooms/RoomDevicesPanel";
 import { RoomHeader } from "@ui/components/rooms/RoomHeader";
 import { RoomTimelinePanel } from "@ui/components/rooms/RoomTimelinePanel";
 import { RoomZonesList } from "@ui/components/rooms/RoomZonesList";
-import { buildRoomBreadcrumbs } from "@ui/lib/navigation";
+import { buildRoomBreadcrumbs, buildStructureCapacityAdvisorPath } from "@ui/lib/navigation";
 import { useRoomDetailView } from "@ui/pages/roomDetailHooks";
 
 export interface RoomDetailPageProps {
@@ -22,6 +24,17 @@ export function RoomDetailPage({ structureId, roomId }: RoomDetailPageProps): Re
     snapshot.header.roomName
   );
   const hasRouterContext = useInRouterContext();
+  const navigate: NavigateFunction = useNavigate();
+  const handleGhostAction = useCallback(
+    (payload: ControlCardGhostActionPayload) => {
+      console.info("[stub] open capacity advisor", {
+        structureId,
+        origin: payload
+      });
+      navigate(buildStructureCapacityAdvisorPath(structureId));
+    },
+    [navigate, structureId]
+  );
 
   return (
     <section aria-label={`Room detail for ${snapshot.header.roomName}`} className="flex flex-1 flex-col gap-6">
@@ -54,6 +67,36 @@ export function RoomDetailPage({ structureId, roomId }: RoomDetailPageProps): Re
       />
 
       <RoomZonesList zones={snapshot.zones} />
+
+      <LightingControlCard
+        title={snapshot.controls.lighting.title}
+        description={snapshot.controls.lighting.description ?? undefined}
+        measuredPpfd={snapshot.controls.lighting.measuredPpfd}
+        targetPpfd={snapshot.controls.lighting.targetPpfd}
+        deviation={snapshot.controls.lighting.deviation}
+        schedule={snapshot.controls.lighting.schedule}
+        onTargetPpfdChange={snapshot.controls.lighting.onTargetChange}
+        onScheduleSubmit={snapshot.controls.lighting.onScheduleSubmit}
+        isScheduleSubmitting={snapshot.controls.lighting.isScheduleSubmitting}
+        deviceTiles={snapshot.controls.lighting.deviceTiles}
+        ghostPlaceholders={snapshot.controls.lighting.ghostPlaceholders}
+        deviceSectionEmptyLabel={snapshot.controls.lighting.deviceSectionEmptyLabel}
+        scheduleSubmitLabel={snapshot.controls.lighting.scheduleSubmitLabel}
+        onGhostAction={handleGhostAction}
+      />
+
+      <ClimateControlCard
+        title={snapshot.controls.climate.title}
+        description={snapshot.controls.climate.description ?? undefined}
+        temperature={snapshot.controls.climate.temperature}
+        humidity={snapshot.controls.climate.humidity}
+        co2={snapshot.controls.climate.co2}
+        ach={snapshot.controls.climate.ach}
+        deviceClasses={snapshot.controls.climate.deviceClasses}
+        ghostPlaceholders={snapshot.controls.climate.ghostPlaceholders}
+        deviceSectionEmptyLabel={snapshot.controls.climate.deviceSectionEmptyLabel}
+        onGhostAction={handleGhostAction}
+      />
 
       <RoomClimateSnapshot climate={snapshot.climate} />
 

--- a/packages/ui/src/pages/ZoneDetailPage.tsx
+++ b/packages/ui/src/pages/ZoneDetailPage.tsx
@@ -1,4 +1,7 @@
-import type { ReactElement } from "react";
+import { useCallback, type ReactElement } from "react";
+import { useNavigate, type NavigateFunction } from "react-router-dom";
+import { LightingControlCard, ClimateControlCard } from "@ui/components/controls";
+import type { ControlCardGhostActionPayload } from "@ui/components/controls/ControlCard";
 import { ZoneActionsPanel } from "@ui/components/zones/ZoneActionsPanel";
 import { ZoneClimateSnapshot } from "@ui/components/zones/ZoneClimateSnapshot";
 import { ZoneDevicesPanel } from "@ui/components/zones/ZoneDevicesPanel";
@@ -6,6 +9,7 @@ import { ZoneHeader } from "@ui/components/zones/ZoneHeader";
 import { ZoneKpiPanel } from "@ui/components/zones/ZoneKpiPanel";
 import { ZonePestPanel } from "@ui/components/zones/ZonePestPanel";
 import { useZoneDetailView } from "@ui/pages/zoneDetailHooks";
+import { buildStructureCapacityAdvisorPath } from "@ui/lib/navigation";
 
 export interface ZoneDetailPageProps {
   readonly structureId: string;
@@ -15,6 +19,17 @@ export interface ZoneDetailPageProps {
 
 export function ZoneDetailPage({ structureId, roomId, zoneId }: ZoneDetailPageProps): ReactElement {
   const snapshot = useZoneDetailView(structureId, roomId, zoneId);
+  const navigate: NavigateFunction = useNavigate();
+  const handleGhostAction = useCallback(
+    (payload: ControlCardGhostActionPayload) => {
+      console.info("[stub] open capacity advisor", {
+        structureId,
+        origin: payload
+      });
+      navigate(buildStructureCapacityAdvisorPath(structureId));
+    },
+    [navigate, structureId]
+  );
 
   return (
     <section aria-label={`Zone detail for ${snapshot.header.zoneName}`} className="flex flex-1 flex-col gap-6">
@@ -23,6 +38,36 @@ export function ZoneDetailPage({ structureId, roomId, zoneId }: ZoneDetailPagePr
       <ZoneKpiPanel kpis={snapshot.kpis} />
 
       <ZonePestPanel pest={snapshot.pest} />
+
+      <LightingControlCard
+        title={snapshot.controls.lighting.title}
+        description={snapshot.controls.lighting.description ?? undefined}
+        measuredPpfd={snapshot.controls.lighting.measuredPpfd}
+        targetPpfd={snapshot.controls.lighting.targetPpfd}
+        deviation={snapshot.controls.lighting.deviation}
+        schedule={snapshot.controls.lighting.schedule}
+        onTargetPpfdChange={snapshot.controls.lighting.onTargetChange}
+        onScheduleSubmit={snapshot.controls.lighting.onScheduleSubmit}
+        isScheduleSubmitting={snapshot.controls.lighting.isScheduleSubmitting}
+        deviceTiles={snapshot.controls.lighting.deviceTiles}
+        ghostPlaceholders={snapshot.controls.lighting.ghostPlaceholders}
+        deviceSectionEmptyLabel={snapshot.controls.lighting.deviceSectionEmptyLabel}
+        scheduleSubmitLabel={snapshot.controls.lighting.scheduleSubmitLabel}
+        onGhostAction={handleGhostAction}
+      />
+
+      <ClimateControlCard
+        title={snapshot.controls.climate.title}
+        description={snapshot.controls.climate.description ?? undefined}
+        temperature={snapshot.controls.climate.temperature}
+        humidity={snapshot.controls.climate.humidity}
+        co2={snapshot.controls.climate.co2}
+        ach={snapshot.controls.climate.ach}
+        deviceClasses={snapshot.controls.climate.deviceClasses}
+        ghostPlaceholders={snapshot.controls.climate.ghostPlaceholders}
+        deviceSectionEmptyLabel={snapshot.controls.climate.deviceSectionEmptyLabel}
+        onGhostAction={handleGhostAction}
+      />
 
       <ZoneClimateSnapshot climate={snapshot.climate} />
 

--- a/packages/ui/src/pages/__tests__/roomDetailHooks.test.tsx
+++ b/packages/ui/src/pages/__tests__/roomDetailHooks.test.tsx
@@ -1,0 +1,105 @@
+/* eslint-disable @typescript-eslint/no-magic-numbers */
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { RoomDetailSnapshot } from "@ui/pages/roomDetailHooks";
+import { useRoomDetailView } from "@ui/pages/roomDetailHooks";
+import { applyReadModelSnapshot, resetReadModelStore } from "@ui/state/readModels";
+import { deterministicReadModelSnapshot } from "@ui/test-utils/readModelFixtures";
+import { resetIntentState } from "@ui/state/intents";
+import { clearTelemetrySnapshots } from "@ui/state/telemetry";
+import type { ReadModelSnapshot } from "@ui/state/readModels.types";
+
+type DeepMutable<T> = T extends (...args: never[]) => unknown
+  ? T
+  : T extends readonly (infer U)[]
+    ? DeepMutable<U>[]
+    : T extends object
+      ? { -readonly [K in keyof T]: DeepMutable<T[K]> }
+      : T;
+
+const STRUCTURE_ID = "structure-green-harbor";
+const GROW_ROOM_ID = "room-veg-a";
+const STORAGE_ROOM_ID = "room-post-process";
+
+let latestSnapshot: RoomDetailSnapshot | null = null;
+
+function RoomTestProbe({ structureId, roomId }: { structureId: string; roomId: string }): null {
+  latestSnapshot = useRoomDetailView(structureId, roomId);
+  return null;
+}
+
+function assertSnapshot(
+  snapshot: RoomDetailSnapshot | null,
+  message: string
+): asserts snapshot is RoomDetailSnapshot {
+  if (!snapshot) {
+    throw new Error(message);
+  }
+}
+
+describe("useRoomDetailView", () => {
+  beforeEach(() => {
+    latestSnapshot = null;
+    resetReadModelStore();
+    resetIntentState();
+    clearTelemetrySnapshots();
+  });
+
+  afterEach(() => {
+    cleanup();
+    latestSnapshot = null;
+    resetReadModelStore();
+    resetIntentState();
+    clearTelemetrySnapshots();
+  });
+
+  it("aggregates lighting and climate controls across room zones", () => {
+    render(<RoomTestProbe structureId={STRUCTURE_ID} roomId={GROW_ROOM_ID} />);
+
+    assertSnapshot(latestSnapshot, "Expected snapshot after rendering grow room probe");
+    expect(latestSnapshot.controls.lighting.targetPpfd).toBe(550);
+    expect(latestSnapshot.controls.lighting.deviceTiles.length).toBeGreaterThan(0);
+    expect(latestSnapshot.controls.climate.deviceClasses.length).toBeGreaterThan(0);
+    expect(latestSnapshot.controls.climate.ghostPlaceholders).toHaveLength(0);
+  });
+
+  it("derives fallback lighting target for rooms without zones", () => {
+    render(<RoomTestProbe structureId={STRUCTURE_ID} roomId={STORAGE_ROOM_ID} />);
+
+    assertSnapshot(latestSnapshot, "Expected snapshot after rendering storage room probe");
+    expect(latestSnapshot.controls.lighting.targetPpfd).toBe(180);
+    expect(latestSnapshot.controls.lighting.deviceTiles).toHaveLength(0);
+    expect(latestSnapshot.controls.lighting.ghostPlaceholders.length).toBeGreaterThan(0);
+  });
+
+  it("emits ghost placeholders when required device classes are missing", () => {
+    const mutatedSnapshot = structuredClone(
+      deterministicReadModelSnapshot
+    ) as DeepMutable<ReadModelSnapshot>;
+    const structure = mutatedSnapshot.structures.find((candidate) => candidate.id === STRUCTURE_ID);
+    if (!structure) {
+      throw new Error("Structure not found in deterministic snapshot");
+    }
+    const room = structure.rooms.find((candidate) => candidate.id === GROW_ROOM_ID);
+    if (!room) {
+      throw new Error("Room not found in deterministic snapshot");
+    }
+
+    room.devices = room.devices.filter((device) => device.class !== "lighting");
+    structure.devices = structure.devices.filter((device) => device.class !== "climate");
+
+    applyReadModelSnapshot(mutatedSnapshot as ReadModelSnapshot);
+
+    render(<RoomTestProbe structureId={STRUCTURE_ID} roomId={GROW_ROOM_ID} />);
+
+    assertSnapshot(latestSnapshot, "Expected snapshot after applying mutated read model");
+    expect(latestSnapshot.controls.lighting.deviceTiles).toHaveLength(0);
+    expect(latestSnapshot.controls.lighting.ghostPlaceholders[0]).toMatchObject({
+      deviceClassId: "lighting"
+    });
+    expect(latestSnapshot.controls.climate.ghostPlaceholders).toContainEqual(
+      expect.objectContaining({ deviceClassId: "climate" })
+    );
+  });
+});
+/* eslint-enable @typescript-eslint/no-magic-numbers */


### PR DESCRIPTION
## Summary
- extend the zone and room detail hooks to surface lighting/climate control snapshots, including ghost placeholders for missing device classes
- mount the LightingControlCard and ClimateControlCard on the zone and room detail pages with shared capacity-advisor CTA wiring
- exercise the new hooks and page wiring with Vitest coverage and log the delivery in the changelog

## Testing
- pnpm --filter @wb/ui test RoomDetailPage.test.tsx ZoneDetailPage.test.tsx -- --runInBand
- pnpm -w -r test


------
https://chatgpt.com/codex/tasks/task_e_68f0a11375b08325abc3cca97d690f4b