### PR TITLE
Complete HR workforce surface

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,14 @@
 
 ### Unreleased — Hotfix Batch 03
 
+- Task 6000: Replaced the workforce KPI shell with the HR directory, activity
+  timeline, task queues, capacity snapshot, and action panel. Introduced
+  workforce filter state via Zustand, wired the HR route to the new intent
+  client, refreshed HR navigation labels, and added deterministic Vitest
+  coverage for directory rendering, filtering, task queue actions, and intent
+  dispatch flows (`packages/ui/src/pages/WorkforcePage.tsx`,
+  `packages/ui/src/components/workforce/**`,
+  `packages/ui/src/pages/__tests__/WorkforcePage.test.tsx`).
 - Task 5100: Established the shared control card scaffold with reusable header
   metrics, deviation badge, and device grid sections under
   `packages/ui/src/components/controls`, added ghost device-class placeholders

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.5",
     "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.5.1",
     "@types/react": "^18.3.4",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react-swc": "^3.8.0",

--- a/packages/ui/src/components/workforce/ActionPanel.tsx
+++ b/packages/ui/src/components/workforce/ActionPanel.tsx
@@ -1,0 +1,241 @@
+import { useState, type ReactElement } from "react";
+import type { WorkforceAssigneeOption } from "@ui/components/workforce/TaskQueues";
+
+export interface WorkforceActionTargetOption {
+  readonly id: string;
+  readonly label: string;
+}
+
+export interface WorkforceActionPanelProps {
+  readonly employees: readonly WorkforceAssigneeOption[];
+  readonly assignmentTargets: readonly WorkforceActionTargetOption[];
+  readonly zoneTargets: readonly WorkforceActionTargetOption[];
+  readonly maintenanceTargets: readonly WorkforceActionTargetOption[];
+  readonly intentsEnabled: boolean;
+  readonly onAssign: (employeeId: string, targetId: string) => void;
+  readonly onInspectionStart: (zoneId: string) => void;
+  readonly onInspectionComplete: (zoneId: string) => void;
+  readonly onTreatmentStart: (zoneId: string) => void;
+  readonly onTreatmentComplete: (zoneId: string) => void;
+  readonly onMaintenanceStart: (targetId: string) => void;
+  readonly onMaintenanceComplete: (targetId: string) => void;
+}
+
+function isActionDisabled(enabled: boolean, ...values: readonly (string | null | undefined)[]): boolean {
+  if (!enabled) {
+    return true;
+  }
+
+  return values.some((value) => !value);
+}
+
+export function WorkforceActionPanel({
+  employees,
+  assignmentTargets,
+  zoneTargets,
+  maintenanceTargets,
+  intentsEnabled,
+  onAssign,
+  onInspectionStart,
+  onInspectionComplete,
+  onTreatmentStart,
+  onTreatmentComplete,
+  onMaintenanceStart,
+  onMaintenanceComplete
+}: WorkforceActionPanelProps): ReactElement {
+  const [selectedEmployeeId, setSelectedEmployeeId] = useState<string>("");
+  const [selectedAssignmentTarget, setSelectedAssignmentTarget] = useState<string>("");
+  const [selectedZone, setSelectedZone] = useState<string>("");
+  const [selectedMaintenanceTarget, setSelectedMaintenanceTarget] = useState<string>("");
+
+  const assignDisabled = isActionDisabled(intentsEnabled, selectedEmployeeId, selectedAssignmentTarget);
+  const inspectionDisabled = isActionDisabled(intentsEnabled, selectedZone);
+  const maintenanceDisabled = isActionDisabled(intentsEnabled, selectedMaintenanceTarget);
+
+  return (
+    <section aria-labelledby="hr-action-panel-heading" className="space-y-4">
+      <header className="flex flex-col gap-2">
+        <p className="text-sm uppercase tracking-[0.25em] text-accent-muted">Tasking</p>
+        <h2 className="text-2xl font-semibold text-text-primary" id="hr-action-panel-heading">
+          Workforce action panel
+        </h2>
+        <p className="text-sm text-text-muted">
+          Dispatch assignments and trigger inspections, treatments, or maintenance. Actions reuse the same intents as
+          zone and room surfaces.
+        </p>
+        {!intentsEnabled ? (
+          <p className="text-xs text-text-muted">
+            Transport base URL not configured. Intent buttons are disabled for safety.
+          </p>
+        ) : null}
+      </header>
+
+      <div className="grid gap-4 lg:grid-cols-3">
+        <div className="space-y-3 rounded-xl border border-border-base bg-canvas-base/70 p-5">
+          <h3 className="text-lg font-semibold text-text-primary">Assign / Reassign</h3>
+          <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-[0.2em] text-accent-muted">
+            Employee
+            <select
+              aria-label="Select employee"
+              className="rounded-lg border border-border-base bg-canvas-base px-3 py-2 text-sm text-text-primary"
+              value={selectedEmployeeId}
+              onChange={(event) => {
+                setSelectedEmployeeId(event.currentTarget.value);
+              }}
+            >
+              <option value="">Select employee</option>
+              {employees.map((employee) => (
+                <option key={employee.id} value={employee.id}>
+                  {employee.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-[0.2em] text-accent-muted">
+            Target (structure / room / zone)
+            <select
+              aria-label="Select assignment target"
+              className="rounded-lg border border-border-base bg-canvas-base px-3 py-2 text-sm text-text-primary"
+              value={selectedAssignmentTarget}
+              onChange={(event) => {
+                setSelectedAssignmentTarget(event.currentTarget.value);
+              }}
+            >
+              <option value="">Select target</option>
+              {assignmentTargets.map((target) => (
+                <option key={target.id} value={target.id}>
+                  {target.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button
+            type="button"
+            className="w-full rounded-lg border border-accent-primary/70 bg-accent-primary/20 px-3 py-2 text-sm font-semibold text-accent-primary"
+            onClick={() => {
+              onAssign(selectedEmployeeId, selectedAssignmentTarget);
+            }}
+            disabled={assignDisabled}
+            aria-disabled={assignDisabled}
+          >
+            Dispatch assignment
+          </button>
+        </div>
+
+        <div className="space-y-3 rounded-xl border border-border-base bg-canvas-base/70 p-5">
+          <h3 className="text-lg font-semibold text-text-primary">Inspections & Treatments</h3>
+          <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-[0.2em] text-accent-muted">
+            Zone
+            <select
+              aria-label="Select zone for inspection or treatment"
+              className="rounded-lg border border-border-base bg-canvas-base px-3 py-2 text-sm text-text-primary"
+              value={selectedZone}
+              onChange={(event) => {
+                setSelectedZone(event.currentTarget.value);
+              }}
+            >
+              <option value="">Select zone</option>
+              {zoneTargets.map((zone) => (
+                <option key={zone.id} value={zone.id}>
+                  {zone.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <div className="grid gap-2">
+            <button
+              type="button"
+              className="rounded-lg border border-border-base/70 bg-canvas-base px-3 py-2 text-sm text-text-primary transition hover:border-accent-primary hover:text-accent-primary"
+              onClick={() => {
+                onInspectionStart(selectedZone);
+              }}
+              disabled={inspectionDisabled}
+              aria-disabled={inspectionDisabled}
+            >
+              Acknowledge inspection
+            </button>
+            <button
+              type="button"
+              className="rounded-lg border border-border-base/70 bg-canvas-base px-3 py-2 text-sm text-text-primary transition hover:border-accent-primary hover:text-accent-primary"
+              onClick={() => {
+                onInspectionComplete(selectedZone);
+              }}
+              disabled={inspectionDisabled}
+              aria-disabled={inspectionDisabled}
+            >
+              Complete inspection
+            </button>
+            <button
+              type="button"
+              className="rounded-lg border border-border-base/70 bg-canvas-base px-3 py-2 text-sm text-text-primary transition hover:border-accent-primary hover:text-accent-primary"
+              onClick={() => {
+                onTreatmentStart(selectedZone);
+              }}
+              disabled={inspectionDisabled}
+              aria-disabled={inspectionDisabled}
+            >
+              Launch treatment
+            </button>
+            <button
+              type="button"
+              className="rounded-lg border border-border-base/70 bg-canvas-base px-3 py-2 text-sm text-text-primary transition hover:border-accent-primary hover:text-accent-primary"
+              onClick={() => {
+                onTreatmentComplete(selectedZone);
+              }}
+              disabled={inspectionDisabled}
+              aria-disabled={inspectionDisabled}
+            >
+              Complete treatment
+            </button>
+          </div>
+        </div>
+
+        <div className="space-y-3 rounded-xl border border-border-base bg-canvas-base/70 p-5">
+          <h3 className="text-lg font-semibold text-text-primary">Maintenance</h3>
+          <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-[0.2em] text-accent-muted">
+            Device / target
+            <select
+              aria-label="Select maintenance target"
+              className="rounded-lg border border-border-base bg-canvas-base px-3 py-2 text-sm text-text-primary"
+              value={selectedMaintenanceTarget}
+              onChange={(event) => {
+                setSelectedMaintenanceTarget(event.currentTarget.value);
+              }}
+            >
+              <option value="">Select target</option>
+              {maintenanceTargets.map((target) => (
+                <option key={target.id} value={target.id}>
+                  {target.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <div className="grid gap-2">
+            <button
+              type="button"
+              className="rounded-lg border border-border-base/70 bg-canvas-base px-3 py-2 text-sm text-text-primary transition hover:border-accent-primary hover:text-accent-primary"
+              onClick={() => {
+                onMaintenanceStart(selectedMaintenanceTarget);
+              }}
+              disabled={maintenanceDisabled}
+              aria-disabled={maintenanceDisabled}
+            >
+              Start maintenance
+            </button>
+            <button
+              type="button"
+              className="rounded-lg border border-border-base/70 bg-canvas-base px-3 py-2 text-sm text-text-primary transition hover:border-accent-primary hover:text-accent-primary"
+              onClick={() => {
+                onMaintenanceComplete(selectedMaintenanceTarget);
+              }}
+              disabled={maintenanceDisabled}
+              aria-disabled={maintenanceDisabled}
+            >
+              Complete maintenance
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/ui/src/components/workforce/ActivityTimeline.tsx
+++ b/packages/ui/src/components/workforce/ActivityTimeline.tsx
@@ -1,0 +1,60 @@
+import type { ReactElement } from "react";
+
+export interface WorkforceActivityEntryView {
+  readonly id: string;
+  readonly timestampLabel: string;
+  readonly title: string;
+  readonly description: string;
+  readonly scopeLabel: string;
+  readonly assigneeLabel: string | null;
+  readonly durationLabel: string;
+}
+
+export interface WorkforceActivityTimelineProps {
+  readonly entries: readonly WorkforceActivityEntryView[];
+}
+
+export function WorkforceActivityTimeline({ entries }: WorkforceActivityTimelineProps): ReactElement {
+  return (
+    <section aria-labelledby="hr-activity-heading" className="space-y-4">
+      <header className="flex flex-col gap-2">
+        <p className="text-sm uppercase tracking-[0.25em] text-accent-muted">Activity</p>
+        <h2 className="text-2xl font-semibold text-text-primary" id="hr-activity-heading">
+          Recent HR activity timeline
+        </h2>
+        <p className="text-sm text-text-muted">
+          Timeline of inspections, treatments, harvests, and maintenance tasks filtered by your HR criteria.
+        </p>
+      </header>
+
+      <ol className="space-y-4" aria-label="HR activity timeline">
+        {entries.map((entry) => (
+          <li
+            key={entry.id}
+            className="rounded-xl border border-border-base bg-canvas-base/70 p-5"
+            aria-label={entry.title}
+          >
+            <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-text-muted">
+              <span className="font-semibold uppercase tracking-[0.2em] text-accent-muted">
+                {entry.timestampLabel}
+              </span>
+              <span>{entry.durationLabel}</span>
+            </div>
+            <h3 className="mt-3 text-lg font-semibold text-text-primary">{entry.title}</h3>
+            <p className="mt-1 text-sm text-text-muted">{entry.description}</p>
+            <div className="mt-3 flex flex-wrap items-center gap-3 text-xs text-accent-muted">
+              <span className="rounded-full border border-accent-muted/40 px-3 py-1 uppercase tracking-[0.2em]">
+                {entry.scopeLabel}
+              </span>
+              {entry.assigneeLabel ? (
+                <span className="rounded-full border border-accent-muted/40 px-3 py-1 uppercase tracking-[0.2em]">
+                  {entry.assigneeLabel}
+                </span>
+              ) : null}
+            </div>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/packages/ui/src/components/workforce/CapacitySnapshot.tsx
+++ b/packages/ui/src/components/workforce/CapacitySnapshot.tsx
@@ -1,0 +1,62 @@
+import type { ReactElement } from "react";
+
+export interface WorkforceCapacityEntryView {
+  readonly role: string;
+  readonly headcount: number;
+  readonly queuedTasks: number;
+  readonly coverageStatus: "ok" | "warn" | "critical";
+  readonly coverageHint: string;
+}
+
+export interface WorkforceCapacitySnapshotProps {
+  readonly entries: readonly WorkforceCapacityEntryView[];
+}
+
+function resolveStatusClass(status: WorkforceCapacityEntryView["coverageStatus"]): string {
+  switch (status) {
+    case "ok":
+      return "border-accent-primary/40 text-accent-primary";
+    case "warn":
+      return "border-accent-warning/60 text-accent-warning";
+    case "critical":
+      return "border-destructive/60 text-destructive";
+    default:
+      return "border-border-base text-text-primary";
+  }
+}
+
+export function WorkforceCapacitySnapshot({ entries }: WorkforceCapacitySnapshotProps): ReactElement {
+  return (
+    <section aria-labelledby="hr-capacity-heading" className="space-y-4">
+      <header className="flex flex-col gap-2">
+        <p className="text-sm uppercase tracking-[0.25em] text-accent-muted">Capacity</p>
+        <h2 className="text-2xl font-semibold text-text-primary" id="hr-capacity-heading">
+          Capacity coverage snapshot
+        </h2>
+        <p className="text-sm text-text-muted">
+          Headcount compared to open tasks for each role. Coverage hints surface pressure points.
+        </p>
+      </header>
+
+      <ul className="grid gap-3 md:grid-cols-2" aria-label="HR capacity snapshot">
+        {entries.map((entry) => (
+          <li key={entry.role} className="rounded-xl border border-border-base bg-canvas-base/60 p-5">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="text-lg font-semibold text-text-primary">{entry.role}</p>
+                <p className="text-sm text-text-muted">Headcount {entry.headcount}</p>
+                <p className="text-sm text-text-muted">Queued tasks {entry.queuedTasks}</p>
+              </div>
+              <span
+                className={`rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] ${resolveStatusClass(entry.coverageStatus)}`}
+              >
+                {entry.coverageStatus.toUpperCase()}
+              </span>
+            </div>
+            <p className="mt-3 text-sm text-text-muted">{entry.coverageHint}</p>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/packages/ui/src/components/workforce/Directory.tsx
+++ b/packages/ui/src/components/workforce/Directory.tsx
@@ -1,0 +1,188 @@
+import type { ReactElement } from "react";
+import { cn } from "@ui/lib/cn";
+
+export interface WorkforceFilterOption {
+  readonly value: string | null;
+  readonly label: string;
+}
+
+export interface WorkforceDirectoryFiltersProps {
+  readonly structures: readonly WorkforceFilterOption[];
+  readonly rooms: readonly WorkforceFilterOption[];
+  readonly zones: readonly WorkforceFilterOption[];
+  readonly roles: readonly WorkforceFilterOption[];
+  readonly selectedStructureId: string | null;
+  readonly selectedRoomId: string | null;
+  readonly selectedZoneId: string | null;
+  readonly selectedRole: string | null;
+  readonly onStructureChange: (value: string | null) => void;
+  readonly onRoomChange: (value: string | null) => void;
+  readonly onZoneChange: (value: string | null) => void;
+  readonly onRoleChange: (value: string | null) => void;
+}
+
+export interface WorkforceDirectoryEntryView {
+  readonly id: string;
+  readonly name: string;
+  readonly role: string;
+  readonly hourlyCostLabel: string;
+  readonly moralePercent: number;
+  readonly fatiguePercent: number;
+  readonly skills: readonly string[];
+  readonly assignmentLabel: string;
+  readonly locationPath: string;
+  readonly overtimeMinutes: number;
+  readonly recentActivity: string | null;
+}
+
+export interface WorkforceDirectoryProps {
+  readonly filters: WorkforceDirectoryFiltersProps;
+  readonly entries: readonly WorkforceDirectoryEntryView[];
+}
+
+function renderFilterOption(option: WorkforceFilterOption): ReactElement {
+  return (
+    <option key={option.value ?? "all"} value={option.value ?? ""}>
+      {option.label}
+    </option>
+  );
+}
+
+function resolveOvertimeLabel(minutes: number): string {
+  if (minutes <= 0) {
+    return "No overtime";
+  }
+
+  return `${minutes.toString()} min overtime`;
+}
+
+export function WorkforceDirectory({ filters, entries }: WorkforceDirectoryProps): ReactElement {
+  return (
+    <section aria-labelledby="hr-directory-heading" className="space-y-4">
+      <header className="flex flex-col gap-2">
+        <p className="text-sm uppercase tracking-[0.25em] text-accent-muted">HR</p>
+        <h2 className="text-2xl font-semibold text-text-primary" id="hr-directory-heading">
+          Workforce directory
+        </h2>
+        <p className="text-sm text-text-muted">
+          Review employee assignments, morale, and recent activity. Use the filters to narrow by structure, room,
+          zone, or role.
+        </p>
+      </header>
+
+      <div className="grid gap-3 lg:grid-cols-[repeat(4,minmax(0,1fr))]">
+        <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-[0.2em] text-accent-muted">
+          Structure
+          <select
+            aria-label="Filter by structure"
+            className="rounded-lg border border-border-base bg-canvas-base px-3 py-2 text-sm text-text-primary"
+            value={filters.selectedStructureId ?? ""}
+            onChange={(event) => {
+              filters.onStructureChange(event.currentTarget.value || null);
+            }}
+          >
+            {filters.structures.map(renderFilterOption)}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-[0.2em] text-accent-muted">
+          Room
+          <select
+            aria-label="Filter by room"
+            className="rounded-lg border border-border-base bg-canvas-base px-3 py-2 text-sm text-text-primary"
+            value={filters.selectedRoomId ?? ""}
+            onChange={(event) => {
+              filters.onRoomChange(event.currentTarget.value || null);
+            }}
+          >
+            {filters.rooms.map(renderFilterOption)}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-[0.2em] text-accent-muted">
+          Zone
+          <select
+            aria-label="Filter by zone"
+            className="rounded-lg border border-border-base bg-canvas-base px-3 py-2 text-sm text-text-primary"
+            value={filters.selectedZoneId ?? ""}
+            onChange={(event) => {
+              filters.onZoneChange(event.currentTarget.value || null);
+            }}
+          >
+            {filters.zones.map(renderFilterOption)}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-[0.2em] text-accent-muted">
+          Role
+          <select
+            aria-label="Filter by role"
+            className="rounded-lg border border-border-base bg-canvas-base px-3 py-2 text-sm text-text-primary"
+            value={filters.selectedRole ?? ""}
+            onChange={(event) => {
+              filters.onRoleChange(event.currentTarget.value || null);
+            }}
+          >
+            {filters.roles.map(renderFilterOption)}
+          </select>
+        </label>
+      </div>
+
+      <ul className="grid gap-4 lg:grid-cols-2" aria-label="Workforce directory entries">
+        {entries.map((entry) => (
+          <li
+            key={entry.id}
+            className="flex flex-col gap-4 rounded-xl border border-border-base bg-canvas-base/70 p-5"
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <p className="text-lg font-semibold text-text-primary">{entry.name}</p>
+                <p className="text-sm text-text-muted">{entry.role}</p>
+              </div>
+              <div className="text-right text-sm">
+                <p className="font-semibold text-text-primary">{entry.hourlyCostLabel}</p>
+                <p className="text-xs text-text-muted">Hourly cost</p>
+              </div>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2 text-xs text-accent-muted">
+              {entry.skills.map((skill) => (
+                <span key={skill} className="rounded-full border border-accent-muted/30 px-2 py-1 uppercase tracking-[0.2em]">
+                  {skill}
+                </span>
+              ))}
+            </div>
+
+            <div className="rounded-lg border border-border-subtle bg-canvas-raised/50 p-4">
+              <p className="text-sm font-semibold text-text-primary">{entry.assignmentLabel}</p>
+              <p className="text-xs text-text-muted">{entry.locationPath}</p>
+              <p className="mt-2 text-xs text-text-muted">
+                {entry.recentActivity ?? "No recent activity recorded."}
+              </p>
+            </div>
+
+            <div className="flex flex-wrap items-center justify-between gap-3 text-sm">
+              <div className="flex items-center gap-3">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.2em] text-accent-muted">Morale</p>
+                  <p className="font-semibold text-text-primary">{entry.moralePercent}%</p>
+                </div>
+                <div>
+                  <p className="text-xs uppercase tracking-[0.2em] text-accent-muted">Fatigue</p>
+                  <p className="font-semibold text-text-primary">{entry.fatiguePercent}%</p>
+                </div>
+              </div>
+              <span
+                className={cn(
+                  "rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em]",
+                  entry.overtimeMinutes > 0
+                    ? "border-accent-warning text-accent-warning"
+                    : "border-accent-muted text-accent-muted"
+                )}
+              >
+                {resolveOvertimeLabel(entry.overtimeMinutes)}
+              </span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/packages/ui/src/components/workforce/TaskQueues.tsx
+++ b/packages/ui/src/components/workforce/TaskQueues.tsx
@@ -1,0 +1,158 @@
+import { useId, useState, type ReactElement } from "react";
+
+export interface WorkforceAssigneeOption {
+  readonly id: string;
+  readonly label: string;
+}
+
+export interface WorkforceTaskQueueEntryAction {
+  readonly label: string;
+  readonly onClick: () => void;
+  readonly disabled?: boolean;
+}
+
+export interface WorkforceTaskQueueEntryView {
+  readonly id: string;
+  readonly typeLabel: string;
+  readonly statusLabel: string;
+  readonly scopeLabel: string;
+  readonly dueLabel: string;
+  readonly assigneeId: string | null;
+  readonly assigneeName: string | null;
+  readonly assignable: boolean;
+  readonly onAssign: (assigneeId: string | null) => void;
+  readonly actions: readonly WorkforceTaskQueueEntryAction[];
+}
+
+export interface WorkforceTaskQueueView {
+  readonly id: string;
+  readonly title: string;
+  readonly entries: readonly WorkforceTaskQueueEntryView[];
+}
+
+export interface WorkforceTaskQueuesProps {
+  readonly queues: readonly WorkforceTaskQueueView[];
+  readonly assignees: readonly WorkforceAssigneeOption[];
+}
+
+export function WorkforceTaskQueues({ queues, assignees }: WorkforceTaskQueuesProps): ReactElement {
+  return (
+    <section aria-labelledby="hr-task-queues-heading" className="space-y-4">
+      <header className="flex flex-col gap-2">
+        <p className="text-sm uppercase tracking-[0.25em] text-accent-muted">Task queues</p>
+        <h2 className="text-2xl font-semibold text-text-primary" id="hr-task-queues-heading">
+          Upcoming and in-progress tasks
+        </h2>
+        <p className="text-sm text-text-muted">
+          Read-only queues mirror zone and room surfaces. Assign team members or trigger intents when you have
+          permissions.
+        </p>
+      </header>
+
+      <div className="space-y-4">
+        {queues.map((queue) => (
+          <article
+            key={queue.id}
+            aria-label={`${queue.title} tasks`}
+            className="space-y-3 rounded-xl border border-border-base bg-canvas-base/60 p-5"
+          >
+            <header className="flex items-center justify-between">
+              <h3 className="text-lg font-semibold text-text-primary">{queue.title}</h3>
+            </header>
+            <ul className="space-y-3" aria-label={`${queue.title} tasks`}>
+              {queue.entries.map((entry) => (
+                <TaskQueueEntry
+                  key={entry.id}
+                  entry={entry}
+                  assignees={assignees}
+                />
+              ))}
+            </ul>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+interface TaskQueueEntryProps {
+  readonly entry: WorkforceTaskQueueEntryView;
+  readonly assignees: readonly WorkforceAssigneeOption[];
+}
+
+function TaskQueueEntry({ entry, assignees }: TaskQueueEntryProps): ReactElement {
+  const selectId = useId();
+  const [selectedAssigneeId, setSelectedAssigneeId] = useState<string>(entry.assigneeId ?? "");
+  const assignButtonLabel = entry.assigneeId ? "Reassign" : "Assign";
+  const hasAssignees = assignees.length > 0;
+  const canAssign = entry.assignable && hasAssignees && selectedAssigneeId.length > 0;
+
+  return (
+    <li className="space-y-3 rounded-lg border border-border-base/60 bg-canvas-raised/40 p-4">
+      <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-text-muted">
+        <span className="font-semibold uppercase tracking-[0.2em] text-accent-muted">{entry.typeLabel}</span>
+        <span>{entry.statusLabel}</span>
+      </div>
+      <div className="flex flex-col gap-1 text-sm text-text-primary">
+        <p>{entry.scopeLabel}</p>
+        <p className="text-xs text-text-muted">Due {entry.dueLabel}</p>
+        {entry.assigneeName ? (
+          <p className="text-xs text-text-muted">Assigned to {entry.assigneeName}</p>
+        ) : (
+          <p className="text-xs text-text-muted">Unassigned</p>
+        )}
+      </div>
+
+      {entry.assignable ? (
+        <div className="flex flex-col gap-2">
+          <label className="text-xs font-semibold uppercase tracking-[0.2em] text-accent-muted" htmlFor={selectId}>
+            Select assignee
+          </label>
+          <div className="flex flex-wrap items-center gap-3">
+            <select
+              id={selectId}
+              className="min-w-[12rem] flex-1 rounded-lg border border-border-base bg-canvas-base px-3 py-2 text-sm text-text-primary"
+              value={selectedAssigneeId}
+              onChange={(event) => {
+                setSelectedAssigneeId(event.currentTarget.value);
+              }}
+            >
+              <option value="">Unassigned</option>
+              {assignees.map((assignee) => (
+                <option key={assignee.id} value={assignee.id}>
+                  {assignee.label}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              className="rounded-lg border border-accent-primary/70 bg-accent-primary/20 px-3 py-2 text-sm font-semibold text-accent-primary disabled:opacity-60"
+              onClick={() => {
+                entry.onAssign(selectedAssigneeId === "" ? null : selectedAssigneeId);
+              }}
+              disabled={!canAssign}
+              aria-disabled={!canAssign}
+            >
+              {assignButtonLabel}
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      <div className="flex flex-wrap gap-2">
+        {entry.actions.map((action) => (
+          <button
+            key={action.label}
+            type="button"
+            className="rounded-lg border border-border-base/70 bg-canvas-base px-3 py-2 text-sm text-text-primary transition hover:border-accent-primary hover:text-accent-primary"
+            onClick={action.onClick}
+            disabled={action.disabled}
+            aria-disabled={action.disabled}
+          >
+            {action.label}
+          </button>
+        ))}
+      </div>
+    </li>
+  );
+}

--- a/packages/ui/src/design/tokens.ts
+++ b/packages/ui/src/design/tokens.ts
@@ -34,7 +34,7 @@ export const workspaceCopy = {
   appName: "Weed Breed",
   leftRail: {
     header: "Operations",
-    placeholder: "Navigate across company overview, structures, workforce, and strains.",
+    placeholder: "Navigate across company overview, structures, HR, and strains.",
     collapseToggle: {
       collapse: "Collapse navigation",
       expand: "Expand navigation"

--- a/packages/ui/src/lib/navigation.ts
+++ b/packages/ui/src/lib/navigation.ts
@@ -78,7 +78,7 @@ export const workspaceStructures: WorkspaceStructureNavItem[] = [
 export const workspaceTopLevelRoutes = {
   company: { label: "Company overview", path: "/dashboard" },
   structures: { label: "Structures overview", path: "/structures" },
-  hr: { label: "Workforce KPIs", path: "/workforce" },
+  hr: { label: "HR & workforce", path: "/workforce" },
   strains: { label: "Strain library", path: "/strains" }
 } as const;
 

--- a/packages/ui/src/pages/WorkforcePage.tsx
+++ b/packages/ui/src/pages/WorkforcePage.tsx
@@ -1,127 +1,863 @@
-import type { ReactElement } from "react";
-import { AlertTriangle, ClipboardList, Gauge, Users2 } from "lucide-react";
-import { WorkforceKpiCard } from "@ui/components/workforce/KpiCard";
-import { useWorkforceSnapshot } from "@ui/state/workforce";
-import type { WorkforceSnapshotOverrides } from "@ui/state/workforce";
+import { useMemo, type ReactElement } from "react";
+import { HOURS_PER_DAY } from "@engine/constants/simConstants.ts";
+import {
+  WorkforceDirectory,
+  type WorkforceDirectoryEntryView,
+  type WorkforceDirectoryFiltersProps,
+  type WorkforceFilterOption
+} from "@ui/components/workforce/Directory";
+import {
+  WorkforceActivityTimeline,
+  type WorkforceActivityEntryView
+} from "@ui/components/workforce/ActivityTimeline";
+import {
+  WorkforceTaskQueues,
+  type WorkforceTaskQueueView,
+  type WorkforceAssigneeOption,
+  type WorkforceTaskQueueEntryAction
+} from "@ui/components/workforce/TaskQueues";
+import {
+  WorkforceCapacitySnapshot,
+  type WorkforceCapacityEntryView
+} from "@ui/components/workforce/CapacitySnapshot";
+import {
+  WorkforceActionPanel,
+  type WorkforceActionTargetOption
+} from "@ui/components/workforce/ActionPanel";
+import { useHRReadModel, useStructureReadModels } from "@ui/lib/readModelHooks";
+import { formatCurrency, useShellLocale } from "@ui/lib/locale";
+import { useWorkforceFilters } from "@ui/state/workforce";
+import type {
+  HrActivityEntry,
+  HrDirectoryEntry,
+  HrTaskQueue,
+  HrTaskQueueEntry,
+  StructureReadModel,
+  WorkforceAssignment
+} from "@ui/state/readModels.types";
+import type { IntentClient, IntentSubmissionHandlers } from "@ui/transport";
 
-export interface WorkforcePageProps {
-  readonly overrides?: WorkforceSnapshotOverrides;
+interface AssignmentContext {
+  readonly structureId: string | null;
+  readonly structureName: string | null;
+  readonly roomId: string | null;
+  readonly roomName: string | null;
+  readonly zoneId: string | null;
+  readonly zoneName: string | null;
 }
 
-export function WorkforcePage({ overrides }: WorkforcePageProps = {}): ReactElement {
-  const snapshot = useWorkforceSnapshot(overrides);
-  const { headcount, roleMix, utilization, warnings } = snapshot;
+interface ZoneLocation extends AssignmentContext {
+  readonly zoneId: string;
+}
+
+interface RoomLocation extends AssignmentContext {
+  readonly roomId: string;
+}
+
+interface StructureLocation {
+  readonly structureId: string;
+  readonly structureName: string;
+}
+
+interface LocationIndex {
+  readonly structures: Map<string, StructureLocation>;
+  readonly rooms: Map<string, RoomLocation>;
+  readonly zones: Map<string, ZoneLocation>;
+  readonly devices: Map<string, AssignmentContext>;
+}
+
+const DEFAULT_DURATION_LABEL = "Duration 1h";
+
+const HR_ASSIGN_INTENT = "hr.assign" as const;
+const PEST_INSPECTION_START_INTENT = "pest.inspect.start" as const;
+const PEST_INSPECTION_COMPLETE_INTENT = "pest.inspect.complete" as const;
+const PEST_TREATMENT_START_INTENT = "pest.treat.start" as const;
+const PEST_TREATMENT_COMPLETE_INTENT = "pest.treat.complete" as const;
+const MAINTENANCE_START_INTENT = "maintenance.start" as const;
+const MAINTENANCE_COMPLETE_INTENT = "maintenance.complete" as const;
+
+export interface WorkforcePageProps {
+  readonly intentClient?: IntentClient | null;
+}
+
+function createLocationIndex(structures: readonly StructureReadModel[]): LocationIndex {
+  const structureMap = new Map<string, StructureLocation>();
+  const roomMap = new Map<string, RoomLocation>();
+  const zoneMap = new Map<string, ZoneLocation>();
+  const deviceMap = new Map<string, AssignmentContext>();
+
+  for (const structure of structures) {
+    structureMap.set(structure.id, { structureId: structure.id, structureName: structure.name });
+
+    for (const device of structure.devices) {
+      deviceMap.set(device.id, {
+        structureId: structure.id,
+        structureName: structure.name,
+        roomId: null,
+        roomName: null,
+        zoneId: null,
+        zoneName: null
+      });
+    }
+
+    for (const room of structure.rooms) {
+      roomMap.set(room.id, {
+        structureId: structure.id,
+        structureName: structure.name,
+        roomId: room.id,
+        roomName: room.name,
+        zoneId: null,
+        zoneName: null
+      });
+
+      for (const device of room.devices) {
+        deviceMap.set(device.id, {
+          structureId: structure.id,
+          structureName: structure.name,
+          roomId: room.id,
+          roomName: room.name,
+          zoneId: null,
+          zoneName: null
+        });
+      }
+
+      for (const zone of room.zones) {
+        zoneMap.set(zone.id, {
+          structureId: structure.id,
+          structureName: structure.name,
+          roomId: room.id,
+          roomName: room.name,
+          zoneId: zone.id,
+          zoneName: zone.name
+        });
+      }
+    }
+  }
+
+  return { structures: structureMap, rooms: roomMap, zones: zoneMap, devices: deviceMap } satisfies LocationIndex;
+}
+
+function resolveAssignmentContext(
+  assignment: WorkforceAssignment,
+  index: LocationIndex
+): AssignmentContext {
+  if (assignment.assignedScope === "structure") {
+    const structure = index.structures.get(assignment.targetId);
+    if (structure) {
+      return {
+        structureId: structure.structureId,
+        structureName: structure.structureName,
+        roomId: null,
+        roomName: null,
+        zoneId: null,
+        zoneName: null
+      } satisfies AssignmentContext;
+    }
+
+    return {
+      structureId: assignment.targetId,
+      structureName: assignment.targetId,
+      roomId: null,
+      roomName: null,
+      zoneId: null,
+      zoneName: null
+    } satisfies AssignmentContext;
+  }
+
+  if (assignment.assignedScope === "room") {
+    const room = index.rooms.get(assignment.targetId);
+    if (room) {
+      return {
+        structureId: room.structureId,
+        structureName: room.structureName,
+        roomId: room.roomId,
+        roomName: room.roomName,
+        zoneId: null,
+        zoneName: null
+      } satisfies AssignmentContext;
+    }
+
+    return {
+      structureId: null,
+      structureName: null,
+      roomId: assignment.targetId,
+      roomName: assignment.targetId,
+      zoneId: null,
+      zoneName: null
+    } satisfies AssignmentContext;
+  }
+
+  const zone = index.zones.get(assignment.targetId);
+  if (zone) {
+    return zone;
+  }
+
+  return {
+    structureId: null,
+    structureName: null,
+    roomId: null,
+    roomName: null,
+    zoneId: assignment.targetId,
+    zoneName: assignment.targetId
+  } satisfies AssignmentContext;
+}
+
+function formatLocationPath(context: AssignmentContext, fallback: string): string {
+  const segments: string[] = [];
+  if (context.structureName) {
+    segments.push(context.structureName);
+  }
+  if (context.roomName) {
+    segments.push(context.roomName);
+  }
+  if (context.zoneName) {
+    segments.push(context.zoneName);
+  }
+
+  if (segments.length === 0) {
+    return fallback;
+  }
+
+  return segments.join(" › ");
+}
+
+function formatAssignmentLabel(scope: WorkforceAssignment["assignedScope"]): string {
+  switch (scope) {
+    case "structure":
+      return "Structure assignment";
+    case "room":
+      return "Room assignment";
+    case "zone":
+    default:
+      return "Zone assignment";
+  }
+}
+
+function formatTickLabel(tick: number): string {
+  const day = Math.floor(tick / HOURS_PER_DAY) + 1;
+  const hour = tick % HOURS_PER_DAY;
+  return `Day ${day.toString()} · Hour ${hour.toString()}`;
+}
+
+function matchesLocationFilters(
+  context: AssignmentContext,
+  selection: ReturnType<typeof useWorkforceFilters>["selection"]
+): boolean {
+  if (selection.structureId && context.structureId !== selection.structureId) {
+    return false;
+  }
+
+  if (selection.roomId && context.roomId !== selection.roomId) {
+    return false;
+  }
+
+  if (selection.zoneId && context.zoneId !== selection.zoneId) {
+    return false;
+  }
+
+  return true;
+}
+
+function buildRoleOptions(directory: readonly HrDirectoryEntry[]): WorkforceFilterOption[] {
+  const roles = Array.from(new Set(directory.map((entry) => entry.role))).sort((left, right) => left.localeCompare(right));
+  return [{ value: null, label: "All roles" }, ...roles.map((role) => ({ value: role, label: role }))];
+}
+
+function buildLatestActivityByEmployee(entries: readonly HrActivityEntry[]): Map<string, HrActivityEntry> {
+  const activityMap = new Map<string, HrActivityEntry>();
+  for (const entry of entries) {
+    if (!entry.assigneeId) {
+      continue;
+    }
+    activityMap.set(entry.assigneeId, entry);
+  }
+  return activityMap;
+}
+
+function resolveTaskContext(
+  entry: HrTaskQueueEntry,
+  index: LocationIndex
+): AssignmentContext {
+  if (entry.targetScope === "zone") {
+    const zone = index.zones.get(entry.targetId);
+    if (zone) {
+      return zone;
+    }
+    return {
+      structureId: null,
+      structureName: null,
+      roomId: null,
+      roomName: null,
+      zoneId: entry.targetId,
+      zoneName: entry.targetId
+    } satisfies AssignmentContext;
+  }
+
+  if (entry.targetScope === "room") {
+    const room = index.rooms.get(entry.targetId);
+    if (room) {
+      return room;
+    }
+    return {
+      structureId: null,
+      structureName: null,
+      roomId: entry.targetId,
+      roomName: entry.targetId,
+      zoneId: null,
+      zoneName: null
+    } satisfies AssignmentContext;
+  }
+
+  const structure = index.structures.get(entry.targetId);
+  if (structure) {
+    return {
+      structureId: structure.structureId,
+      structureName: structure.structureName,
+      roomId: null,
+      roomName: null,
+      zoneId: null,
+      zoneName: null
+    } satisfies AssignmentContext;
+  }
+
+  const device = index.devices.get(entry.targetId);
+  if (device) {
+    return device;
+  }
+
+  return {
+    structureId: null,
+    structureName: null,
+    roomId: null,
+    roomName: null,
+    zoneId: null,
+    zoneName: null
+  } satisfies AssignmentContext;
+}
+
+function resolveScopeLabel(entry: HrTaskQueueEntry, context: AssignmentContext): string {
+  const scope = entry.targetScope;
+  if (scope === "zone" && context.zoneName) {
+    return `Zone · ${context.zoneName}`;
+  }
+  if (scope === "room" && context.roomName) {
+    return `Room · ${context.roomName}`;
+  }
+  if (scope === "structure" && context.structureName) {
+    return `Structure · ${context.structureName}`;
+  }
+  return `${scope.charAt(0).toUpperCase()}${scope.slice(1)} · ${entry.targetId}`;
+}
+
+function buildAssigneeOptions(directory: readonly HrDirectoryEntry[]): WorkforceAssigneeOption[] {
+  return directory.map((entry) => ({
+    id: entry.id,
+    label: `${entry.name} — ${entry.role}`
+  }));
+}
+
+function buildAssignmentTargets(structures: readonly StructureReadModel[]): WorkforceActionTargetOption[] {
+  const targets: WorkforceActionTargetOption[] = [];
+
+  for (const structure of structures) {
+    targets.push({ id: structure.id, label: `Structure · ${structure.name}` });
+
+    for (const room of structure.rooms) {
+      targets.push({ id: room.id, label: `${structure.name} › ${room.name}` });
+      for (const zone of room.zones) {
+        targets.push({ id: zone.id, label: `${structure.name} › ${room.name} › ${zone.name}` });
+      }
+    }
+  }
+
+  return targets;
+}
+
+function buildZoneTargets(index: LocationIndex): WorkforceActionTargetOption[] {
+  return Array.from(index.zones.values(), (zone) => ({
+    id: zone.zoneId,
+    label: formatLocationPath(zone, zone.zoneName ?? zone.zoneId)
+  })).sort((left, right) => left.label.localeCompare(right.label));
+}
+
+function buildMaintenanceTargets(index: LocationIndex, taskQueues: readonly HrTaskQueue[]): WorkforceActionTargetOption[] {
+  const targets = new Map<string, string>();
+  for (const queue of taskQueues) {
+    for (const entry of queue.entries) {
+      if (entry.type !== "maintenance") {
+        continue;
+      }
+      const context = resolveTaskContext(entry, index);
+      const label = formatLocationPath(context, entry.targetId);
+      targets.set(entry.targetId, label);
+    }
+  }
+
+  return Array.from(targets.entries(), ([id, label]) => ({ id, label })).sort((left, right) =>
+    left.label.localeCompare(right.label)
+  );
+}
+
+export function WorkforcePage({ intentClient = null }: WorkforcePageProps = {}): ReactElement {
+  const hr = useHRReadModel();
+  const structures = useStructureReadModels();
+  const locale = useShellLocale();
+  const { selection, setStructure, setRoom, setZone, setRole } = useWorkforceFilters();
+  const locationIndex = useMemo(() => createLocationIndex(structures), [structures]);
+  const latestActivityByEmployee = useMemo(
+    () => buildLatestActivityByEmployee(hr.activityTimeline),
+    [hr.activityTimeline]
+  );
+  const directoryMap = useMemo(() => new Map(hr.directory.map((entry) => [entry.id, entry])), [hr.directory]);
+
+  const roleOptions = useMemo(() => buildRoleOptions(hr.directory), [hr.directory]);
+  const structureOptions = useMemo<WorkforceFilterOption[]>(
+    () => [{ value: null, label: "All structures" }, ...structures.map((structure) => ({ value: structure.id, label: structure.name }))],
+    [structures]
+  );
+
+  const rooms = useMemo(() => {
+    if (selection.structureId) {
+      return structures.find((structure) => structure.id === selection.structureId)?.rooms ?? [];
+    }
+    return structures.flatMap((structure) => structure.rooms);
+  }, [structures, selection.structureId]);
+
+  const roomOptions = useMemo<WorkforceFilterOption[]>(() => {
+    const options: WorkforceFilterOption[] = [{ value: null, label: "All rooms" }];
+    for (const room of rooms) {
+      const parentStructure = structures.find((structure) => structure.rooms.some((candidate) => candidate.id === room.id));
+      const label = parentStructure && !selection.structureId ? `${parentStructure.name} — ${room.name}` : room.name;
+      options.push({ value: room.id, label });
+    }
+    return options;
+  }, [rooms, structures, selection.structureId]);
+
+  const zones = useMemo(() => {
+    if (selection.roomId) {
+      return rooms.find((room) => room.id === selection.roomId)?.zones ?? [];
+    }
+    return rooms.flatMap((room) => room.zones);
+  }, [rooms, selection.roomId]);
+
+  const zoneOptions = useMemo<WorkforceFilterOption[]>(() => {
+    const options: WorkforceFilterOption[] = [{ value: null, label: "All zones" }];
+    for (const zone of zones) {
+      const parentRoom = rooms.find((room) => room.zones.some((candidate) => candidate.id === zone.id)) ?? null;
+      const parentStructure = structures.find((structure) => structure.rooms.some((candidate) => candidate.id === parentRoom?.id)) ?? null;
+      const labelParts: string[] = [];
+      if (parentStructure && !selection.structureId) {
+        labelParts.push(parentStructure.name);
+      }
+      if (parentRoom && !selection.roomId) {
+        labelParts.push(parentRoom.name);
+      }
+      labelParts.push(zone.name);
+      options.push({ value: zone.id, label: labelParts.join(" — ") });
+    }
+    return options;
+  }, [zones, rooms, structures, selection.structureId, selection.roomId]);
+
+  const directoryFilters: WorkforceDirectoryFiltersProps = {
+    structures: structureOptions,
+    rooms: roomOptions,
+    zones: zoneOptions,
+    roles: roleOptions,
+    selectedStructureId: selection.structureId,
+    selectedRoomId: selection.roomId,
+    selectedZoneId: selection.zoneId,
+    selectedRole: selection.role,
+    onStructureChange: setStructure,
+    onRoomChange: setRoom,
+    onZoneChange: setZone,
+    onRoleChange: setRole
+  } satisfies WorkforceDirectoryFiltersProps;
+
+  const directoryEntries = useMemo<WorkforceDirectoryEntryView[]>(() => {
+    return hr.directory
+      .map((entry) => {
+        const context = resolveAssignmentContext(entry.assignment, locationIndex);
+        return {
+          entry,
+          context
+        };
+      })
+      .filter(({ entry, context }) => {
+        if (!matchesLocationFilters(context, selection)) {
+          return false;
+        }
+        if (selection.role && entry.role !== selection.role) {
+          return false;
+        }
+        return true;
+      })
+      .map(({ entry, context }) => {
+        const recentActivity = latestActivityByEmployee.get(entry.id);
+        return {
+          id: entry.id,
+          name: entry.name,
+          role: entry.role,
+          hourlyCostLabel: `${formatCurrency(entry.hourlyCost, locale)}/h`,
+          moralePercent: entry.moralePercent,
+          fatiguePercent: entry.fatiguePercent,
+          skills: entry.skills,
+          assignmentLabel: formatAssignmentLabel(entry.assignment.assignedScope),
+          locationPath: formatLocationPath(context, entry.assignment.targetId),
+          overtimeMinutes: entry.overtimeMinutes,
+          recentActivity: recentActivity ? recentActivity.description : null
+        } satisfies WorkforceDirectoryEntryView;
+      });
+  }, [
+    hr.directory,
+    latestActivityByEmployee,
+    selection,
+    locale,
+    locationIndex
+  ]);
+
+  const activityEntries = useMemo<WorkforceActivityEntryView[]>(() => {
+    return hr.activityTimeline
+      .map((entry) => {
+        const assignee = entry.assigneeId ? directoryMap.get(entry.assigneeId) ?? null : null;
+        const context = assignee
+          ? resolveAssignmentContext(assignee.assignment, locationIndex)
+          : ({
+              structureId: null,
+              structureName: null,
+              roomId: null,
+              roomName: null,
+              zoneId: null,
+              zoneName: null
+            } satisfies AssignmentContext);
+        return { entry, context, assignee };
+      })
+      .filter(({ assignee, context }) => {
+        if (!matchesLocationFilters(context, selection)) {
+          return false;
+        }
+        if (selection.role) {
+          if (!assignee) {
+            return false;
+          }
+          return assignee.role === selection.role;
+        }
+        return true;
+      })
+      .map(({ entry, context, assignee }) => {
+        const scopeLabel = (() => {
+          if (entry.scope === "zone" && context.zoneName) {
+            return `Zone · ${context.zoneName}`;
+          }
+          if (entry.scope === "room" && context.roomName) {
+            return `Room · ${context.roomName}`;
+          }
+          if (entry.scope === "structure" && context.structureName) {
+            return `Structure · ${context.structureName}`;
+          }
+          return `${entry.scope.charAt(0).toUpperCase()}${entry.scope.slice(1)}`;
+        })();
+
+        const assigneeLabel = assignee ? `Assignee · ${assignee.name}` : null;
+
+        return {
+          id: entry.id,
+          timestampLabel: formatTickLabel(entry.timestamp),
+          title: entry.title,
+          description: entry.description,
+          scopeLabel,
+          assigneeLabel,
+          durationLabel: DEFAULT_DURATION_LABEL
+        } satisfies WorkforceActivityEntryView;
+      });
+  }, [
+    hr.activityTimeline,
+    directoryMap,
+    selection,
+    locationIndex
+  ]);
+
+  const assigneeOptions = useMemo(() => buildAssigneeOptions(hr.directory), [hr.directory]);
+
+  const acknowledgementHandlers: IntentSubmissionHandlers = useMemo(
+    () => ({ onResult: () => undefined }),
+    []
+  );
+
+  const queueViews = useMemo<WorkforceTaskQueueView[]>(() => {
+    return hr.taskQueues.map((queue) => ({
+      id: queue.id,
+      title: queue.title,
+      entries: queue.entries
+        .map((entry) => {
+          const context = resolveTaskContext(entry, locationIndex);
+          const assignee = entry.assigneeId ? directoryMap.get(entry.assigneeId) ?? null : null;
+          return { entry, context, assignee };
+        })
+        .filter(({ assignee, context }) => {
+          if (!matchesLocationFilters(context, selection)) {
+            return false;
+          }
+          if (selection.role) {
+            if (!assignee) {
+              return false;
+            }
+            return assignee.role === selection.role;
+          }
+          return true;
+        })
+        .map(({ entry, context, assignee }) => {
+          const actions: WorkforceTaskQueueEntryAction[] = [];
+          if (entry.type === "inspection") {
+            actions.push({
+              label: "Acknowledge inspection",
+              onClick: () => {
+                if (!intentClient) {
+                  return;
+                }
+
+                void intentClient
+                  .submit(
+                    { type: PEST_INSPECTION_START_INTENT, zoneId: entry.targetId },
+                    acknowledgementHandlers
+                  )
+                  .catch(() => undefined);
+              },
+              disabled: !intentClient
+            });
+            actions.push({
+              label: "Complete inspection",
+              onClick: () => {
+                if (!intentClient) {
+                  return;
+                }
+
+                void intentClient
+                  .submit(
+                    { type: PEST_INSPECTION_COMPLETE_INTENT, zoneId: entry.targetId },
+                    acknowledgementHandlers
+                  )
+                  .catch(() => undefined);
+              },
+              disabled: !intentClient
+            });
+          } else if (entry.type === "treatment") {
+            actions.push({
+              label: "Launch treatment",
+              onClick: () => {
+                if (!intentClient) {
+                  return;
+                }
+
+                void intentClient
+                  .submit(
+                    { type: PEST_TREATMENT_START_INTENT, zoneId: entry.targetId },
+                    acknowledgementHandlers
+                  )
+                  .catch(() => undefined);
+              },
+              disabled: !intentClient
+            });
+            actions.push({
+              label: "Complete treatment",
+              onClick: () => {
+                if (!intentClient) {
+                  return;
+                }
+
+                void intentClient
+                  .submit(
+                    { type: PEST_TREATMENT_COMPLETE_INTENT, zoneId: entry.targetId },
+                    acknowledgementHandlers
+                  )
+                  .catch(() => undefined);
+              },
+              disabled: !intentClient
+            });
+          } else if (entry.type === "maintenance") {
+            actions.push({
+              label: "Start maintenance",
+              onClick: () => {
+                if (!intentClient) {
+                  return;
+                }
+
+                void intentClient
+                  .submit(
+                    { type: MAINTENANCE_START_INTENT, deviceId: entry.targetId },
+                    acknowledgementHandlers
+                  )
+                  .catch(() => undefined);
+              },
+              disabled: !intentClient
+            });
+            actions.push({
+              label: "Complete maintenance",
+              onClick: () => {
+                if (!intentClient) {
+                  return;
+                }
+
+                void intentClient
+                  .submit(
+                    { type: MAINTENANCE_COMPLETE_INTENT, deviceId: entry.targetId },
+                    acknowledgementHandlers
+                  )
+                  .catch(() => undefined);
+              },
+              disabled: !intentClient
+            });
+          }
+
+          return {
+            id: entry.id,
+            typeLabel: `${entry.type.charAt(0).toUpperCase()}${entry.type.slice(1)}`,
+            statusLabel: `Status: ${entry.status.replace(/-/g, " ")}`,
+            scopeLabel: resolveScopeLabel(entry, context),
+            dueLabel: formatTickLabel(entry.dueTick),
+            assigneeId: entry.assigneeId,
+            assigneeName: assignee ? assignee.name : null,
+            assignable: true,
+            onAssign: (assigneeId) => {
+              if (!assigneeId) {
+                return;
+              }
+              if (!intentClient) {
+                return;
+              }
+
+              void intentClient
+                .submit(
+                  { type: HR_ASSIGN_INTENT, employeeId: assigneeId, target: entry.targetId },
+                  acknowledgementHandlers
+                )
+                .catch(() => undefined);
+            },
+            actions
+          };
+        })
+    } satisfies WorkforceTaskQueueView));
+  }, [
+    hr.taskQueues,
+    selection,
+    locationIndex,
+    directoryMap,
+    intentClient,
+    acknowledgementHandlers
+  ]);
+
+  const capacityEntries = useMemo<WorkforceCapacityEntryView[]>(() => {
+    return hr.capacitySnapshot.map((entry) => {
+      const coverageDelta = entry.headcount - entry.queuedTasks;
+      const coverageHint = (() => {
+        if (coverageDelta > 0) {
+          return `Surplus capacity: ${coverageDelta.toString()} team member(s) available.`;
+        }
+        if (coverageDelta === 0) {
+          return "Balanced coverage across open tasks.";
+        }
+        return `Understaffed by ${Math.abs(coverageDelta).toString()} team member(s).`;
+      })();
+      const coverageStatus: WorkforceCapacityEntryView["coverageStatus"] =
+        entry.coverageStatus === "block" ? "critical" : entry.coverageStatus;
+
+      return {
+        role: entry.role,
+        headcount: entry.headcount,
+        queuedTasks: entry.queuedTasks,
+        coverageStatus,
+        coverageHint
+      } satisfies WorkforceCapacityEntryView;
+    });
+  }, [hr.capacitySnapshot]);
+
+  const assignmentTargets = useMemo(() => buildAssignmentTargets(structures), [structures]);
+  const zoneTargets = useMemo(() => buildZoneTargets(locationIndex), [locationIndex]);
+  const maintenanceTargets = useMemo(
+    () => buildMaintenanceTargets(locationIndex, hr.taskQueues),
+    [locationIndex, hr.taskQueues]
+  );
 
   return (
-    <section aria-label="Workforce KPIs" className="flex flex-1 flex-col gap-6">
-      <header className="space-y-2">
-        <p className="text-sm uppercase tracking-[0.25em] text-accent-muted">Workforce</p>
-        <div className="flex items-center gap-3">
-          <Users2 aria-hidden="true" className="size-6 text-accent-primary" />
-          <h2 className="text-3xl font-semibold text-text-primary">Labour KPI overview</h2>
-        </div>
-        <p className="text-sm text-text-muted">
-          Placeholder labour analytics surface summarising headcount coverage, role distribution, utilisation, and operations
-          warnings until read-model hydration lands.
-        </p>
-      </header>
-
-      <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
-        <div className="grid gap-4 md:grid-cols-2">
-          <WorkforceKpiCard
-            description="Snapshot of active staffing across cultivation, post-harvest, and facilities teams."
-            icon={Users2}
-            title="Headcount overview"
-          >
-            <dl className="space-y-3">
-              <div>
-                <dt className="text-xs uppercase tracking-[0.2em] text-accent-muted">Total team members</dt>
-                <dd className="text-base font-semibold">{headcount.totalTeamMembers}</dd>
-              </div>
-              <div className="grid grid-cols-2 gap-3 text-sm">
-                <div>
-                  <dt className="text-xs uppercase tracking-[0.2em] text-accent-muted">Active</dt>
-                  <dd className="font-medium text-text-primary">{headcount.activeTeamMembers}</dd>
-                </div>
-                <div>
-                  <dt className="text-xs uppercase tracking-[0.2em] text-accent-muted">Unavailable</dt>
-                  <dd className="font-medium text-text-primary">{headcount.unavailableTeamMembers}</dd>
-                </div>
-                <div>
-                  <dt className="text-xs uppercase tracking-[0.2em] text-accent-muted">Open roles</dt>
-                  <dd className="font-medium text-text-primary">{headcount.openRoles}</dd>
-                </div>
-              </div>
-            </dl>
-          </WorkforceKpiCard>
-
-          <WorkforceKpiCard
-            description="Role distribution expressed as percentage of total workforce." 
-            icon={ClipboardList}
-            title="Role mix"
-          >
-            <ul className="space-y-2">
-              {roleMix.map((entry) => (
-                <li key={entry.id} className="flex items-center justify-between gap-3">
-                  <span className="text-text-primary">{entry.roleName}</span>
-                  <span className="text-sm text-text-muted">{entry.headcount} · {entry.percentOfTeam}%</span>
-                </li>
-              ))}
-            </ul>
-          </WorkforceKpiCard>
-
-          <WorkforceKpiCard
-            description="Utilisation compares assigned labour hours against SEC §4.2 pipeline demand."
-            icon={Gauge}
-            title="Utilisation"
-          >
-            <dl className="space-y-3">
-              <div>
-                <dt className="text-xs uppercase tracking-[0.2em] text-accent-muted">Average utilisation</dt>
-                <dd className="text-base font-semibold">{utilization.averageUtilizationPercent}%</dd>
-              </div>
-              <div>
-                <dt className="text-xs uppercase tracking-[0.2em] text-accent-muted">Target</dt>
-                <dd className="text-base font-semibold">{utilization.targetUtilizationPercent}%</dd>
-              </div>
-              <div className="space-y-2">
-                <dt className="text-xs uppercase tracking-[0.2em] text-accent-muted">Focus areas</dt>
-                <ul className="list-disc space-y-1 pl-4 text-sm text-text-muted">
-                  {utilization.focusAreas.map((focusArea) => (
-                    <li key={focusArea}>{focusArea}</li>
-                  ))}
-                </ul>
-              </div>
-              <p className="text-xs text-text-muted">{utilization.notes}</p>
-            </dl>
-          </WorkforceKpiCard>
-        </div>
-
-        <section aria-labelledby="workforce-warnings" className="space-y-4 rounded-xl border border-border-base bg-canvas-subtle/60 p-6">
-          <div className="flex items-center gap-3">
-            <AlertTriangle aria-hidden="true" className="size-5 text-accent-warning" />
-            <h3 className="text-lg font-semibold text-text-primary" id="workforce-warnings">
-              Active warnings
-            </h3>
-          </div>
-          {warnings.length > 0 ? (
-            <ul className="space-y-3" aria-label="Workforce warnings">
-              {warnings.map((warning) => (
-                <li key={warning.id} className="rounded-lg border border-border-subtle bg-canvas-base/70 p-4">
-                  <p className="text-sm font-semibold text-text-primary">
-                    [{warning.severity.toUpperCase()}] {warning.message}
-                  </p>
-                  <p className="mt-1 text-sm text-text-muted">{warning.suggestedAction}</p>
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <p className="text-sm text-text-muted">
-              All workforce systems nominal. No warnings registered for the current simulation hour.
-            </p>
-          )}
-        </section>
+    <section aria-label="HR surface" className="flex flex-1 flex-col gap-8">
+      <WorkforceDirectory filters={directoryFilters} entries={directoryEntries} />
+      <WorkforceActivityTimeline entries={activityEntries} />
+      <div className="grid gap-6 xl:grid-cols-[2fr_1fr]">
+        <WorkforceTaskQueues queues={queueViews} assignees={assigneeOptions} />
+        <WorkforceCapacitySnapshot entries={capacityEntries} />
       </div>
+      <WorkforceActionPanel
+        employees={assigneeOptions}
+        assignmentTargets={assignmentTargets}
+        zoneTargets={zoneTargets}
+        maintenanceTargets={maintenanceTargets}
+        intentsEnabled={Boolean(intentClient)}
+        onAssign={(employeeId, targetId) => {
+          if (!employeeId || !targetId) {
+            return;
+          }
+          if (!intentClient) {
+            return;
+          }
+
+          void intentClient
+            .submit({ type: HR_ASSIGN_INTENT, employeeId, target: targetId }, acknowledgementHandlers)
+            .catch(() => undefined);
+        }}
+        onInspectionStart={(zoneId) => {
+          if (!intentClient) {
+            return;
+          }
+
+          void intentClient
+            .submit({ type: PEST_INSPECTION_START_INTENT, zoneId }, acknowledgementHandlers)
+            .catch(() => undefined);
+        }}
+        onInspectionComplete={(zoneId) => {
+          if (!intentClient) {
+            return;
+          }
+
+          void intentClient
+            .submit({ type: PEST_INSPECTION_COMPLETE_INTENT, zoneId }, acknowledgementHandlers)
+            .catch(() => undefined);
+        }}
+        onTreatmentStart={(zoneId) => {
+          if (!intentClient) {
+            return;
+          }
+
+          void intentClient
+            .submit({ type: PEST_TREATMENT_START_INTENT, zoneId }, acknowledgementHandlers)
+            .catch(() => undefined);
+        }}
+        onTreatmentComplete={(zoneId) => {
+          if (!intentClient) {
+            return;
+          }
+
+          void intentClient
+            .submit({ type: PEST_TREATMENT_COMPLETE_INTENT, zoneId }, acknowledgementHandlers)
+            .catch(() => undefined);
+        }}
+        onMaintenanceStart={(targetId) => {
+          if (!intentClient) {
+            return;
+          }
+
+          void intentClient
+            .submit({ type: MAINTENANCE_START_INTENT, deviceId: targetId }, acknowledgementHandlers)
+            .catch(() => undefined);
+        }}
+        onMaintenanceComplete={(targetId) => {
+          if (!intentClient) {
+            return;
+          }
+
+          void intentClient
+            .submit({ type: MAINTENANCE_COMPLETE_INTENT, deviceId: targetId }, acknowledgementHandlers)
+            .catch(() => undefined);
+        }}
+      />
     </section>
   );
 }

--- a/packages/ui/src/pages/__tests__/WorkforcePage.test.tsx
+++ b/packages/ui/src/pages/__tests__/WorkforcePage.test.tsx
@@ -1,70 +1,165 @@
 import { render, screen, within } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { WorkforcePage } from "@ui/pages/WorkforcePage";
+import { resetWorkforceFilters } from "@ui/state/workforce";
+import type { IntentClient, IntentSubmissionHandlers } from "@ui/transport";
 
-const MAIN_HEADING_LEVEL = 2;
-const CARD_HEADING_LEVEL = 3;
-const DEFAULT_WARNING_COUNT = 2;
+interface IntentClientStub {
+  readonly client: IntentClient;
+  readonly submit: ReturnType<typeof vi.fn>;
+}
+
+function createIntentClientStub(): IntentClientStub {
+  const submit = vi.fn(
+    (_intent: Parameters<IntentClient["submit"]>[0], handlers: IntentSubmissionHandlers) => {
+      const result = { ok: true, ack: { ok: true } } as const;
+      handlers.onResult(result);
+      return Promise.resolve(result);
+    }
+  );
+
+  const client: IntentClient = {
+    submit,
+    disconnect: vi.fn().mockResolvedValue(undefined)
+  } satisfies IntentClient;
+
+  return { client, submit };
+}
+
+beforeEach(() => {
+  resetWorkforceFilters();
+});
+
+type UserInteractions = ReturnType<typeof userEvent.setup>;
+
+const FIRST_CALL = 1;
+const SECOND_CALL = 2;
+const THIRD_CALL = 3;
+const FOURTH_CALL = 4;
 
 describe("WorkforcePage", () => {
-  it("renders placeholder KPI content", () => {
-    render(<WorkforcePage />);
+  it("renders the HR directory with assignments and activity", () => {
+    const { client } = createIntentClientStub();
+    render(<WorkforcePage intentClient={client} />);
 
+    expect(screen.getByRole("heading", { level: 2, name: /Workforce directory/i })).toBeInTheDocument();
+
+    const directoryList = screen.getByRole("list", { name: /workforce directory entries/i });
+    const leonieCard = within(directoryList).getByText("Leonie Krause").closest("li");
+    if (!(leonieCard instanceof HTMLElement)) {
+      throw new Error("Expected directory entry to render inside a list item");
+    }
+
+    const leonieWithin = within(leonieCard);
+    expect(leonieWithin.getByText("Cultivation Lead")).toBeInTheDocument();
+    expect(leonieWithin.getByText("cultivation")).toBeInTheDocument();
+    expect(leonieWithin.getByText("ipm")).toBeInTheDocument();
+    expect(leonieWithin.getByText(/Zone assignment/i)).toBeInTheDocument();
+    expect(leonieWithin.getByText(/Green Harbor › Vegetative Bay A › Veg A-1/)).toBeInTheDocument();
+    expect(leonieWithin.getByText("€32.00/h")).toBeInTheDocument();
+    expect(leonieWithin.getByText(/Morale/i).nextElementSibling?.textContent).toContain("86");
+    expect(leonieWithin.getByText(/Fatigue/i).nextElementSibling?.textContent).toContain("35");
+    expect(leonieWithin.getByText(/45 min overtime/i)).toBeInTheDocument();
     expect(
-      screen.getByRole("heading", { level: MAIN_HEADING_LEVEL, name: /labour kpi overview/i })
+      leonieWithin.getByText(/Leonie Krause completed vegetative inspection A-1\./i)
     ).toBeInTheDocument();
-
-    const headcountHeading = screen.getByRole("heading", { level: CARD_HEADING_LEVEL, name: /headcount overview/i });
-    const headcountSection = headcountHeading.closest("section");
-    if (!(headcountSection instanceof HTMLElement)) {
-      throw new Error("Headcount KPI should render inside a section element");
-    }
-    const headcountWithin = within(headcountSection);
-    expect(headcountWithin.getByText(/^28$/)).toBeInTheDocument();
-    expect(headcountWithin.getByText(/^24$/)).toBeInTheDocument();
-    expect(headcountWithin.getByText(/^3$/)).toBeInTheDocument();
-    expect(headcountWithin.getByText(/^2$/)).toBeInTheDocument();
-
-    const roleMixHeading = screen.getByRole("heading", { level: CARD_HEADING_LEVEL, name: /role mix/i });
-    const roleMixSection = roleMixHeading.closest("section");
-    if (!(roleMixSection instanceof HTMLElement)) {
-      throw new Error("Role mix KPI should render inside a section element");
-    }
-    const roleMixWithin = within(roleMixSection);
-    expect(roleMixWithin.getByText(/Cultivation technicians/i)).toBeInTheDocument();
-    expect(roleMixWithin.getByText(/12 · 43%/i)).toBeInTheDocument();
-    expect(roleMixWithin.getByText(/Post-processing/i)).toBeInTheDocument();
-
-    const utilisationHeading = screen.getByRole("heading", { level: CARD_HEADING_LEVEL, name: /utilisation/i });
-    const utilisationSection = utilisationHeading.closest("section");
-    if (!(utilisationSection instanceof HTMLElement)) {
-      throw new Error("Utilisation KPI should render inside a section element");
-    }
-    const utilisationWithin = within(utilisationSection);
-    expect(utilisationWithin.getByText(/82%/)).toBeInTheDocument();
-    expect(utilisationWithin.getByText(/85%/)).toBeInTheDocument();
-    expect(
-      utilisationWithin.getByText(/Vegetative care shifts nearing overtime thresholds/i)
-    ).toBeInTheDocument();
-
-    const warningsHeading = screen.getByRole("heading", { level: CARD_HEADING_LEVEL, name: /active warnings/i });
-    const warningsSection = warningsHeading.closest("section");
-    if (!(warningsSection instanceof HTMLElement)) {
-      throw new Error("Warnings card should render inside a section element");
-    }
-    const warningsWithin = within(warningsSection);
-    const warningList = warningsWithin.getByRole("list", { name: /workforce warnings/i });
-    const warningItems = within(warningList).getAllByRole("listitem");
-    expect(warningItems).toHaveLength(DEFAULT_WARNING_COUNT);
-    expect(warningItems[0]).toHaveTextContent(/Vegetative care staffing running at 92%/i);
-    expect(warningItems[1]).toHaveTextContent(/Preventive maintenance window overlaps/i);
   });
 
-  it("renders fallback text when no warnings are present", () => {
-    render(<WorkforcePage overrides={{ warnings: [] }} />);
+  it("filters directory and timeline entries by zone", async () => {
+    const user: UserInteractions = userEvent.setup();
+    const { client } = createIntentClientStub();
+    render(<WorkforcePage intentClient={client} />);
 
-    expect(
-      screen.getByText(/All workforce systems nominal\. No warnings registered for the current simulation hour\./i)
-    ).toBeInTheDocument();
+    await user.selectOptions(screen.getByLabelText(/Filter by zone/i), ["zone-veg-a-1"]);
+
+    expect(screen.getByText("Leonie Krause")).toBeInTheDocument();
+    expect(screen.queryByText("Jamal Nguyen")).not.toBeInTheDocument();
+
+    const timeline = screen.getByRole("list", { name: /hr activity timeline/i });
+    expect(within(timeline).getByText(/Veg inspection/i)).toBeInTheDocument();
+    expect(within(timeline).queryByText(/Harvest lot/i)).not.toBeInTheDocument();
+  });
+
+  it("displays task queues and dispatches assignment and task intents", async () => {
+    const user: UserInteractions = userEvent.setup();
+    const { client, submit } = createIntentClientStub();
+    render(<WorkforcePage intentClient={client} />);
+
+    const inspectionsSection = screen.getByRole("article", { name: /Inspections tasks/i });
+    const inspectionWithin = within(inspectionsSection);
+
+    const assignButton = inspectionWithin.getAllByRole("button", { name: /reassign/i })[0];
+    await user.click(assignButton);
+    expect(submit).toHaveBeenNthCalledWith(
+      FIRST_CALL,
+      expect.objectContaining({ type: "hr.assign", employeeId: "employee-leonie-krause", target: "zone-veg-a-1" }),
+      expect.any(Object)
+    );
+
+    await user.click(inspectionWithin.getByRole("button", { name: /acknowledge inspection/i }));
+    expect(submit).toHaveBeenNthCalledWith(
+      SECOND_CALL,
+      expect.objectContaining({ type: "pest.inspect.start", zoneId: "zone-veg-a-1" }),
+      expect.any(Object)
+    );
+
+    await user.click(inspectionWithin.getByRole("button", { name: /complete inspection/i }));
+    expect(submit).toHaveBeenNthCalledWith(
+      THIRD_CALL,
+      expect.objectContaining({ type: "pest.inspect.complete", zoneId: "zone-veg-a-1" }),
+      expect.any(Object)
+    );
+
+    const maintenanceSection = screen.getByRole("article", { name: /Maintenance tasks/i });
+    const maintenanceWithin = within(maintenanceSection);
+    await user.click(maintenanceWithin.getByRole("button", { name: /start maintenance/i }));
+    expect(submit).toHaveBeenNthCalledWith(
+      FOURTH_CALL,
+      expect.objectContaining({ type: "maintenance.start", deviceId: "device-hvac-pro-12" }),
+      expect.any(Object)
+    );
+  });
+
+  it("renders capacity coverage hints", () => {
+    const { client } = createIntentClientStub();
+    render(<WorkforcePage intentClient={client} />);
+
+    const capacityList = screen.getByRole("list", { name: /HR capacity snapshot/i });
+    const ipmCard = within(capacityList).getByText(/IPM Specialist/i).closest("li");
+    if (!(ipmCard instanceof HTMLElement)) {
+      throw new Error("Expected capacity entry to render inside a list item");
+    }
+
+    expect(within(ipmCard).getByText(/Understaffed by 1 team member/)).toBeInTheDocument();
+  });
+
+  it("dispatches action panel intents for assignment, inspection, treatment, and maintenance", async () => {
+    const user: UserInteractions = userEvent.setup();
+    const { client, submit } = createIntentClientStub();
+    render(<WorkforcePage intentClient={client} />);
+
+    await user.selectOptions(screen.getByLabelText(/Select employee/i), ["employee-jamal-nguyen"]);
+    await user.selectOptions(screen.getByLabelText(/Select assignment target/i), ["zone-veg-a-2"]);
+    await user.click(screen.getByRole("button", { name: /Dispatch assignment/i }));
+    expect(submit).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "hr.assign", employeeId: "employee-jamal-nguyen", target: "zone-veg-a-2" }),
+      expect.any(Object)
+    );
+
+    await user.selectOptions(screen.getByLabelText(/Select zone for inspection or treatment/i), ["zone-veg-a-1"]);
+    await user.click(screen.getByRole("button", { name: /Launch treatment/i }));
+    expect(submit).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "pest.treat.start", zoneId: "zone-veg-a-1" }),
+      expect.any(Object)
+    );
+
+    const maintenanceSelect = screen.getByLabelText(/Select maintenance target/i);
+    await user.selectOptions(maintenanceSelect, ["device-hvac-pro-12"]);
+    await user.click(screen.getByRole("button", { name: /Complete maintenance/i }));
+    expect(submit).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "maintenance.complete", deviceId: "device-hvac-pro-12" }),
+      expect.any(Object)
+    );
   });
 });

--- a/packages/ui/src/routes/WorkforceRoute.tsx
+++ b/packages/ui/src/routes/WorkforceRoute.tsx
@@ -1,6 +1,25 @@
 import type { ReactElement } from "react";
 import { WorkforcePage } from "@ui/pages/WorkforcePage";
+import { createIntentClient, type IntentClient } from "@ui/transport";
+
+const runtimeBaseUrl = (() => {
+  const configured = import.meta.env.VITE_TRANSPORT_BASE_URL as string | undefined;
+
+  if (configured && configured.length > 0) {
+    return configured;
+  }
+
+  if (typeof window !== "undefined" && window.location.origin) {
+    return window.location.origin;
+  }
+
+  return undefined;
+})();
+
+const intentClient: IntentClient | null = runtimeBaseUrl
+  ? createIntentClient({ baseUrl: runtimeBaseUrl })
+  : null;
 
 export function WorkforceRoute(): ReactElement {
-  return <WorkforcePage />;
+  return <WorkforcePage intentClient={intentClient} />;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.0.0
         version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/user-event':
+        specifier: ^14.5.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/react':
         specifier: ^18.3.4
         version: 18.3.26
@@ -900,6 +903,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@ts-morph/common@0.25.0':
     resolution: {integrity: sha512-kMnZz+vGGHi4GoHnLmMhGNjm44kGtKUXGnOvrKmMwAuvNjM/PgKVGfUnL7IDvK7Jb2QQ82jq3Zmp04Gy+r3Dkg==}
@@ -3145,6 +3154,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.26
       '@types/react-dom': 18.3.7(@types/react@18.3.26)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@ts-morph/common@0.25.0':
     dependencies:


### PR DESCRIPTION
## Summary
- finish replacing the workforce page with the HR directory, task queues, capacity snapshot, and action panel wired to intent submissions
- add workforce filter state, supporting components, and navigation/tokens copy updates for the HR section
- extend tests and dependencies so the new HR surface, filters, and intents are covered deterministically

## Testing
- pnpm --filter @wb/ui lint
- pnpm -w lint *(fails: pre-existing facade/transport lint errors)*
- pnpm -w -r typecheck *(fails: pre-existing engine schema issues)*
- pnpm -w -r test
- pnpm -w -r build *(fails: pre-existing @wb/engine build errors)*

------
https://chatgpt.com/codex/tasks/task_e_68f0b27977708325bdb36ae0e86f303c