### PR TITLE
feat(ui): add inline rename and zone move dialog

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -55,6 +55,15 @@
   "Open Capacity Advisor" routing, expanded the read-model hooks to surface
   control snapshots, and added Vitest coverage for hook data assembly, page
   rendering, and CTA navigation.
+- Task 8000: Introduced an intent-aware inline rename field reused across
+  structure, room, and zone headers, wrapped the app router in a shared intent
+  client provider, and added a zone movement dialog that enforces growroom-only
+  placement within the same structure with deterministic eligibility tests
+  (`packages/ui/src/components/common/InlineRenameField.tsx`,
+  `packages/ui/src/components/flows/ZoneMoveDialog.tsx`,
+  `packages/ui/src/pages/{StructurePage,RoomDetailPage,ZoneDetailPage}.tsx`,
+  `packages/ui/src/App.tsx`, and
+  `packages/ui/src/components/flows/__tests__/ZoneMoveDialog.test.tsx`).
 - Task 0000: Introduced the global workspace shell with a responsive left rail
   (Company → Structures → HR → Strains), a sticky simulation control bar with
   play/pause/step and deterministic speed chips, locale-aware balance and tick

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from "react";
 import { RouterProvider, createBrowserRouter } from "react-router-dom";
-import { createTelemetryBinder, createReadModelClient } from "@ui/transport";
+import { IntentClientProvider, createIntentClient, createTelemetryBinder, createReadModelClient } from "@ui/transport";
 import { workspaceRoutes } from "@ui/routes/workspaceRoutes";
 import { configureReadModelClient, refreshReadModels } from "@ui/state/readModels";
 
@@ -26,6 +26,8 @@ const readModelClient = runtimeBaseUrl
   ? createReadModelClient({ baseUrl: runtimeBaseUrl })
   : null;
 
