### PR TITLE
fix: expose critical palette tokens to tailwind

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,12 @@
   satisfy React's act() guard (`packages/ui/src/components/common/InlineRenameField.tsx`,
   `packages/ui/src/pages/__tests__/WorkforcePage.test.tsx`,
   `packages/ui/src/components/flows/__tests__/ZoneMoveDialog.test.tsx`).
+- HOTFIX-052: Completed the foundation color tokens with warning/critical/success
+  variants across accent, border, text, and surface palettes so Tailwind can
+  materialise the `accent-critical` utilities referenced by structure capacity
+  styling. Updated the Tailwind config to surface the new palette branch for
+  background helpers (`packages/ui/src/design/tokens.ts`,
+  `packages/ui/tailwind.config.ts`).
 
 - Task 6000: Replaced the workforce KPI shell with the HR directory, activity
   timeline, task queues, capacity snapshot, and action panel. Introduced

--- a/packages/ui/src/design/tokens.ts
+++ b/packages/ui/src/design/tokens.ts
@@ -7,14 +7,25 @@ export const foundationTheme = {
     },
     accent: {
       primary: "#16a34a",
-      muted: "#bbf7d0"
+      muted: "#bbf7d0",
+      warning: "#f59e0b",
+      critical: "#ef4444"
     },
     border: {
-      base: "#1f2937"
+      base: "#1f2937",
+      subtle: "#243046",
+      strong: "#334155",
+      success: "#16a34a"
     },
     text: {
       primary: "#f9fafb",
-      muted: "#9ca3af"
+      muted: "#9ca3af",
+      critical: "#fca5a5",
+      success: "#bbf7d0"
+    },
+    surface: {
+      critical: "#ef4444",
+      success: "#16a34a"
     }
   },
   fontFamily: {

--- a/packages/ui/tailwind.config.ts
+++ b/packages/ui/tailwind.config.ts
@@ -14,7 +14,8 @@ const config: Config = {
         canvas: foundationTheme.colors.canvas,
         accent: foundationTheme.colors.accent,
         border: foundationTheme.colors.border,
-        text: foundationTheme.colors.text
+        text: foundationTheme.colors.text,
+        surface: foundationTheme.colors.surface
       },
       fontFamily,
       borderRadius: foundationTheme.borderRadius,


### PR DESCRIPTION
## Summary
- extend the foundation theme with warning, critical, and success color variants so accent-critical utilities compile
- surface the new surface palette branch through the Tailwind config for background helpers
- document the palette hotfix in the UI changelog

## Testing
- pnpm --filter ui build *(fails: vite not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f1a57ab2208325afcc2114f9282282