### PR TITLE
test(ui): align facility duplicate previews

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,11 @@
   PPFD/DLI rendering, schedule submission guards, grid snapping, and device
   toggle behaviour via Vitest suites in `packages/ui/src/components/controls`
   and `packages/ui/src/lib`.
+- Task 7000: Introduced facility expansion flows covering room creation,
+  zone creation, sowing, duplication, and area updates. Added deterministic
+  validation utilities with Vitest coverage for capacity checks, compatibility
+  statuses, and acquisition previews, and scaffolded reusable dialog components
+  under `packages/ui/src/components/forms` that dispatch the new intents.
 - Task 5300: Delivered the climate control card with per-metric temperature,
   humidity, CO₂, and ACH sections using the shared control scaffold, rendered
   deviation badges driven by numeric tolerances, added climate device class

--- a/packages/ui/src/components/forms/FacilityDialogs.tsx
+++ b/packages/ui/src/components/forms/FacilityDialogs.tsx
@@ -1,0 +1,778 @@
+import { useMemo, useState, type FormEvent, type ReactElement } from "react";
+import type { IntentClient, IntentSubmissionHandlers } from "@ui/transport";
+import type {
+  CompatibilityMaps,
+  ContainerPriceEntry,
+  IrrigationLinePriceEntry,
+  PriceBookCatalog,
+  RoomReadModel,
+  SeedlingPriceEntry,
+  StructureReadModel,
+  SubstratePriceEntry,
+  ZoneReadModel
+} from "@ui/state/readModels.types";
+import {
+  deriveZoneWizardResult,
+  findSeedlingPriceForStrain,
+  previewRoomDuplicate,
+  previewZoneDuplicate,
+  validateRoomAreaUpdate,
+  validateRoomCreate,
+  validateSowing,
+  validateZoneAreaUpdate,
+  type RoomAreaUpdateResult,
+  type RoomCreateIntentPayload,
+  type RoomDuplicateResult,
+  type RoomSetAreaIntentPayload,
+  type SowingResult,
+  type ZoneAreaUpdateResult,
+  type ZoneCreateIntentPayload,
+  type ZoneDuplicateResult
+} from "@ui/lib/facilityFlows";
+
+type SelectOption<T> = Readonly<{ id: string; label: string; value: T }>;
+
+function parseNumber(value: string): number | null {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+interface SubmissionState {
+  readonly isSubmitting: boolean;
+  readonly error: string | null;
+}
+
+function useSubmissionState(): [SubmissionState, (updater: SubmissionState) => void] {
+  const [state, setState] = useState<SubmissionState>({ isSubmitting: false, error: null });
+  return [state, setState];
+}
+
+async function submitIntent(
+  payload: Record<string, unknown>,
+  intentClient: IntentClient,
+  setSubmission: (state: SubmissionState) => void,
+  onSuccess?: () => void
+): Promise<void> {
+  setSubmission({ isSubmitting: true, error: null });
+  try {
+    const handlers: IntentSubmissionHandlers = {
+      onResult() {
+        // acknowledgement handled by resolved result
+      }
+    };
+    const result = await intentClient.submit(payload, handlers);
+
+    if (result.ok) {
+      setSubmission({ isSubmitting: false, error: null });
+      if (onSuccess) {
+        onSuccess();
+      }
+      return;
+    }
+
+    setSubmission({ isSubmitting: false, error: result.dictionary.description });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to submit intent.";
+    setSubmission({ isSubmitting: false, error: message });
+  }
+}
+
+interface RoomCreateDialogProps {
+  readonly structure: StructureReadModel;
+  readonly intentClient: IntentClient;
+  readonly onSubmitted?: () => void;
+}
+
+export function RoomCreateDialog({ structure, intentClient, onSubmitted }: RoomCreateDialogProps): ReactElement {
+  const [name, setName] = useState("");
+  const [purpose, setPurpose] = useState("growroom");
+  const [areaInput, setAreaInput] = useState("");
+  const [heightInput, setHeightInput] = useState("");
+  const [submission, setSubmission] = useSubmissionState();
+
+  const areaValue = parseNumber(areaInput) ?? Number.NaN;
+  const heightValue = parseNumber(heightInput);
+
+  const validation = useMemo(() =>
+    validateRoomCreate({
+      structure,
+      name,
+      purpose,
+      area_m2: areaValue,
+      height_m: heightValue
+    }),
+  [structure, name, purpose, areaValue, heightValue]);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!validation.payload) {
+      return;
+    }
+
+    void submitIntent(validation.payload, intentClient, setSubmission, onSubmitted);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="flex flex-col gap-2">
+        <label className="flex flex-col">
+          <span className="font-medium">Room name</span>
+          <input
+            value={name}
+            onChange={(event) => {
+              setName(event.target.value);
+            }}
+            className="border rounded px-2 py-1"
+          />
+        </label>
+        <label className="flex flex-col">
+          <span className="font-medium">Purpose</span>
+          <input
+            value={purpose}
+            onChange={(event) => {
+              setPurpose(event.target.value);
+            }}
+            className="border rounded px-2 py-1"
+          />
+        </label>
+        <label className="flex flex-col">
+          <span className="font-medium">Area (m²)</span>
+          <input
+            value={areaInput}
+            onChange={(event) => {
+              setAreaInput(event.target.value);
+            }}
+            className="border rounded px-2 py-1"
+          />
+        </label>
+        <label className="flex flex-col">
+          <span className="font-medium">Height (m, optional)</span>
+          <input
+            value={heightInput}
+            onChange={(event) => {
+              setHeightInput(event.target.value);
+            }}
+            className="border rounded px-2 py-1"
+          />
+        </label>
+      </div>
+
+      {validation.errors.length > 0 && (
+        <ul className="text-sm text-red-600 list-disc list-inside">
+          {validation.errors.map((error) => (
+            <li key={error}>{error}</li>
+          ))}
+        </ul>
+      )}
+
+      {submission.error && <p className="text-sm text-red-600">{submission.error}</p>}
+
+      <button type="submit" className="px-4 py-2 rounded bg-emerald-600 text-white" disabled={!validation.isValid || submission.isSubmitting}>
+        Create room
+      </button>
+    </form>
+  );
+}
+
+interface ZoneCreateWizardProps {
+  readonly room: RoomReadModel;
+  readonly compatibility: CompatibilityMaps;
+  readonly intentClient: IntentClient;
+  readonly cultivationOptions: readonly SelectOption<{ areaPerPlant_m2: number }>[];
+  readonly irrigationOptions: readonly SelectOption<null>[];
+  readonly seedlingOptions: readonly SelectOption<SeedlingPriceEntry | null>[];
+  readonly containerOptions: readonly SelectOption<ContainerPriceEntry | null>[];
+  readonly substrateOptions: readonly SelectOption<SubstratePriceEntry | null>[];
+  readonly irrigationLineOptions: readonly SelectOption<IrrigationLinePriceEntry | null>[];
+  readonly onSubmitted?: () => void;
+}
+
+export function ZoneCreateWizard({
+  room,
+  compatibility,
+  intentClient,
+  cultivationOptions,
+  irrigationOptions,
+  seedlingOptions,
+  containerOptions,
+  substrateOptions,
+  irrigationLineOptions,
+  onSubmitted
+}: ZoneCreateWizardProps): ReactElement {
+  const [areaInput, setAreaInput] = useState("");
+  const [cultivationId, setCultivationId] = useState(cultivationOptions[0]?.id ?? "");
+  const [irrigationId, setIrrigationId] = useState(irrigationOptions[0]?.id ?? "");
+  const [seedlingId, setSeedlingId] = useState(seedlingOptions[0]?.id ?? "");
+  const [containerId, setContainerId] = useState(containerOptions[0]?.id ?? "");
+  const [substrateId, setSubstrateId] = useState(substrateOptions[0]?.id ?? "");
+  const [lineId, setLineId] = useState(irrigationLineOptions[0]?.id ?? "");
+  const [submission, setSubmission] = useSubmissionState();
+
+  const areaValue = parseNumber(areaInput) ?? Number.NaN;
+  const cultivation = cultivationOptions.find((option) => option.id === cultivationId) ?? null;
+  const seedling = seedlingOptions.find((option) => option.id === seedlingId)?.value ?? null;
+  const container = containerOptions.find((option) => option.id === containerId)?.value ?? null;
+  const substrate = substrateOptions.find((option) => option.id === substrateId)?.value ?? null;
+  const irrigationLine = irrigationLineOptions.find((option) => option.id === lineId)?.value ?? null;
+
+  const validation = useMemo(() =>
+    deriveZoneWizardResult({
+      room,
+      area_m2: areaValue,
+      cultivationMethodId: cultivationId,
+      areaPerPlant_m2: cultivation?.value.areaPerPlant_m2 ?? 0,
+      irrigationMethodId: irrigationId,
+      seedlingPrice: seedling ?? null,
+      containerPrice: container ?? null,
+      substratePrice: substrate ?? null,
+      irrigationLinePrice: irrigationLine ?? null,
+      compatibility
+    }),
+  [room, areaValue, cultivationId, cultivation?.value.areaPerPlant_m2, irrigationId, seedling, container, substrate, irrigationLine, compatibility]);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!validation.payload) {
+      return;
+    }
+
+    void submitIntent(validation.payload, intentClient, setSubmission, onSubmitted);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="grid gap-3">
+        <label className="flex flex-col">
+          <span className="font-medium">Zone area (m²)</span>
+          <input
+            value={areaInput}
+            onChange={(event) => {
+              setAreaInput(event.target.value);
+            }}
+            className="border rounded px-2 py-1"
+          />
+        </label>
+        <label className="flex flex-col">
+          <span className="font-medium">Cultivation method</span>
+          <select
+            value={cultivationId}
+            onChange={(event) => {
+              setCultivationId(event.target.value);
+            }}
+            className="border rounded px-2 py-1"
+          >
+            {cultivationOptions.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col">
+          <span className="font-medium">Irrigation method</span>
+          <select
+            value={irrigationId}
+            onChange={(event) => {
+              setIrrigationId(event.target.value);
+            }}
+            className="border rounded px-2 py-1"
+          >
+            {irrigationOptions.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col">
+          <span className="font-medium">Seedling price</span>
+          <select
+            value={seedlingId}
+            onChange={(event) => {
+              setSeedlingId(event.target.value);
+            }}
+            className="border rounded px-2 py-1"
+          >
+            {seedlingOptions.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col">
+          <span className="font-medium">Container</span>
+          <select
+            value={containerId}
+            onChange={(event) => {
+              setContainerId(event.target.value);
+            }}
+            className="border rounded px-2 py-1"
+          >
+            {containerOptions.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col">
+          <span className="font-medium">Substrate</span>
+          <select
+            value={substrateId}
+            onChange={(event) => {
+              setSubstrateId(event.target.value);
+            }}
+            className="border rounded px-2 py-1"
+          >
+            {substrateOptions.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col">
+          <span className="font-medium">Irrigation line</span>
+          <select
+            value={lineId}
+            onChange={(event) => {
+              setLineId(event.target.value);
+            }}
+            className="border rounded px-2 py-1"
+          >
+            {irrigationLineOptions.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div className="text-sm">
+        <p>Cultivation status: {validation.cultivationStatus}</p>
+        <p>Irrigation status: {validation.irrigationStatus}</p>
+        <p>Max plants: {validation.maxPlants}</p>
+        <p>Acquisition cost preview: {validation.acquisitionCost.toFixed(2)}</p>
+      </div>
+
+      {validation.errors.length > 0 && (
+        <ul className="text-sm text-red-600 list-disc list-inside">
+          {validation.errors.map((error) => (
+            <li key={error}>{error}</li>
+          ))}
+        </ul>
+      )}
+
+      {submission.error && <p className="text-sm text-red-600">{submission.error}</p>}
+
+      <button type="submit" className="px-4 py-2 rounded bg-emerald-600 text-white" disabled={!validation.isValid || submission.isSubmitting}>
+        Create zone
+      </button>
+    </form>
+  );
+}
+
+interface ZoneSowingDialogProps {
+  readonly zone: ZoneReadModel;
+  readonly compatibility: CompatibilityMaps;
+  readonly priceBook: PriceBookCatalog;
+  readonly intentClient: IntentClient;
+  readonly strainOptions: readonly SelectOption<string>[];
+  readonly onSubmitted?: () => void;
+}
+
+export function ZoneSowingDialog({
+  zone,
+  compatibility,
+  priceBook,
+  intentClient,
+  strainOptions,
+  onSubmitted
+}: ZoneSowingDialogProps): ReactElement {
+  const [strainId, setStrainId] = useState(strainOptions[0]?.value ?? "");
+  const [countInput, setCountInput] = useState("");
+  const [submission, setSubmission] = useSubmissionState();
+
+  const countValue = parseNumber(countInput) ?? Number.NaN;
+  const seedlingPrice = findSeedlingPriceForStrain(priceBook, strainId);
+
+  const validation = useMemo(
+    () =>
+      validateSowing({
+        zone,
+        strainId,
+        count: Number.isFinite(countValue) ? Math.trunc(countValue) : NaN,
+        compatibility,
+        seedlingPrice
+      }),
+    [zone, strainId, countValue, compatibility, seedlingPrice]
+  );
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!validation.payload) {
+      return;
+    }
+
+    void submitIntent(validation.payload, intentClient, setSubmission, onSubmitted);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <label className="flex flex-col">
+        <span className="font-medium">Strain</span>
+        <select
+          value={strainId}
+          onChange={(event) => {
+            setStrainId(event.target.value);
+          }}
+          className="border rounded px-2 py-1"
+        >
+          {strainOptions.map((option) => (
+            <option key={option.id} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="flex flex-col">
+        <span className="font-medium">Plant count</span>
+        <input
+          value={countInput}
+          onChange={(event) => {
+            setCountInput(event.target.value);
+          }}
+          className="border rounded px-2 py-1"
+        />
+      </label>
+
+      <div className="text-sm">
+        <p>Cultivation status: {validation.cultivationStatus}</p>
+        <p>Irrigation status: {validation.irrigationStatus}</p>
+        <p>Cost preview: {validation.totalCost.toFixed(2)}</p>
+      </div>
+
+      {validation.errors.length > 0 && (
+        <ul className="text-sm text-red-600 list-disc list-inside">
+          {validation.errors.map((error) => (
+            <li key={error}>{error}</li>
+          ))}
+        </ul>
+      )}
+
+      {submission.error && <p className="text-sm text-red-600">{submission.error}</p>}
+
+      <button type="submit" className="px-4 py-2 rounded bg-emerald-600 text-white" disabled={!validation.isValid || submission.isSubmitting}>
+        Sow plants
+      </button>
+    </form>
+  );
+}
+
+interface RoomDuplicateDialogProps {
+  readonly structure: StructureReadModel;
+  readonly room: RoomReadModel;
+  readonly priceBook: PriceBookCatalog;
+  readonly intentClient: IntentClient;
+  readonly onSubmitted?: () => void;
+}
+
+export function RoomDuplicateDialog({
+  structure,
+  room,
+  priceBook,
+  intentClient,
+  onSubmitted
+}: RoomDuplicateDialogProps): ReactElement {
+  const [copiesInput, setCopiesInput] = useState("1");
+  const [submission, setSubmission] = useSubmissionState();
+  const copiesValue = parseNumber(copiesInput) ?? Number.NaN;
+
+  const validation = useMemo(
+    () =>
+      previewRoomDuplicate({
+        structure,
+        room,
+        copies: Number.isFinite(copiesValue) ? Math.trunc(copiesValue) : NaN,
+        priceBook
+      }),
+    [structure, room, copiesValue, priceBook]
+  );
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!validation.payload) {
+      return;
+    }
+
+    void submitIntent(validation.payload, intentClient, setSubmission, onSubmitted);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <label className="flex flex-col">
+        <span className="font-medium">Number of copies</span>
+        <input
+          value={copiesInput}
+          onChange={(event) => {
+            setCopiesInput(event.target.value);
+          }}
+          className="border rounded px-2 py-1"
+        />
+      </label>
+
+      <div className="text-sm">
+        <p>Device capex preview: {validation.deviceCapitalExpenditure.toFixed(2)}</p>
+        <p>Cloned plants: {validation.clonedPlantCount}</p>
+      </div>
+
+      {validation.errors.length > 0 && (
+        <ul className="text-sm text-red-600 list-disc list-inside">
+          {validation.errors.map((error) => (
+            <li key={error}>{error}</li>
+          ))}
+        </ul>
+      )}
+
+      {submission.error && <p className="text-sm text-red-600">{submission.error}</p>}
+
+      <button type="submit" className="px-4 py-2 rounded bg-emerald-600 text-white" disabled={!validation.isValid || submission.isSubmitting}>
+        Duplicate room
+      </button>
+    </form>
+  );
+}
+
+interface ZoneDuplicateDialogProps {
+  readonly structure: StructureReadModel;
+  readonly room: RoomReadModel;
+  readonly zone: ZoneReadModel;
+  readonly priceBook: PriceBookCatalog;
+  readonly compatibility: CompatibilityMaps;
+  readonly intentClient: IntentClient;
+  readonly onSubmitted?: () => void;
+}
+
+export function ZoneDuplicateDialog({
+  structure,
+  room,
+  zone,
+  priceBook,
+  compatibility,
+  intentClient,
+  onSubmitted
+}: ZoneDuplicateDialogProps): ReactElement {
+  const [copiesInput, setCopiesInput] = useState("1");
+  const [submission, setSubmission] = useSubmissionState();
+  const copiesValue = parseNumber(copiesInput) ?? Number.NaN;
+
+  const validation = useMemo(
+    () =>
+      previewZoneDuplicate({
+        structure,
+        room,
+        zone,
+        copies: Number.isFinite(copiesValue) ? Math.trunc(copiesValue) : NaN,
+        priceBook,
+        compatibility
+      }),
+    [structure, room, zone, copiesValue, priceBook, compatibility]
+  );
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!validation.payload) {
+      return;
+    }
+
+    void submitIntent(validation.payload, intentClient, setSubmission, onSubmitted);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <label className="flex flex-col">
+        <span className="font-medium">Number of copies</span>
+        <input
+          value={copiesInput}
+          onChange={(event) => {
+            setCopiesInput(event.target.value);
+          }}
+          className="border rounded px-2 py-1"
+        />
+      </label>
+
+      <div className="text-sm">
+        <p>Device capex preview: {validation.deviceCapitalExpenditure.toFixed(2)}</p>
+        <p>Cloned plants: {validation.clonedPlantCount}</p>
+      </div>
+
+      {validation.errors.length > 0 && (
+        <ul className="text-sm text-red-600 list-disc list-inside">
+          {validation.errors.map((error) => (
+            <li key={error}>{error}</li>
+          ))}
+        </ul>
+      )}
+
+      {submission.error && <p className="text-sm text-red-600">{submission.error}</p>}
+
+      <button type="submit" className="px-4 py-2 rounded bg-emerald-600 text-white" disabled={!validation.isValid || submission.isSubmitting}>
+        Duplicate zone
+      </button>
+    </form>
+  );
+}
+
+interface RoomAreaUpdateDialogProps {
+  readonly structure: StructureReadModel;
+  readonly room: RoomReadModel;
+  readonly intentClient: IntentClient;
+  readonly onSubmitted?: (result: RoomAreaUpdateResult) => void;
+}
+
+export function RoomAreaUpdateDialog({
+  structure,
+  room,
+  intentClient,
+  onSubmitted
+}: RoomAreaUpdateDialogProps): ReactElement {
+  const [areaInput, setAreaInput] = useState("");
+  const [submission, setSubmission] = useSubmissionState();
+  const areaValue = parseNumber(areaInput) ?? Number.NaN;
+
+  const validation = useMemo(
+    () => validateRoomAreaUpdate({ structure, room, nextArea_m2: areaValue }),
+    [structure, room, areaValue]
+  );
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!validation.payload) {
+      return;
+    }
+
+    void submitIntent(validation.payload, intentClient, setSubmission, () => {
+      onSubmitted?.(validation);
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <label className="flex flex-col">
+        <span className="font-medium">New area (m²)</span>
+        <input
+          value={areaInput}
+          onChange={(event) => {
+            setAreaInput(event.target.value);
+          }}
+          className="border rounded px-2 py-1"
+        />
+      </label>
+
+      <div className="text-sm">
+        <p>Projected volume: {validation.nextVolume_m3.toFixed(2)}</p>
+      </div>
+
+      {validation.errors.length > 0 && (
+        <ul className="text-sm text-red-600 list-disc list-inside">
+          {validation.errors.map((error) => (
+            <li key={error}>{error}</li>
+          ))}
+        </ul>
+      )}
+
+      {submission.error && <p className="text-sm text-red-600">{submission.error}</p>}
+
+      <button type="submit" className="px-4 py-2 rounded bg-emerald-600 text-white" disabled={!validation.isValid || submission.isSubmitting}>
+        Update room area
+      </button>
+    </form>
+  );
+}
+
+interface ZoneAreaUpdateDialogProps {
+  readonly room: RoomReadModel;
+  readonly zone: ZoneReadModel;
+  readonly areaPerPlant_m2: number;
+  readonly intentClient: IntentClient;
+  readonly onSubmitted?: (result: ZoneAreaUpdateResult) => void;
+}
+
+export function ZoneAreaUpdateDialog({
+  room,
+  zone,
+  areaPerPlant_m2,
+  intentClient,
+  onSubmitted
+}: ZoneAreaUpdateDialogProps): ReactElement {
+  const [areaInput, setAreaInput] = useState("");
+  const [submission, setSubmission] = useSubmissionState();
+  const areaValue = parseNumber(areaInput) ?? Number.NaN;
+
+  const validation = useMemo(
+    () => validateZoneAreaUpdate({ room, zone, nextArea_m2: areaValue, areaPerPlant_m2 }),
+    [room, zone, areaValue, areaPerPlant_m2]
+  );
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!validation.payload) {
+      return;
+    }
+
+    void submitIntent(validation.payload, intentClient, setSubmission, () => {
+      onSubmitted?.(validation);
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <label className="flex flex-col">
+        <span className="font-medium">New area (m²)</span>
+        <input
+          value={areaInput}
+          onChange={(event) => {
+            setAreaInput(event.target.value);
+          }}
+          className="border rounded px-2 py-1"
+        />
+      </label>
+
+      <div className="text-sm">
+        <p>Max plants: {validation.maxPlants}</p>
+      </div>
+
+      {validation.errors.length > 0 && (
+        <ul className="text-sm text-red-600 list-disc list-inside">
+          {validation.errors.map((error) => (
+            <li key={error}>{error}</li>
+          ))}
+        </ul>
+      )}
+
+      {submission.error && <p className="text-sm text-red-600">{submission.error}</p>}
+
+      <button type="submit" className="px-4 py-2 rounded bg-emerald-600 text-white" disabled={!validation.isValid || submission.isSubmitting}>
+        Update zone area
+      </button>
+    </form>
+  );
+}
+
+export type {
+  RoomCreateIntentPayload,
+  ZoneCreateIntentPayload,
+  SowingResult,
+  ZoneDuplicateResult,
+  RoomDuplicateResult,
+  RoomAreaUpdateResult,
+  ZoneAreaUpdateResult,
+  RoomSetAreaIntentPayload
+};

--- a/packages/ui/src/components/forms/index.ts
+++ b/packages/ui/src/components/forms/index.ts
@@ -1,0 +1,20 @@
+export {
+  RoomCreateDialog,
+  ZoneCreateWizard,
+  ZoneSowingDialog,
+  RoomDuplicateDialog,
+  ZoneDuplicateDialog,
+  RoomAreaUpdateDialog,
+  ZoneAreaUpdateDialog
+} from "./FacilityDialogs";
+
+export type {
+  RoomCreateIntentPayload,
+  ZoneCreateIntentPayload,
+  SowingResult,
+  ZoneDuplicateResult,
+  RoomDuplicateResult,
+  RoomAreaUpdateResult,
+  ZoneAreaUpdateResult,
+  RoomSetAreaIntentPayload
+} from "./FacilityDialogs";

--- a/packages/ui/src/lib/__tests__/facilityFlows.test.ts
+++ b/packages/ui/src/lib/__tests__/facilityFlows.test.ts
@@ -1,0 +1,339 @@
+import { describe, expect, it } from "vitest";
+import { AREA_QUANTUM_M2, ROOM_DEFAULT_HEIGHT_M } from "@engine/constants/simConstants.ts";
+import type {
+  CompatibilityMaps,
+  PriceBookCatalog,
+  RoomReadModel,
+  StructureReadModel,
+  ZoneReadModel
+} from "@ui/state/readModels.types";
+import { deterministicReadModelSnapshot } from "@ui/test-utils/readModelFixtures";
+import {
+  deriveZoneWizardResult,
+  findSeedlingPriceForStrain,
+  previewRoomDuplicate,
+  previewZoneDuplicate,
+  validateRoomAreaUpdate,
+  validateRoomCreate,
+  validateSowing,
+  validateZoneAreaUpdate
+} from "@ui/lib/facilityFlows";
+
+function getStructure(): StructureReadModel {
+  return deterministicReadModelSnapshot.structures[0];
+}
+
+function getRoom(): RoomReadModel {
+  return getStructure().rooms[0];
+}
+
+function getZone(): ZoneReadModel {
+  return getRoom().zones[0];
+}
+
+const priceBook: PriceBookCatalog = deterministicReadModelSnapshot.priceBook;
+const compatibility: CompatibilityMaps = deterministicReadModelSnapshot.compatibility;
+
+const ROOM_CREATE_TEST_AREA = 50;
+const ZONE_WIZARD_TEST_AREA = 20;
+const CULTIVATION_DENSITY = 0.25;
+const SOW_COUNT = 5;
+
+describe("validateRoomCreate", () => {
+  it("produces a valid payload when area and volume fit within structure capacity", () => {
+    const structure = getStructure();
+    const area = Math.min(structure.capacity.areaFree_m2, ROOM_CREATE_TEST_AREA);
+    const result = validateRoomCreate({
+      structure,
+      name: "Propagation Bay",
+      purpose: "growroom",
+      area_m2: area,
+      height_m: ROOM_DEFAULT_HEIGHT_M
+    });
+
+    expect(result.isValid).toBe(true);
+    expect(result.payload).toEqual({
+      type: "room.create",
+      structureId: structure.id,
+      name: "Propagation Bay",
+      purpose: "growroom",
+      area_m2: area,
+      height_m: ROOM_DEFAULT_HEIGHT_M
+    });
+  });
+
+  it("rejects areas exceeding structure free capacity", () => {
+    const structure = getStructure();
+    const result = validateRoomCreate({
+      structure,
+      name: "Overflow",
+      purpose: "growroom",
+      area_m2: structure.capacity.areaFree_m2 + AREA_QUANTUM_M2,
+      height_m: ROOM_DEFAULT_HEIGHT_M
+    });
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain("Structure does not have enough free area for the new room.");
+  });
+});
+
+describe("deriveZoneWizardResult", () => {
+  it("calculates max plants and acquisition cost for compatible selections", () => {
+    const room = getRoom();
+    const area = Math.min(room.capacity.areaFree_m2, ZONE_WIZARD_TEST_AREA);
+    const seedlingPrice = findSeedlingPriceForStrain(priceBook, "strain-northern-lights");
+    const containerPrice = priceBook.containers[0];
+    const substratePrice = priceBook.substrates[0];
+    const irrigationLinePrice = priceBook.irrigationLines[0];
+    const result = deriveZoneWizardResult({
+      room,
+      area_m2: area,
+      cultivationMethodId: "cm-sea-of-green",
+      areaPerPlant_m2: CULTIVATION_DENSITY,
+      irrigationMethodId: "ir-drip-inline",
+      seedlingPrice,
+      containerPrice,
+      substratePrice,
+      irrigationLinePrice,
+      compatibility
+    });
+
+    expect(result.isValid).toBe(true);
+    expect(result.maxPlants).toBe(Math.floor(area / CULTIVATION_DENSITY));
+    expect(result.acquisitionCost).toBeGreaterThan(0);
+    expect(result.payload).toEqual({
+      type: "zone.create",
+      structureId: deterministicReadModelSnapshot.structures[0].id,
+      roomId: room.id,
+      area_m2: area,
+      cultivationMethodId: "cm-sea-of-green",
+      irrigationMethodId: "ir-drip-inline",
+      maxPlants: result.maxPlants
+    });
+  });
+
+  it("blocks incompatible irrigation selections", () => {
+    const room = getRoom();
+    const result = deriveZoneWizardResult({
+      room,
+      area_m2: Math.min(room.capacity.areaFree_m2, ZONE_WIZARD_TEST_AREA),
+      cultivationMethodId: "cm-sea-of-green",
+      areaPerPlant_m2: CULTIVATION_DENSITY,
+      irrigationMethodId: "ir-ebb-flow",
+      seedlingPrice: priceBook.seedlings[0],
+      containerPrice: priceBook.containers[0],
+      substratePrice: priceBook.substrates[0],
+      irrigationLinePrice: priceBook.irrigationLines[0],
+      compatibility
+    });
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain(
+      "Irrigation method is incompatible with the selected cultivation method."
+    );
+    expect(result.payload).toBeNull();
+  });
+});
+
+describe("validateSowing", () => {
+  it("approves sowing when zone is empty and compatibility is ok", () => {
+    const zone = { ...getZone(), currentPlantCount: 0, maxPlants: 10 };
+    const seedlingPrice = findSeedlingPriceForStrain(priceBook, zone.strainId);
+    const result = validateSowing({
+      zone,
+      strainId: zone.strainId,
+      count: SOW_COUNT,
+      compatibility,
+      seedlingPrice
+    });
+
+    expect(result.isValid).toBe(true);
+    expect(result.payload).toEqual({
+      type: "plants.sow",
+      zoneId: zone.id,
+      strainId: zone.strainId,
+      count: SOW_COUNT
+    });
+    expect(result.totalCost).toBe(
+      seedlingPrice?.pricePerUnit ? seedlingPrice.pricePerUnit * SOW_COUNT : 0
+    );
+  });
+
+  it("blocks sowing when zone contains plants", () => {
+    const zone = getZone();
+    const result = validateSowing({
+      zone,
+      strainId: zone.strainId,
+      count: 1,
+      compatibility,
+      seedlingPrice: findSeedlingPriceForStrain(priceBook, zone.strainId)
+    });
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain("Zone must be empty before sowing new plants.");
+  });
+});
+
+describe("previewRoomDuplicate", () => {
+  it("calculates device capital expenditure without cloning plants", () => {
+    const baseStructure = getStructure();
+    const room = getRoom();
+    const structure = {
+      ...baseStructure,
+      capacity: {
+        ...baseStructure.capacity,
+        areaFree_m2: room.area_m2 * 2,
+        volumeFree_m3: room.volume_m3 * 2
+      }
+    };
+    const result = previewRoomDuplicate({
+      structure,
+      room,
+      copies: 1,
+      priceBook
+    });
+
+    expect(result.isValid).toBe(true);
+    expect(result.clonedPlantCount).toBe(0);
+    expect(result.deviceCapitalExpenditure).toBeGreaterThanOrEqual(0);
+    expect(result.payload).toEqual({
+      type: "room.duplicate",
+      sourceRoomId: room.id,
+      structureId: structure.id,
+      copies: 1
+    });
+  });
+
+  it("requires sufficient free structure capacity", () => {
+    const structure = getStructure();
+    const room = getRoom();
+    const result = previewRoomDuplicate({
+      structure,
+      room,
+      copies: Math.ceil((structure.capacity.areaFree_m2 + AREA_QUANTUM_M2) / room.area_m2),
+      priceBook
+    });
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain(
+      "Structure does not have enough free area for the duplicates."
+    );
+  });
+});
+
+describe("previewZoneDuplicate", () => {
+  it("applies compatibility checks and zero plant cloning", () => {
+    const structure = getStructure();
+    const zone = getZone();
+    const baseRoom = getRoom();
+    const room = {
+      ...baseRoom,
+      capacity: {
+        ...baseRoom.capacity,
+        areaFree_m2: zone.area_m2 * 2
+      }
+    };
+    const result = previewZoneDuplicate({
+      structure,
+      room,
+      zone,
+      copies: 1,
+      priceBook,
+      compatibility
+    });
+
+    expect(result.isValid).toBe(true);
+    expect(result.clonedPlantCount).toBe(0);
+    expect(result.payload).toEqual({
+      type: "zone.duplicate",
+      sourceZoneId: zone.id,
+      roomId: room.id,
+      structureId: structure.id,
+      copies: 1
+    });
+  });
+
+  it("fails when room lacks free area", () => {
+    const structure = getStructure();
+    const room = getRoom();
+    const zone = getZone();
+    const result = previewZoneDuplicate({
+      structure,
+      room,
+      zone,
+      copies: Math.ceil((room.capacity.areaFree_m2 + AREA_QUANTUM_M2) / zone.area_m2),
+      priceBook,
+      compatibility
+    });
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain("Room does not have enough free area for the duplicates.");
+  });
+});
+
+describe("validateRoomAreaUpdate", () => {
+  it("validates area updates against structure capacity", () => {
+    const structure = getStructure();
+    const room = getRoom();
+    const nextArea = room.area_m2 + AREA_QUANTUM_M2;
+    const result = validateRoomAreaUpdate({ structure, room, nextArea_m2: nextArea });
+
+    expect(result.isValid).toBe(true);
+    expect(result.payload).toEqual({
+      type: "room.setArea",
+      roomId: room.id,
+      structureId: structure.id,
+      area_m2: nextArea
+    });
+    expect(result.nextVolume_m3).toBeGreaterThan(0);
+  });
+
+  it("blocks updates that exceed available volume", () => {
+    const structure = getStructure();
+    const room = getRoom();
+    const excessiveArea = structure.capacity.areaFree_m2 + room.area_m2 + AREA_QUANTUM_M2;
+    const result = validateRoomAreaUpdate({ structure, room, nextArea_m2: excessiveArea });
+
+    expect(result.isValid).toBe(false);
+  });
+});
+
+describe("validateZoneAreaUpdate", () => {
+  it("updates zone area and recalculates max plants", () => {
+    const room = getRoom();
+    const zone = getZone();
+    const nextArea = zone.area_m2 + AREA_QUANTUM_M2;
+    const result = validateZoneAreaUpdate({
+      room,
+      zone,
+      nextArea_m2: nextArea,
+      areaPerPlant_m2: CULTIVATION_DENSITY
+    });
+
+    expect(result.isValid).toBe(true);
+    expect(result.maxPlants).toBe(Math.floor(nextArea / CULTIVATION_DENSITY));
+    expect(result.payload).toEqual({
+      type: "zone.setArea",
+      zoneId: zone.id,
+      roomId: room.id,
+      structureId: deterministicReadModelSnapshot.structures[0].id,
+      area_m2: nextArea,
+      maxPlants: result.maxPlants
+    });
+  });
+
+  it("blocks updates that reduce max plants below current count", () => {
+    const room = getRoom();
+    const zone = { ...getZone(), currentPlantCount: 10, area_m2: ZONE_WIZARD_TEST_AREA };
+    const nextArea = AREA_QUANTUM_M2;
+    const result = validateZoneAreaUpdate({
+      room,
+      zone,
+      nextArea_m2: nextArea,
+      areaPerPlant_m2: 1
+    });
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain("Updated zone would not accommodate existing plants.");
+  });
+});

--- a/packages/ui/src/lib/facilityFlows.ts
+++ b/packages/ui/src/lib/facilityFlows.ts
@@ -1,0 +1,668 @@
+import {
+  AREA_QUANTUM_M2,
+  ROOM_DEFAULT_HEIGHT_M
+} from "@engine/constants/simConstants.ts";
+import type {
+  CompatibilityMaps,
+  CompatibilityStatus,
+  ContainerPriceEntry,
+  IrrigationLinePriceEntry,
+  PriceBookCatalog,
+  RoomReadModel,
+  SeedlingPriceEntry,
+  StructureReadModel,
+  SubstratePriceEntry,
+  ZoneReadModel
+} from "@ui/state/readModels.types";
+
+const EPSILON = 1e-6;
+
+export type RoomCreateIntentPayload = Readonly<{
+  type: "room.create";
+  structureId: string;
+  name: string;
+  purpose: string;
+  area_m2: number;
+  height_m: number;
+}>;
+
+export interface RoomCreateInput {
+  readonly structure: StructureReadModel;
+  readonly name: string;
+  readonly purpose: string;
+  readonly area_m2: number;
+  readonly height_m?: number | null;
+}
+
+export interface ValidationResult<TPayload> {
+  readonly isValid: boolean;
+  readonly errors: readonly string[];
+  readonly payload: TPayload | null;
+}
+
+export interface ZoneWizardInputs {
+  readonly room: RoomReadModel;
+  readonly area_m2: number;
+  readonly cultivationMethodId: string;
+  readonly areaPerPlant_m2: number;
+  readonly irrigationMethodId: string;
+  readonly seedlingPrice: SeedlingPriceEntry | null;
+  readonly containerPrice: ContainerPriceEntry | null;
+  readonly substratePrice: SubstratePriceEntry | null;
+  readonly irrigationLinePrice: IrrigationLinePriceEntry | null;
+  readonly compatibility: CompatibilityMaps;
+}
+
+export type ZoneCreateIntentPayload = Readonly<{
+  type: "zone.create";
+  structureId: string;
+  roomId: string;
+  area_m2: number;
+  cultivationMethodId: string;
+  irrigationMethodId: string;
+  maxPlants: number;
+}>;
+
+export interface ZoneWizardResult extends ValidationResult<ZoneCreateIntentPayload> {
+  readonly cultivationStatus: CompatibilityStatus;
+  readonly irrigationStatus: CompatibilityStatus;
+  readonly maxPlants: number;
+  readonly acquisitionCost: number;
+}
+
+export interface SowingInputs {
+  readonly zone: ZoneReadModel;
+  readonly strainId: string;
+  readonly count: number;
+  readonly compatibility: CompatibilityMaps;
+  readonly seedlingPrice: SeedlingPriceEntry | null;
+}
+
+export type SowingIntentPayload = Readonly<{
+  type: "plants.sow";
+  zoneId: string;
+  strainId: string;
+  count: number;
+}>;
+
+export interface SowingResult extends ValidationResult<SowingIntentPayload> {
+  readonly cultivationStatus: CompatibilityStatus;
+  readonly irrigationStatus: CompatibilityStatus;
+  readonly totalCost: number;
+}
+
+export interface DuplicateRoomInputs {
+  readonly structure: StructureReadModel;
+  readonly room: RoomReadModel;
+  readonly copies: number;
+  readonly priceBook: PriceBookCatalog;
+}
+
+export type RoomDuplicateIntentPayload = Readonly<{
+  type: "room.duplicate";
+  sourceRoomId: string;
+  structureId: string;
+  copies: number;
+}>;
+
+export interface RoomDuplicateResult extends ValidationResult<RoomDuplicateIntentPayload> {
+  readonly clonedPlantCount: number;
+  readonly deviceCapitalExpenditure: number;
+  readonly neutralOperatingCostPerHour: number;
+}
+
+export interface DuplicateZoneInputs {
+  readonly structure: StructureReadModel;
+  readonly room: RoomReadModel;
+  readonly zone: ZoneReadModel;
+  readonly copies: number;
+  readonly priceBook: PriceBookCatalog;
+  readonly compatibility: CompatibilityMaps;
+}
+
+export type ZoneDuplicateIntentPayload = Readonly<{
+  type: "zone.duplicate";
+  sourceZoneId: string;
+  roomId: string;
+  structureId: string;
+  copies: number;
+}>;
+
+export interface ZoneDuplicateResult extends ValidationResult<ZoneDuplicateIntentPayload> {
+  readonly clonedPlantCount: number;
+  readonly deviceCapitalExpenditure: number;
+  readonly neutralOperatingCostPerHour: number;
+}
+
+export interface RoomAreaUpdateInputs {
+  readonly structure: StructureReadModel;
+  readonly room: RoomReadModel;
+  readonly nextArea_m2: number;
+}
+
+export type RoomSetAreaIntentPayload = Readonly<{
+  type: "room.setArea";
+  roomId: string;
+  structureId: string;
+  area_m2: number;
+}>;
+
+export interface RoomAreaUpdateResult extends ValidationResult<RoomSetAreaIntentPayload> {
+  readonly nextVolume_m3: number;
+}
+
+export interface ZoneAreaUpdateInputs {
+  readonly room: RoomReadModel;
+  readonly zone: ZoneReadModel;
+  readonly nextArea_m2: number;
+  readonly areaPerPlant_m2: number;
+}
+
+export type ZoneSetAreaIntentPayload = Readonly<{
+  type: "zone.setArea";
+  zoneId: string;
+  roomId: string;
+  structureId: string;
+  area_m2: number;
+  maxPlants: number;
+}>;
+
+export interface ZoneAreaUpdateResult extends ValidationResult<ZoneSetAreaIntentPayload> {
+  readonly maxPlants: number;
+}
+
+function ensurePositive(value: number): boolean {
+  return Number.isFinite(value) && value > 0;
+}
+
+function isMultipleOfQuantum(area_m2: number): boolean {
+  const quantised = Math.round(area_m2 / AREA_QUANTUM_M2) * AREA_QUANTUM_M2;
+  return Math.abs(quantised - area_m2) < EPSILON;
+}
+
+function normaliseHeight(height_m?: number | null): number {
+  if (!Number.isFinite(height_m ?? Number.NaN)) {
+    return ROOM_DEFAULT_HEIGHT_M;
+  }
+
+  const parsed = Number(height_m);
+  return parsed > 0 ? parsed : ROOM_DEFAULT_HEIGHT_M;
+}
+
+function computeVolume(area_m2: number, height_m: number): number {
+  return area_m2 * height_m;
+}
+
+function appendError(errors: string[], message: string): void {
+  if (!errors.includes(message)) {
+    errors.push(message);
+  }
+}
+
+export function validateRoomCreate(input: RoomCreateInput): ValidationResult<RoomCreateIntentPayload> {
+  const errors: string[] = [];
+
+  if (!ensurePositive(input.area_m2)) {
+    appendError(errors, "Room area must be a positive number.");
+  } else if (!isMultipleOfQuantum(input.area_m2)) {
+    appendError(errors, `Room area must align to ${String(AREA_QUANTUM_M2)} m² increments.`);
+  }
+
+  const height_m = normaliseHeight(input.height_m);
+  const volume_m3 = computeVolume(input.area_m2, height_m);
+
+  const { structure } = input;
+  const freeArea = structure.capacity.areaFree_m2;
+  const freeVolume = structure.capacity.volumeFree_m3;
+
+  if (input.area_m2 - freeArea > EPSILON) {
+    appendError(errors, "Structure does not have enough free area for the new room.");
+  }
+
+  if (volume_m3 - freeVolume > EPSILON) {
+    appendError(errors, "Structure does not have enough free volume for the new room.");
+  }
+
+  if (input.name.trim().length === 0) {
+    appendError(errors, "Room name is required.");
+  }
+
+  if (input.purpose.trim().length === 0) {
+    appendError(errors, "Room purpose is required.");
+  }
+
+  if (errors.length > 0) {
+    return { isValid: false, errors, payload: null };
+  }
+
+  const payload: RoomCreateIntentPayload = {
+    type: "room.create",
+    structureId: structure.id,
+    name: input.name.trim(),
+    purpose: input.purpose,
+    area_m2: input.area_m2,
+    height_m
+  };
+
+  return { isValid: true, errors, payload };
+}
+
+function getCompatibilityStatus(
+  record: Readonly<Record<string, CompatibilityStatus>> | undefined,
+  key: string
+): CompatibilityStatus {
+  if (!record) {
+    return "block";
+  }
+
+  return record[key] ?? "block";
+}
+
+function calculateMaxPlants(area_m2: number, areaPerPlant_m2: number): number {
+  if (!ensurePositive(area_m2) || !ensurePositive(areaPerPlant_m2)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.floor(area_m2 / areaPerPlant_m2));
+}
+
+function calculateZoneAcquisitionCost(
+  maxPlants: number,
+  area_m2: number,
+  seedlingPrice: SeedlingPriceEntry | null,
+  containerPrice: ContainerPriceEntry | null,
+  substratePrice: SubstratePriceEntry | null,
+  irrigationLinePrice: IrrigationLinePriceEntry | null
+): number {
+  const plantCost = seedlingPrice ? seedlingPrice.pricePerUnit * maxPlants : 0;
+  const containerCost = containerPrice ? containerPrice.pricePerUnit * maxPlants : 0;
+  const substrateCost =
+    containerPrice && substratePrice
+      ? containerPrice.capacityLiters * substratePrice.unitPrice_per_L * maxPlants
+      : 0;
+  const irrigationCost = irrigationLinePrice ? irrigationLinePrice.pricePerSquareMeter * area_m2 : 0;
+
+  return plantCost + containerCost + substrateCost + irrigationCost;
+}
+
+export function deriveZoneWizardResult(inputs: ZoneWizardInputs): ZoneWizardResult {
+  const {
+    room,
+    area_m2,
+    cultivationMethodId,
+    areaPerPlant_m2,
+    irrigationMethodId,
+    seedlingPrice,
+    containerPrice,
+    substratePrice,
+    irrigationLinePrice,
+    compatibility
+  } = inputs;
+
+  const errors: string[] = [];
+
+  if (!ensurePositive(area_m2)) {
+    appendError(errors, "Zone area must be a positive number.");
+  } else if (!isMultipleOfQuantum(area_m2)) {
+    appendError(errors, `Zone area must align to ${String(AREA_QUANTUM_M2)} m² increments.`);
+  }
+
+  const availableRoomArea = room.capacity.areaFree_m2;
+  if (area_m2 - availableRoomArea > EPSILON) {
+    appendError(errors, "Room does not have enough free area for the zone.");
+  }
+
+  const irrigationMap = Object.hasOwn(compatibility.cultivationToIrrigation, cultivationMethodId)
+    ? compatibility.cultivationToIrrigation[cultivationMethodId]
+    : undefined;
+  const cultivationStatus = (() => {
+    if (!irrigationMap) {
+      return "block" as const;
+    }
+
+    const statuses = Object.values(irrigationMap);
+    if (statuses.includes("ok")) {
+      return "ok" as const;
+    }
+
+    if (statuses.includes("warn")) {
+      return "warn" as const;
+    }
+
+    return "block" as const;
+  })();
+  const irrigationStatus = getCompatibilityStatus(irrigationMap, irrigationMethodId);
+
+  if (irrigationStatus === "block") {
+    appendError(errors, "Irrigation method is incompatible with the selected cultivation method.");
+  }
+
+  const maxPlants = calculateMaxPlants(area_m2, areaPerPlant_m2);
+  const acquisitionCost = calculateZoneAcquisitionCost(
+    maxPlants,
+    area_m2,
+    seedlingPrice,
+    containerPrice,
+    substratePrice,
+    irrigationLinePrice
+  );
+
+  if (maxPlants <= 0) {
+    appendError(errors, "Zone must support at least one plant.");
+  }
+
+  if (errors.length > 0) {
+    return {
+      isValid: false,
+      errors,
+      payload: null,
+      cultivationStatus,
+      irrigationStatus,
+      maxPlants,
+      acquisitionCost
+    };
+  }
+
+  const payload: ZoneCreateIntentPayload = {
+    type: "zone.create",
+    structureId: room.structureId,
+    roomId: room.id,
+    area_m2,
+    cultivationMethodId,
+    irrigationMethodId,
+    maxPlants
+  };
+
+  return {
+    isValid: true,
+    errors,
+    payload,
+    cultivationStatus,
+    irrigationStatus,
+    maxPlants,
+    acquisitionCost
+  };
+}
+
+function findSeedlingPrice(
+  priceBook: PriceBookCatalog,
+  strainId: string
+): SeedlingPriceEntry | null {
+  return priceBook.seedlings.find((entry) => entry.strainId === strainId) ?? null;
+}
+
+export function validateSowing(inputs: SowingInputs): SowingResult {
+  const { zone, strainId, count, compatibility, seedlingPrice } = inputs;
+  const errors: string[] = [];
+
+  if (zone.currentPlantCount > 0) {
+    appendError(errors, "Zone must be empty before sowing new plants.");
+  }
+
+  if (!Number.isInteger(count) || count <= 0) {
+    appendError(errors, "Plant count must be a positive integer.");
+  }
+
+  if (count - zone.maxPlants > EPSILON) {
+    appendError(errors, "Plant count exceeds zone capacity.");
+  }
+
+  const strainEntry = Object.hasOwn(compatibility.strainToCultivation, strainId)
+    ? compatibility.strainToCultivation[strainId]
+    : undefined;
+  const cultivationStatus = getCompatibilityStatus(strainEntry?.cultivation, zone.cultivationMethodId);
+  const irrigationStatus = getCompatibilityStatus(strainEntry?.irrigation, zone.irrigationMethodId);
+
+  if (cultivationStatus === "block") {
+    appendError(errors, "Selected strain is incompatible with the zone's cultivation method.");
+  }
+
+  if (irrigationStatus === "block") {
+    appendError(errors, "Selected strain is incompatible with the zone's irrigation method.");
+  }
+
+  const totalCost = seedlingPrice ? seedlingPrice.pricePerUnit * count : 0;
+
+  if (errors.length > 0) {
+    return {
+      isValid: false,
+      errors,
+      payload: null,
+      cultivationStatus,
+      irrigationStatus,
+      totalCost
+    };
+  }
+
+  const payload: SowingIntentPayload = {
+    type: "plants.sow",
+    zoneId: zone.id,
+    strainId,
+    count
+  };
+
+  return {
+    isValid: true,
+    errors,
+    payload,
+    cultivationStatus,
+    irrigationStatus,
+    totalCost
+  };
+}
+
+function sumDeviceCapex(zone: ZoneReadModel, priceBook: PriceBookCatalog): number {
+  let total = 0;
+  for (const device of zone.devices) {
+    const priceEntry = priceBook.devices.find((entry) => entry.deviceSlug === device.slug);
+    if (priceEntry) {
+      total += priceEntry.capitalExpenditure;
+    }
+  }
+  return total;
+}
+
+export function previewRoomDuplicate(inputs: DuplicateRoomInputs): RoomDuplicateResult {
+  const { structure, room, copies, priceBook } = inputs;
+  const errors: string[] = [];
+
+  if (!Number.isInteger(copies) || copies <= 0) {
+    appendError(errors, "Copies must be a positive integer.");
+  }
+
+  const availableArea = structure.capacity.areaFree_m2;
+  const requiredArea = room.area_m2 * copies;
+  if (requiredArea - availableArea > EPSILON) {
+    appendError(errors, "Structure does not have enough free area for the duplicates.");
+  }
+
+  const availableVolume = structure.capacity.volumeFree_m3;
+  const requiredVolume = room.volume_m3 * copies;
+  if (requiredVolume - availableVolume > EPSILON) {
+    appendError(errors, "Structure does not have enough free volume for the duplicates.");
+  }
+
+  const clonedPlantCount = 0;
+  const zoneDeviceCost = room.zones.reduce(
+    (accumulator, zone) => accumulator + sumDeviceCapex(zone, priceBook),
+    0
+  );
+  const structureDeviceCost = room.devices.reduce((accumulator, device) => {
+    const entry = priceBook.devices.find((item) => item.deviceSlug === device.slug);
+    return entry ? accumulator + entry.capitalExpenditure : accumulator;
+  }, 0);
+  const deviceCapitalExpenditure = (zoneDeviceCost + structureDeviceCost) * copies;
+
+  if (errors.length > 0) {
+    return {
+      isValid: false,
+      errors,
+      payload: null,
+      clonedPlantCount,
+      deviceCapitalExpenditure,
+      neutralOperatingCostPerHour: 0
+    };
+  }
+
+  const payload: RoomDuplicateIntentPayload = {
+    type: "room.duplicate",
+    sourceRoomId: room.id,
+    structureId: structure.id,
+    copies
+  };
+
+  return {
+    isValid: true,
+    errors,
+    payload,
+    clonedPlantCount,
+    deviceCapitalExpenditure,
+    neutralOperatingCostPerHour: 0
+  };
+}
+
+export function previewZoneDuplicate(inputs: DuplicateZoneInputs): ZoneDuplicateResult {
+  const { structure, room, zone, copies, priceBook, compatibility } = inputs;
+  const errors: string[] = [];
+
+  if (!Number.isInteger(copies) || copies <= 0) {
+    appendError(errors, "Copies must be a positive integer.");
+  }
+
+  const availableArea = room.capacity.areaFree_m2;
+  const requiredArea = zone.area_m2 * copies;
+  if (requiredArea - availableArea > EPSILON) {
+    appendError(errors, "Room does not have enough free area for the duplicates.");
+  }
+
+  const strainCompatibility = Object.hasOwn(compatibility.strainToCultivation, zone.strainId)
+    ? compatibility.strainToCultivation[zone.strainId]
+    : undefined;
+  const cultivationStatus = getCompatibilityStatus(
+    strainCompatibility?.cultivation,
+    zone.cultivationMethodId
+  );
+  const zoneIrrigationMap = Object.hasOwn(compatibility.cultivationToIrrigation, zone.cultivationMethodId)
+    ? compatibility.cultivationToIrrigation[zone.cultivationMethodId]
+    : undefined;
+  const irrigationStatus = getCompatibilityStatus(zoneIrrigationMap, zone.irrigationMethodId);
+
+  if (cultivationStatus === "block") {
+    appendError(errors, "Zone cultivation method is no longer eligible for duplication.");
+  }
+
+  if (irrigationStatus === "block") {
+    appendError(errors, "Zone irrigation method is no longer eligible for duplication.");
+  }
+
+  const clonedPlantCount = 0;
+  const deviceCapitalExpenditure = sumDeviceCapex(zone, priceBook) * copies;
+
+  if (errors.length > 0) {
+    return {
+      isValid: false,
+      errors,
+      payload: null,
+      clonedPlantCount,
+      deviceCapitalExpenditure,
+      neutralOperatingCostPerHour: 0
+    };
+  }
+
+  const payload: ZoneDuplicateIntentPayload = {
+    type: "zone.duplicate",
+    sourceZoneId: zone.id,
+    roomId: room.id,
+    structureId: structure.id,
+    copies
+  };
+
+  return {
+    isValid: true,
+    errors,
+    payload,
+    clonedPlantCount,
+    deviceCapitalExpenditure,
+    neutralOperatingCostPerHour: 0
+  };
+}
+
+export function validateRoomAreaUpdate(inputs: RoomAreaUpdateInputs): RoomAreaUpdateResult {
+  const { structure, room, nextArea_m2 } = inputs;
+  const errors: string[] = [];
+
+  if (!ensurePositive(nextArea_m2)) {
+    appendError(errors, "Room area must be a positive number.");
+  } else if (!isMultipleOfQuantum(nextArea_m2)) {
+    appendError(errors, `Room area must align to ${String(AREA_QUANTUM_M2)} m² increments.`);
+  }
+
+  const availableArea = structure.capacity.areaFree_m2 + room.area_m2;
+  if (nextArea_m2 - availableArea > EPSILON) {
+    appendError(errors, "Structure does not have enough free area for the updated room size.");
+  }
+
+  const currentHeight = room.area_m2 > 0 ? room.volume_m3 / room.area_m2 : ROOM_DEFAULT_HEIGHT_M;
+  const nextVolume_m3 = computeVolume(nextArea_m2, currentHeight);
+  const availableVolume = structure.capacity.volumeFree_m3 + room.volume_m3;
+  if (nextVolume_m3 - availableVolume > EPSILON) {
+    appendError(errors, "Structure does not have enough free volume for the updated room size.");
+  }
+
+  if (errors.length > 0) {
+    return { isValid: false, errors, payload: null, nextVolume_m3 };
+  }
+
+  const payload: RoomSetAreaIntentPayload = {
+    type: "room.setArea",
+    roomId: room.id,
+    structureId: structure.id,
+    area_m2: nextArea_m2
+  };
+
+  return { isValid: true, errors, payload, nextVolume_m3 };
+}
+
+export function validateZoneAreaUpdate(inputs: ZoneAreaUpdateInputs): ZoneAreaUpdateResult {
+  const { room, zone, nextArea_m2, areaPerPlant_m2 } = inputs;
+  const errors: string[] = [];
+
+  if (!ensurePositive(nextArea_m2)) {
+    appendError(errors, "Zone area must be a positive number.");
+  } else if (!isMultipleOfQuantum(nextArea_m2)) {
+    appendError(errors, `Zone area must align to ${String(AREA_QUANTUM_M2)} m² increments.`);
+  }
+
+  const availableArea = room.capacity.areaFree_m2 + zone.area_m2;
+  if (nextArea_m2 - availableArea > EPSILON) {
+    appendError(errors, "Room does not have enough free area for the updated zone size.");
+  }
+
+  const maxPlants = calculateMaxPlants(nextArea_m2, areaPerPlant_m2);
+  if (maxPlants < zone.currentPlantCount) {
+    appendError(errors, "Updated zone would not accommodate existing plants.");
+  }
+
+  if (errors.length > 0) {
+    return { isValid: false, errors, payload: null, maxPlants };
+  }
+
+  const payload: ZoneSetAreaIntentPayload = {
+    type: "zone.setArea",
+    zoneId: zone.id,
+    roomId: room.id,
+    structureId: room.structureId,
+    area_m2: nextArea_m2,
+    maxPlants
+  };
+
+  return { isValid: true, errors, payload, maxPlants };
+}
+
+export function findSeedlingPriceForStrain(
+  priceBook: PriceBookCatalog,
+  strainId: string
+): SeedlingPriceEntry | null {
+  return findSeedlingPrice(priceBook, strainId);
+}
+


### PR DESCRIPTION
## Summary
- update room and zone duplication tests to allocate deterministic free capacity before exercising happy paths
- retain negative coverage for exceeding room and structure capacity during duplication flows

## Testing
- pnpm -w lint *(fails: legacy unsafe-assignment violations in @wb/facade and related packages)*
- pnpm -w -r typecheck *(fails: existing schema incompatibilities and readonly mutations in @wb/engine)*
- CI=1 pnpm -w -r test *(fails: known WorkforcePage DOM query issue outside this change)*
- pnpm -w -r build *(fails: @wb/engine TypeScript build errors present on main)*

------
https://chatgpt.com/codex/tasks/task_e_68f0db6d9e108325b3cbf6784630e384