+const intentClient = runtimeBaseUrl ? createIntentClient({ baseUrl: runtimeBaseUrl }) : null;
+
 if (telemetryBinder) {
   telemetryBinder.connect();
 } else {
@@ -45,7 +47,11 @@ if (readModelClient) {
 const router = createBrowserRouter(workspaceRoutes);
 
 function App(): ReactElement {
-  return <RouterProvider router={router} />;
+  return (
+    <IntentClientProvider client={intentClient}>
+      <RouterProvider router={router} />
+    </IntentClientProvider>
+  );
 }
 
 export default App;

--- a/packages/ui/src/components/common/InlineRenameField.tsx
+++ b/packages/ui/src/components/common/InlineRenameField.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useId, useState, type FormEvent, type ReactElement } from "react";
+import { Pencil, X } from "lucide-react";
+
+const DEFAULT_MAX_LENGTH = 64;
+const NAME_PATTERN = /^[\p{L}\p{N} .,'\-()]+$/u;
+
+function validateName(value: string, maxLength: number): string | null {
+  const trimmed = value.trim();
+
+  if (trimmed.length === 0) {
+    return "Name cannot be empty.";
+  }
+
+  if (trimmed.length > maxLength) {
+    return `Name must be ${maxLength} characters or fewer.`;
+  }
+
+  if (!NAME_PATTERN.test(trimmed)) {
+    return "Name contains unsupported characters.";
+  }
+
+  return null;
+}
+
+export interface InlineRenameFieldProps {
+  readonly name: string;
+  readonly label: string;
+  readonly renameLabel?: string;
+  readonly submitLabel?: string;
+  readonly maxLength?: number;
+  readonly disabledReason?: string;
+  readonly onSubmit: (nextName: string) => Promise<void> | void;
+}
+
+export function InlineRenameField({
+  name,
+  label,
+  renameLabel = "Rename",
+  submitLabel = "Save",
+  maxLength = DEFAULT_MAX_LENGTH,
+  disabledReason,
+  onSubmit
+}: InlineRenameFieldProps): ReactElement {
+  const inputId = useId();
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState(name);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    setDraft(name);
+    setIsEditing(false);
+    setError(null);
+    setIsSubmitting(false);
+  }, [name]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const validationError = validateName(draft, maxLength);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    if (draft.trim() === name.trim()) {
+      setIsEditing(false);
+      setError(null);
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      setError(null);
+      await onSubmit(draft.trim());
+      setIsEditing(false);
+    } catch (reason) {
+      const message = reason instanceof Error ? reason.message : String(reason);
+      setError(message.length > 0 ? message : "Failed to submit rename intent.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!isEditing) {
+    return (
+      <div className="flex items-center gap-2">
+        <h2 className="text-3xl font-semibold text-text-primary" aria-live="polite">
+          {name}
+        </h2>
+        <button
+          type="button"
+          className="inline-flex items-center gap-2 rounded-lg border border-border-base bg-canvas-base px-3 py-1 text-sm font-medium text-text-primary transition hover:border-accent-primary/40 hover:bg-canvas-subtle/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-canvas-raised"
+          onClick={() => {
+            setIsEditing(true);
+            setDraft(name);
+            setError(null);
+          }}
+          disabled={Boolean(disabledReason)}
+          title={disabledReason}
+        >
+          <Pencil aria-hidden="true" className="size-4" />
+          {renameLabel}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex items-center gap-2"
+      aria-label={`Rename ${label.toLowerCase()}`}
+    >
+      <label htmlFor={inputId} className="sr-only">
+        {label}
+      </label>
+      <input
+        id={inputId}
+        value={draft}
+        maxLength={maxLength}
+        onChange={(event) => {
+          setDraft(event.target.value);
+        }}
+        className="rounded-lg border border-border-base bg-canvas-base px-3 py-1 text-3xl font-semibold text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-canvas-raised"
+        aria-invalid={Boolean(error)}
+        aria-describedby={error ? `${inputId}-error` : undefined}
+        disabled={isSubmitting}
+      />
+      <div className="flex items-center gap-2">
+        <button
+          type="submit"
+          className="inline-flex items-center gap-2 rounded-lg border border-accent-primary/60 bg-accent-primary/10 px-3 py-1 text-sm font-medium text-text-primary transition hover:border-accent-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-canvas-raised disabled:opacity-60"
+          disabled={isSubmitting}
+        >
+          {submitLabel}
+        </button>
+        <button
+          type="button"
+          className="inline-flex items-center gap-2 rounded-lg border border-border-base bg-canvas-base px-3 py-1 text-sm text-text-muted transition hover:border-border-strong hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-canvas-raised"
+          onClick={() => {
+            setIsEditing(false);
+            setDraft(name);
+            setError(null);
+          }}
+          disabled={isSubmitting}
+        >
+          <X aria-hidden="true" className="size-4" />
+          Cancel
+        </button>
+      </div>
+      {error ? (
+        <p id={`${inputId}-error`} className="text-sm text-accent-critical">
+          {error}
+        </p>
+      ) : null}
+    </form>
+  );
+}

--- a/packages/ui/src/components/common/__tests__/InlineRenameField.test.tsx
+++ b/packages/ui/src/components/common/__tests__/InlineRenameField.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { InlineRenameField } from "@ui/components/common/InlineRenameField";
+
+describe("InlineRenameField", () => {
+  it("renders rename button and toggles to input when editing", () => {
+    const onSubmit = vi.fn();
+    render(
+      <InlineRenameField name="Green Harbor" label="Structure" onSubmit={onSubmit} />
+    );
+
+    expect(screen.getByRole("heading", { name: /green harbor/i })).toBeInTheDocument();
+    const button = screen.getByRole("button", { name: /rename/i });
+    fireEvent.click(button);
+
+    const input = screen.getByRole("textbox", { name: /rename structure/i });
+    expect(input).toHaveValue("Green Harbor");
+  });
+
+  it("validates empty and invalid names", () => {
+    const onSubmit = vi.fn();
+    render(
+      <InlineRenameField name="Green Harbor" label="Structure" onSubmit={onSubmit} />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /rename/i }));
+
+    const input = screen.getByRole("textbox", { name: /rename structure/i });
+    fireEvent.change(input, { target: { value: "" } });
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(screen.getByText(/cannot be empty/i)).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    fireEvent.change(input, { target: { value: "Green Harbor!!!" } });
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    expect(screen.getByText(/unsupported characters/i)).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("submits trimmed name", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(
+      <InlineRenameField name="Green Harbor" label="Structure" onSubmit={onSubmit} />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /rename/i }));
+    const input = screen.getByRole("textbox", { name: /rename structure/i });
+    fireEvent.change(input, { target: { value: "  Harbor West  " } });
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await screen.findByRole("button", { name: /rename/i });
+    expect(onSubmit).toHaveBeenCalledWith("Harbor West");
+  });
+
+  it("displays submission errors", async () => {
+    const onSubmit = vi.fn().mockRejectedValue(new Error("Transport offline"));
+    render(
+      <InlineRenameField name="Green Harbor" label="Structure" onSubmit={onSubmit} />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /rename/i }));
+    fireEvent.change(screen.getByRole("textbox", { name: /rename structure/i }), {
+      target: { value: "Harbor East" }
+    });
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(await screen.findByText(/transport offline/i)).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/flows/ZoneMoveDialog.tsx
+++ b/packages/ui/src/components/flows/ZoneMoveDialog.tsx
@@ -1,0 +1,250 @@
+import { useEffect, useMemo, useState, type FormEvent, type ReactElement } from "react";
+import { AlertTriangle, ArrowRight, DoorOpen } from "lucide-react";
+import type { IntentClient } from "@ui/transport";
+import { submitIntentOrThrow } from "@ui/lib/intentSubmission";
+import type { RoomReadModel } from "@ui/state/readModels.types";
+
+interface ZoneMoveOption {
+  readonly roomId: string;
+  readonly roomName: string;
+  readonly purpose: string;
+  readonly areaFree: number;
+  readonly disabled: boolean;
+  readonly reason: string | null;
+}
+
+export interface ZoneMoveDialogProps {
+  readonly isOpen: boolean;
+  readonly structureId: string;
+  readonly zoneId: string;
+  readonly zoneName: string;
+  readonly zoneArea: number;
+  readonly currentRoomId: string | null;
+  readonly rooms: readonly RoomReadModel[];
+  readonly intentClient: IntentClient | null;
+  readonly onClose: () => void;
+}
+
+const areaFormatter = new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 });
+
+function formatArea(value: number): string {
+  return `${areaFormatter.format(value)} m²`;
+}
+
+function buildOptions(
+  rooms: readonly RoomReadModel[],
+  currentRoomId: string | null,
+  zoneArea: number
+): readonly ZoneMoveOption[] {
+  return rooms
+    .map((room) => {
+      if (room.id === currentRoomId) {
+        return {
+          roomId: room.id,
+          roomName: room.name,
+          purpose: room.purpose,
+          areaFree: room.capacity.areaFree_m2,
+          disabled: true,
+          reason: "Zone already assigned to this room."
+        } satisfies ZoneMoveOption;
+      }
+
+      if (room.purpose !== "growroom") {
+        return {
+          roomId: room.id,
+          roomName: room.name,
+          purpose: room.purpose,
+          areaFree: room.capacity.areaFree_m2,
+          disabled: true,
+          reason: "Room purpose does not support zones."
+        } satisfies ZoneMoveOption;
+      }
+
+      if (room.capacity.areaFree_m2 < zoneArea) {
+        const deficit = Math.max(0, zoneArea - room.capacity.areaFree_m2);
+        return {
+          roomId: room.id,
+          roomName: room.name,
+          purpose: room.purpose,
+          areaFree: room.capacity.areaFree_m2,
+          disabled: true,
+          reason: `Requires ${formatArea(zoneArea)} free. Short by ${formatArea(deficit)}.`
+        } satisfies ZoneMoveOption;
+      }
+
+      return {
+        roomId: room.id,
+        roomName: room.name,
+        purpose: room.purpose,
+        areaFree: room.capacity.areaFree_m2,
+        disabled: false,
+        reason: null
+      } satisfies ZoneMoveOption;
+    })
+    .sort((left, right) => left.roomName.localeCompare(right.roomName));
+}
+
+export function ZoneMoveDialog({
+  isOpen,
+  structureId,
+  zoneId,
+  zoneName,
+  zoneArea,
+  currentRoomId,
+  rooms,
+  intentClient,
+  onClose
+}: ZoneMoveDialogProps): ReactElement | null {
+  const options = useMemo(
+    () => buildOptions(rooms, currentRoomId, zoneArea),
+    [rooms, currentRoomId, zoneArea]
+  );
+  const [selectedRoomId, setSelectedRoomId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setSelectedRoomId(null);
+      setError(null);
+      setIsSubmitting(false);
+    }
+  }, [isOpen, zoneId]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const selectedOption = options.find((option) => option.roomId === selectedRoomId) ?? null;
+  const intentsUnavailable = intentClient === null;
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!selectedRoomId) {
+      setError("Select a destination room.");
+      return;
+    }
+
+    if (selectedOption?.disabled) {
+      setError(selectedOption.reason ?? "Selected room cannot host this zone.");
+      return;
+    }
+
+    if (!intentClient) {
+      setError("Intent transport unavailable.");
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      setError(null);
+      await submitIntentOrThrow(intentClient, {
+        type: "intent.zone.move.v1",
+        structureId,
+        zoneId,
+        targetRoomId: selectedRoomId
+      });
+      onClose();
+    } catch (reason) {
+      const message = reason instanceof Error ? reason.message : String(reason);
+      setError(message.length > 0 ? message : "Failed to submit zone move intent.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div role="dialog" aria-modal="true" className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-xl space-y-4 rounded-xl border border-border-base bg-canvas-base p-6 shadow-lg"
+        aria-label={`Move zone ${zoneName}`}
+      >
+        <div className="flex items-center gap-2">
+          <DoorOpen aria-hidden="true" className="size-5 text-accent-primary" />
+          <h2 className="text-lg font-semibold text-text-primary">Move zone</h2>
+        </div>
+        <p className="text-sm text-text-muted">
+          Select a destination room within this structure. Targets must be growrooms with enough free area to host the
+          zone footprint of {formatArea(zoneArea)}.
+        </p>
+        <fieldset className="space-y-3">
+          <legend className="text-sm font-semibold text-text-primary">Eligible rooms</legend>
+          {options.length === 0 ? (
+            <p className="text-sm text-text-muted">No rooms available in this structure.</p>
+          ) : (
+            <ul className="space-y-2">
+              {options.map((option) => (
+                <li key={option.roomId}>
+                  <label
+                    className={`flex cursor-pointer flex-col gap-1 rounded-lg border p-3 transition ${
+                      option.disabled
+                        ? "border-border-base bg-canvas-subtle text-text-muted"
+                        : "border-border-base bg-canvas-base hover:border-accent-primary/40 hover:bg-canvas-subtle"
+                    }`}
+                  >
+                    <div className="flex items-center gap-2">
+                      <input
+                        type="radio"
+                        name="zone-move-target"
+                        value={option.roomId}
+                        checked={selectedRoomId === option.roomId}
+                        onChange={() => {
+                          setSelectedRoomId(option.roomId);
+                          setError(null);
+                        }}
+                        disabled={option.disabled}
+                      />
+                      <span className="text-sm font-medium text-text-primary">{option.roomName}</span>
+                      <ArrowRight aria-hidden="true" className="size-4 text-text-muted" />
+                      <span className="text-xs uppercase tracking-[0.18em] text-accent-muted">{option.purpose}</span>
+                    </div>
+                    <div className="text-xs text-text-muted">
+                      Free area: {formatArea(option.areaFree)}
+                    </div>
+                    {option.disabled && option.reason ? (
+                      <div className="flex items-center gap-1 text-xs text-accent-critical">
+                        <AlertTriangle aria-hidden="true" className="size-3" />
+                        <span>{option.reason}</span>
+                      </div>
+                    ) : null}
+                  </label>
+                </li>
+              ))}
+            </ul>
+          )}
+        </fieldset>
+
+        {error ? <p className="text-sm text-accent-critical">{error}</p> : null}
+        {intentsUnavailable ? (
+          <p className="text-xs text-text-muted">Intents offline. Connect to transport to move zones.</p>
+        ) : null}
+
+        <div className="flex items-center justify-end gap-2">
+          <button
+            type="button"
+            className="inline-flex items-center gap-2 rounded-lg border border-border-base bg-canvas-base px-3 py-1 text-sm text-text-muted transition hover:border-border-strong hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-canvas-raised"
+            onClick={() => {
+              setSelectedRoomId(null);
+              setError(null);
+              onClose();
+            }}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="inline-flex items-center gap-2 rounded-lg border border-accent-primary/60 bg-accent-primary/10 px-4 py-2 text-sm font-semibold text-text-primary transition hover:border-accent-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-canvas-raised disabled:opacity-60"
+            disabled={
+              isSubmitting || intentsUnavailable || !selectedRoomId || (selectedOption?.disabled ?? false)
+            }
+          >
+            Move zone
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/packages/ui/src/components/flows/__tests__/ZoneMoveDialog.test.tsx
+++ b/packages/ui/src/components/flows/__tests__/ZoneMoveDialog.test.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ZoneMoveDialog } from "@ui/components/flows/ZoneMoveDialog";
+import { deterministicReadModelSnapshot } from "@ui/test-utils/readModelFixtures";
+import type { IntentClient } from "@ui/transport";
+import type { RoomReadModel } from "@ui/state/readModels.types";
+
+function createIntentClientStub(): { client: IntentClient; submit: ReturnType<typeof vi.fn> } {
+  const submit = vi.fn(async () => ({ ok: true }));
+  const client: IntentClient = {
+    submit,
+    async disconnect() {
+      return Promise.resolve();
+    }
+  } satisfies IntentClient;
+  return { client, submit };
+}
+
+describe("ZoneMoveDialog", () => {
+  it("disables rooms that cannot host zones", () => {
+    const structure = deterministicReadModelSnapshot.structures[0];
+    const { client } = createIntentClientStub();
+
+    render(
+      <ZoneMoveDialog
+        isOpen
+        structureId={structure.id}
+        zoneId="zone-veg-a-1"
+        zoneName="Veg A-1"
+        zoneArea={180}
+        currentRoomId="room-veg-a"
+        rooms={structure.rooms}
+        intentClient={client}
+        onClose={() => {}}
+      />
+    );
+
+    const storageroomOption = screen.getByRole("radio", { name: /post-processing/i });
+    expect(storageroomOption).toBeDisabled();
+    expect(screen.getByText(/purpose does not support zones/i)).toBeInTheDocument();
+  });
+
+  it("submits move intent for eligible target", async () => {
+    const structure = deterministicReadModelSnapshot.structures[0];
+    const baseRoom = JSON.parse(JSON.stringify(structure.rooms[0])) as RoomReadModel;
+    const targetRoom: RoomReadModel = {
+      ...baseRoom,
+      id: "room-target",
+      name: "Expansion Bay",
+      capacity: {
+        ...baseRoom.capacity,
+        areaFree_m2: 500
+      },
+      zones: []
+    };
+    const rooms: RoomReadModel[] = [
+      { ...baseRoom, capacity: { ...baseRoom.capacity, areaFree_m2: 120 } },
+      targetRoom
+    ];
+    const stub = createIntentClientStub();
+    const onClose = vi.fn();
+
+    render(
+      <ZoneMoveDialog
+        isOpen
+        structureId={structure.id}
+        zoneId="zone-veg-a-1"
+        zoneName="Veg A-1"
+        zoneArea={100}
+        currentRoomId="room-veg-a"
+        rooms={rooms}
+        intentClient={stub.client}
+        onClose={onClose}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: /expansion bay/i }));
+    fireEvent.click(screen.getByRole("button", { name: /move zone/i }));
+
+    expect(stub.submit).toHaveBeenCalledWith(
+      {
+        type: "intent.zone.move.v1",
+        structureId: structure.id,
+        zoneId: "zone-veg-a-1",
+        targetRoomId: "room-target"
+      },
+      expect.any(Object)
+    );
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/rooms/RoomHeader.tsx
+++ b/packages/ui/src/components/rooms/RoomHeader.tsx
@@ -1,33 +1,15 @@
-import { useEffect, useState, type FormEvent, type ReactElement } from "react";
-import { DoorOpen, Pencil, X } from "lucide-react";
+import type { ReactElement } from "react";
+import { DoorOpen } from "lucide-react";
 import type { RoomDetailHeader } from "@ui/pages/roomDetailHooks";
+import { InlineRenameField } from "@ui/components/common/InlineRenameField";
 
 export interface RoomHeaderProps {
   readonly header: RoomDetailHeader;
-  readonly onRename: (nextName: string) => void;
+  readonly onRename: (nextName: string) => Promise<void>;
   readonly renameDisabledReason?: string;
 }
 
 export function RoomHeader({ header, onRename, renameDisabledReason }: RoomHeaderProps): ReactElement {
-  const [isEditing, setIsEditing] = useState(false);
-  const [draftName, setDraftName] = useState(header.roomName);
-
-  useEffect(() => {
-    setDraftName(header.roomName);
-    setIsEditing(false);
-  }, [header.roomName]);
-
-  function handleSubmit(event: FormEvent<HTMLFormElement>): void {
-    event.preventDefault();
-    const trimmed = draftName.trim();
-    if (!trimmed) {
-      return;
-    }
-
-    onRename(trimmed);
-    setIsEditing(false);
-  }
-
   const achTarget = header.achTarget;
   const achCurrent = header.achCurrent;
   const achPercent = achTarget > 0 ? Math.min(100, Math.round((achCurrent / achTarget) * 100)) : 0;
@@ -39,54 +21,13 @@ export function RoomHeader({ header, onRename, renameDisabledReason }: RoomHeade
       <div className="flex flex-wrap items-center gap-4">
         <div className="flex items-center gap-3">
           <DoorOpen aria-hidden="true" className="size-6 text-accent-primary" />
-          <form onSubmit={handleSubmit} className="flex items-center gap-2" aria-label="Rename room">
-            <label htmlFor="room-name-input" className="sr-only">
-              Room name
-            </label>
-            <input
-              id="room-name-input"
-              className="rounded-lg border border-border-base bg-canvas-base px-3 py-1 text-3xl font-semibold text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-canvas-raised"
-              value={draftName}
-              onChange={(event) => {
-                setDraftName(event.target.value);
-              }}
-              readOnly={!isEditing}
-              aria-disabled={!isEditing}
-            />
-            {isEditing ? (
-              <div className="flex items-center gap-2">
-                <button
-                  type="submit"
-                  className="inline-flex items-center gap-2 rounded-lg border border-accent-primary/60 bg-accent-primary/10 px-3 py-1 text-sm font-medium text-text-primary transition hover:border-accent-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-canvas-raised"
-                >
-                  Save
-                </button>
-                <button
-                  type="button"
-                  className="inline-flex items-center gap-2 rounded-lg border border-border-base bg-canvas-base px-3 py-1 text-sm text-text-muted transition hover:border-border-strong hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-canvas-raised"
-                  onClick={() => {
-                    setIsEditing(false);
-                    setDraftName(header.roomName);
-                  }}
-                >
-                  <X aria-hidden="true" className="size-4" />
-                  Cancel
-                </button>
-              </div>
-            ) : (
-              <button
-                type="button"
-                className="inline-flex items-center gap-2 rounded-lg border border-border-base bg-canvas-base px-3 py-1 text-sm font-medium text-text-primary transition hover:border-accent-primary/40 hover:bg-canvas-subtle/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-canvas-raised"
-                onClick={() => {
-                  setIsEditing(true);
-                }}
-                title={renameDisabledReason}
-              >
-                <Pencil aria-hidden="true" className="size-4" />
-                Rename
-              </button>
-            )}
-          </form>
+          <InlineRenameField
+            name={header.roomName}
+            label="Room name"
+            renameLabel="Rename"
+            disabledReason={renameDisabledReason}
+            onSubmit={onRename}
+          />
         </div>
       </div>
 

--- a/packages/ui/src/components/zones/ZoneHeader.tsx
+++ b/packages/ui/src/components/zones/ZoneHeader.tsx
@@ -1,19 +1,28 @@
 import type { ReactElement } from "react";
 import { Leaf } from "lucide-react";
 import type { ZoneBadge, ZoneHeaderSnapshot } from "@ui/pages/zoneDetailHooks";
+import { InlineRenameField } from "@ui/components/common/InlineRenameField";
 
 export interface ZoneHeaderProps {
   readonly header: ZoneHeaderSnapshot;
+  readonly onRename: (nextName: string) => Promise<void>;
+  readonly renameDisabledReason?: string;
 }
 
-export function ZoneHeader({ header }: ZoneHeaderProps): ReactElement {
+export function ZoneHeader({ header, onRename, renameDisabledReason }: ZoneHeaderProps): ReactElement {
   return (
     <header className="space-y-4" aria-label={`Zone header for ${header.zoneName}`}>
       <div className="space-y-2">
         <p className="text-sm uppercase tracking-[0.25em] text-accent-muted">{header.structureName}</p>
         <div className="flex items-center gap-3">
           <Leaf aria-hidden="true" className="size-6 text-accent-primary" />
-          <h2 className="text-3xl font-semibold text-text-primary">{header.zoneName}</h2>
+          <InlineRenameField
+            name={header.zoneName}
+            label="Zone name"
+            renameLabel="Rename"
+            disabledReason={renameDisabledReason}
+            onSubmit={onRename}
+          />
         </div>
         <p className="text-sm text-text-muted">
           {header.cultivarLabel} · {header.stageLabel} stage

--- a/packages/ui/src/lib/intentSubmission.ts
+++ b/packages/ui/src/lib/intentSubmission.ts
@@ -1,0 +1,17 @@
+import type { IntentClient, IntentSubmissionHandlers } from "@ui/transport";
+
+const handlers: IntentSubmissionHandlers = {
+  onResult() {
+    // Acknowledgement handled via resolved result
+  }
+};
+
+export async function submitIntentOrThrow(
+  intentClient: IntentClient,
+  payload: Record<string, unknown>
+): Promise<void> {
+  const result = await intentClient.submit(payload, handlers);
+  if (!result.ok) {
+    throw new Error(result.dictionary.description);
+  }
+}

--- a/packages/ui/src/routes/WorkforceRoute.tsx
+++ b/packages/ui/src/routes/WorkforceRoute.tsx
@@ -1,25 +1,8 @@
 import type { ReactElement } from "react";
 import { WorkforcePage } from "@ui/pages/WorkforcePage";
-import { createIntentClient, type IntentClient } from "@ui/transport";
-
-const runtimeBaseUrl = (() => {
-  const configured = import.meta.env.VITE_TRANSPORT_BASE_URL as string | undefined;
-
-  if (configured && configured.length > 0) {
-    return configured;
-  }
-
-  if (typeof window !== "undefined" && window.location.origin) {
-    return window.location.origin;
-  }
-
-  return undefined;
-})();
-
-const intentClient: IntentClient | null = runtimeBaseUrl
-  ? createIntentClient({ baseUrl: runtimeBaseUrl })
-  : null;
+import { useIntentClient } from "@ui/transport";
 
 export function WorkforceRoute(): ReactElement {
+  const intentClient = useIntentClient();
   return <WorkforcePage intentClient={intentClient} />;
 }

--- a/packages/ui/src/transport/IntentClientContext.tsx
+++ b/packages/ui/src/transport/IntentClientContext.tsx
@@ -1,0 +1,18 @@
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+import type { IntentClient } from "@ui/transport/intentClient";
+
+const IntentClientContext = createContext<IntentClient | null>(null);
+
+export interface IntentClientProviderProps {
+  readonly client: IntentClient | null;
+  readonly children: ReactNode;
+}
+
+export function IntentClientProvider({ client, children }: IntentClientProviderProps) {
+  const value = useMemo(() => client, [client]);
+  return <IntentClientContext.Provider value={value}>{children}</IntentClientContext.Provider>;
+}
+
+export function useIntentClient(): IntentClient | null {
+  return useContext(IntentClientContext);
+}

--- a/packages/ui/src/transport/index.ts
+++ b/packages/ui/src/transport/index.ts
@@ -11,6 +11,7 @@ export {
   type SuccessfulIntentAck,
   type FailedIntentAck
 } from "./intentClient";
+export { IntentClientProvider, useIntentClient } from "./IntentClientContext";
 export {
   createReadModelClient,
   type ReadModelClientOptions,


### PR DESCRIPTION
## Summary
- add a shared intent client provider so workspace routes can submit intents
- introduce an inline rename field and wire structure, room, and zone headers to rename intents
- add a zone movement dialog with same-structure eligibility messaging and deterministic coverage
- refresh the changelog entry for Task 8000

## Testing
- pnpm install
- pnpm -w lint *(fails: baseline ESLint violations in backend/facade packages)*
- pnpm -w -r typecheck *(fails: baseline engine schema typing errors)*
- pnpm -w -r test *(interrupted after long-running recursive suite)*
- pnpm -w -r build *(fails: engine TypeScript build errors)*

------
https://chatgpt.com/codex/tasks/task_e_68f0eece38748325af5545a54ef57fe4