### PR TITLE
fix: stabilize rename controls and workforce tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,16 @@
 
 ### Unreleased — Hotfix Batch 03
 
+- HOTFIX-046: Hardened UI rename and workforce flows after regression triage.
+  Inline rename now permits editing while the intent transport is offline and
+  surfaces the outage as a muted hint instead of blocking accessibility.
+  Workforce page tests dropped the `@testing-library/user-event` dependency in
+  favour of deterministic `fireEvent` helpers with explicit `waitFor`
+  assertions, and the zone move dialog suite now awaits async submissions to
+  satisfy React's act() guard (`packages/ui/src/components/common/InlineRenameField.tsx`,
+  `packages/ui/src/pages/__tests__/WorkforcePage.test.tsx`,
+  `packages/ui/src/components/flows/__tests__/ZoneMoveDialog.test.tsx`).
+
 - Task 6000: Replaced the workforce KPI shell with the HR directory, activity
   timeline, task queues, capacity snapshot, and action panel. Introduced
   workforce filter state via Zustand, wired the HR route to the new intent

--- a/packages/ui/src/components/common/InlineRenameField.tsx
+++ b/packages/ui/src/components/common/InlineRenameField.tsx
@@ -56,6 +56,12 @@ export function InlineRenameField({
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+
+    if (disabledReason) {
+      setError(disabledReason);
+      return;
+    }
+
     const validationError = validateName(draft, maxLength);
     if (validationError) {
       setError(validationError);
@@ -95,7 +101,7 @@ export function InlineRenameField({
             setDraft(name);
             setError(null);
           }}
-          disabled={Boolean(disabledReason)}
+          aria-disabled={Boolean(disabledReason)}
           title={disabledReason}
         >
           <Pencil aria-hidden="true" className="size-4" />
@@ -106,11 +112,7 @@ export function InlineRenameField({
   }
 
   return (
-    <form
-      onSubmit={handleSubmit}
-      className="flex items-center gap-2"
-      aria-label={`Rename ${label.toLowerCase()}`}
-    >
+    <form onSubmit={handleSubmit} className="flex items-center gap-2">
       <label htmlFor={inputId} className="sr-only">
         {label}
       </label>
@@ -130,7 +132,7 @@ export function InlineRenameField({
         <button
           type="submit"
           className="inline-flex items-center gap-2 rounded-lg border border-accent-primary/60 bg-accent-primary/10 px-3 py-1 text-sm font-medium text-text-primary transition hover:border-accent-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-canvas-raised disabled:opacity-60"
-          disabled={isSubmitting}
+          disabled={isSubmitting || Boolean(disabledReason)}
         >
           {submitLabel}
         </button>
@@ -152,6 +154,9 @@ export function InlineRenameField({
         <p id={`${inputId}-error`} className="text-sm text-accent-critical">
           {error}
         </p>
+      ) : null}
+      {disabledReason && !error ? (
+        <p className="text-xs text-text-muted">{disabledReason}</p>
       ) : null}
     </form>
   );

--- a/packages/ui/src/components/flows/__tests__/ZoneMoveDialog.test.tsx
+++ b/packages/ui/src/components/flows/__tests__/ZoneMoveDialog.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ZoneMoveDialog } from "@ui/components/flows/ZoneMoveDialog";
 import { deterministicReadModelSnapshot } from "@ui/test-utils/readModelFixtures";
@@ -77,15 +77,17 @@ describe("ZoneMoveDialog", () => {
     fireEvent.click(screen.getByRole("radio", { name: /expansion bay/i }));
     fireEvent.click(screen.getByRole("button", { name: /move zone/i }));
 
-    expect(stub.submit).toHaveBeenCalledWith(
-      {
-        type: "intent.zone.move.v1",
-        structureId: structure.id,
-        zoneId: "zone-veg-a-1",
-        targetRoomId: "room-target"
-      },
-      expect.any(Object)
-    );
-    expect(onClose).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(stub.submit).toHaveBeenCalledWith(
+        {
+          type: "intent.zone.move.v1",
+          structureId: structure.id,
+          zoneId: "zone-veg-a-1",
+          targetRoomId: "room-target"
+        },
+        expect.any(Object)
+      );
+      expect(onClose).toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- keep the inline rename form accessible when the intent transport is offline by deferring submit and showing the disabled reason
- migrate the workforce page tests off of @testing-library/user-event, using fireEvent + waitFor and aligning expectations with the rendered copy
- wait for the zone move dialog submission side-effect in its test suite and document the hotfix in the CHANGELOG

## Testing
- pnpm --filter @wb/ui test

------
https://chatgpt.com/codex/tasks/task_e_68f1a2cbfa4483259e0a2753590a08c2