### PR TITLE
feat(facade): forward transport intents to engine pipeline

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -52,6 +52,19 @@
   `packages/facade/src/server/readModelProviders.ts`,
   `packages/facade/tests/unit/server/readModelProviders.test.ts`, `README.md`).
 
+- Task 0084: Wired the façade transport dev server to the engine workforce
+  command pipeline by replacing the console stub with an intent normaliser that
+  validates hiring and workforce raise/termination payloads, queues them via
+  the engine run context, and advances the simulation deterministically on every
+  submission. Added unit and integration tests proving intents are forwarded and
+  failures propagate through the Socket.IO acknowledgement contract, and updated
+  the dev stack documentation to reflect the new behaviour
+  (`packages/facade/src/transport/engineCommandPipeline.ts`,
+  `packages/facade/src/transport/devServer.ts`,
+  `packages/facade/tests/unit/transport/engineCommandPipeline.test.ts`,
+  `packages/facade/tests/integration/transport/intentForwarding.integration.test.ts`,
+  `docs/tools/dev-stack.md`).
+
 - Task 6000: Replaced the workforce KPI shell with the HR directory, activity
   timeline, task queues, capacity snapshot, and action panel. Introduced
   workforce filter state via Zustand, wired the HR route to the new intent

--- a/docs/tools/dev-stack.md
+++ b/docs/tools/dev-stack.md
@@ -34,5 +34,9 @@ Adjust behaviour via the following environment variables:
   health endpoint (defaults to `http://localhost:5173`).
 
 The server currently exposes the `/telemetry` (read-only) and `/intents`
-namespaces. Intents are accepted but not processed until downstream tracks wire
-an intent handler. Shutdown is triggered via `SIGINT`/`SIGTERM`.
+namespaces. Intents are normalised against the façade's workforce command
+pipeline: valid submissions queue engine intents, advance the simulation by one
+deterministic tick, and acknowledge with `{ ok: true }`. Payload validation
+failures or unsupported intent types reject with
+`WB_INTENT_HANDLER_ERROR` acknowledgements, mirroring the Socket.IO contract
+described in SEC/TDD. Shutdown is triggered via `SIGINT`/`SIGTERM`.

--- a/packages/facade/src/transport/engineCommandPipeline.ts
+++ b/packages/facade/src/transport/engineCommandPipeline.ts
@@ -1,0 +1,192 @@
+import { z } from 'zod';
+
+/* eslint-disable wb-sim/no-ts-import-js-extension */
+
+import { type SimulationWorld, type WorkforceIntent, uuidSchema } from '@wb/engine';
+import { runTick, type EngineRunContext } from '@/backend/src/engine/Engine.ts';
+import { queueWorkforceIntents } from '@/backend/src/engine/pipeline/applyWorkforce.ts';
+
+import type { TransportIntentEnvelope } from './adapter.js';
+
+/**
+ * Runtime contract consumed by {@link createEngineCommandPipeline} to access and mutate the
+ * backing simulation world. The façade dev transport server wires this against the demo
+ * harness world to keep intent forwarding deterministic.
+ */
+export interface EngineWorldAccess {
+  /** Returns the current simulation world snapshot. */
+  readonly get: () => SimulationWorld;
+  /** Persists the next simulation world snapshot after processing an intent. */
+  readonly set: (world: SimulationWorld) => void;
+}
+
+/**
+ * Options accepted by {@link createEngineCommandPipeline}.
+ */
+export interface EngineCommandPipelineOptions {
+  /** Read/write accessors for the simulation world handled by the façade. */
+  readonly world: EngineWorldAccess;
+  /** Optional engine run context shared across ticks. Defaults to an empty context. */
+  readonly context?: EngineRunContext;
+}
+
+/**
+ * Runtime command pipeline that normalises transport intents and forwards them to the engine.
+ */
+export interface EngineCommandPipeline {
+  /** Engine execution context reused across intent submissions. */
+  readonly context: EngineRunContext;
+  /**
+   * Normalises and queues the provided transport intent before advancing the engine pipeline.
+   *
+   * @throws {Error} When the intent type is unsupported or fails validation.
+   */
+  handle(intent: TransportIntentEnvelope): Promise<void>;
+}
+
+const hiringMarketScanSchema = z.object({
+  structureId: uuidSchema,
+});
+
+const hiringMarketHireSchema = z.object({
+  candidate: z.object({
+    structureId: uuidSchema,
+    candidateId: uuidSchema,
+  }),
+});
+
+const workforceRaiseAcceptSchema = z.object({
+  employeeId: uuidSchema,
+  rateIncreaseFactor: z.number().finite().optional(),
+  moraleBoost01: z.number().finite().optional(),
+});
+
+const workforceRaiseBonusSchema = z.object({
+  employeeId: uuidSchema,
+  bonusAmount_cc: z.number().finite().optional(),
+  rateIncreaseFactor: z.number().finite().optional(),
+  moraleBoost01: z.number().finite().optional(),
+});
+
+const workforceRaiseIgnoreSchema = z.object({
+  employeeId: uuidSchema,
+  moralePenalty01: z.number().finite().optional(),
+});
+
+const workforceTerminationSchema = z.object({
+  employeeId: uuidSchema,
+  reasonSlug: z.string().trim().min(1).optional(),
+  severanceCc: z.number().finite().optional(),
+  moraleRipple01: z.number().finite().optional(),
+});
+
+function toWorkforceIntent(envelope: TransportIntentEnvelope): WorkforceIntent | null {
+  switch (envelope.type) {
+    case 'hiring.market.scan': {
+      const { structureId } = hiringMarketScanSchema.parse(envelope);
+      return { type: 'hiring.market.scan', structureId } satisfies WorkforceIntent;
+    }
+
+    case 'hiring.market.hire': {
+      const { candidate } = hiringMarketHireSchema.parse(envelope);
+      return { type: 'hiring.market.hire', candidate } satisfies WorkforceIntent;
+    }
+
+    case 'workforce.raise.accept': {
+      const { employeeId, rateIncreaseFactor, moraleBoost01 } = workforceRaiseAcceptSchema.parse(envelope);
+      return {
+        type: 'workforce.raise.accept',
+        employeeId,
+        rateIncreaseFactor,
+        moraleBoost01,
+      } satisfies WorkforceIntent;
+    }
+
+    case 'workforce.raise.bonus': {
+      const {
+        employeeId,
+        bonusAmount_cc: bonusAmountCc,
+        rateIncreaseFactor,
+        moraleBoost01,
+      } = workforceRaiseBonusSchema.parse(envelope);
+
+      return {
+        type: 'workforce.raise.bonus',
+        employeeId,
+        bonusAmount_cc: bonusAmountCc,
+        rateIncreaseFactor,
+        moraleBoost01,
+      } satisfies WorkforceIntent;
+    }
+
+    case 'workforce.raise.ignore': {
+      const { employeeId, moralePenalty01 } = workforceRaiseIgnoreSchema.parse(envelope);
+      return {
+        type: 'workforce.raise.ignore',
+        employeeId,
+        moralePenalty01,
+      } satisfies WorkforceIntent;
+    }
+
+    case 'workforce.employee.terminate': {
+      const {
+        employeeId,
+        reasonSlug,
+        severanceCc,
+        moraleRipple01,
+      } = workforceTerminationSchema.parse(envelope);
+      return {
+        type: 'workforce.employee.terminate',
+        employeeId,
+        reasonSlug,
+        severanceCc,
+        moraleRipple01,
+      } satisfies WorkforceIntent;
+    }
+
+    default:
+      return null;
+  }
+}
+
+function normaliseIntent(envelope: TransportIntentEnvelope): WorkforceIntent {
+  try {
+    const intent = toWorkforceIntent(envelope);
+
+    if (!intent) {
+      throw new Error(`Unsupported intent type: ${envelope.type}`);
+    }
+
+    return intent;
+  } catch (error: unknown) {
+    if (error instanceof z.ZodError) {
+      const issues = error.issues.map((issue) => issue.message).join('; ');
+      throw new Error(`Intent payload failed validation: ${issues}`);
+    }
+
+    throw error instanceof Error ? error : new Error(String(error));
+  }
+}
+
+/**
+ * Creates an engine-backed command pipeline that translates transport intents into engine
+ * intents before advancing the simulation by one deterministic tick per submission.
+ */
+export function createEngineCommandPipeline(
+  options: EngineCommandPipelineOptions,
+): EngineCommandPipeline {
+  const context: EngineRunContext = options.context ?? {};
+
+  return {
+    context,
+    async handle(envelope: TransportIntentEnvelope): Promise<void> {
+      const world = options.world.get();
+      const intent = normaliseIntent(envelope);
+
+      queueWorkforceIntents(context, [intent]);
+      const { world: nextWorld } = runTick(world, context);
+      options.world.set(nextWorld);
+    },
+  } satisfies EngineCommandPipeline;
+}
+

--- a/packages/facade/tests/integration/transport/intentForwarding.integration.test.ts
+++ b/packages/facade/tests/integration/transport/intentForwarding.integration.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+
+/* eslint-disable wb-sim/no-ts-import-js-extension */
+
+import { type EngineRunContext } from '@/backend/src/engine/Engine.ts';
+import { consumeWorkforceMarketCharges } from '@/backend/src/engine/pipeline/applyWorkforce.ts';
+import { createDemoWorld } from '@/backend/src/engine/testHarness.ts';
+
+import {
+  INTENT_EVENT,
+  SOCKET_ERROR_CODES,
+  type TransportAck,
+} from '../../../src/transport/adapter.ts';
+import { createEngineCommandPipeline } from '../../../src/transport/engineCommandPipeline.js';
+import {
+  createNamespaceClient,
+  createTransportHarness,
+  disconnectClient,
+} from './helpers.ts';
+
+describe('transport intent forwarding', () => {
+  it('acknowledges successful workforce intents after forwarding to the engine pipeline', async () => {
+    let world = createDemoWorld();
+    const context: EngineRunContext = {};
+    const pipeline = createEngineCommandPipeline({
+      world: {
+        get: () => world,
+        set(nextWorld) {
+          world = nextWorld;
+        },
+      },
+      context,
+    });
+
+    const structureId = world.company.structures[0]?.id;
+    if (!structureId) {
+      throw new Error('Demo world missing structure id for hiring market scan intent.');
+    }
+
+    const harness = await createTransportHarness((intent) => pipeline.handle(intent));
+    let client: Awaited<ReturnType<typeof createNamespaceClient>> | null = null;
+
+    try {
+      client = await createNamespaceClient(harness, '/intents');
+
+      const ack = await new Promise<TransportAck>((resolve) => {
+        client.emit(
+          INTENT_EVENT,
+          { type: 'hiring.market.scan', structureId },
+          (response: TransportAck) => {
+            resolve(response);
+          },
+        );
+      });
+
+      expect(ack).toEqual({ ok: true });
+
+      const charges = consumeWorkforceMarketCharges(context);
+      expect(charges).toBeDefined();
+      expect(charges).not.toHaveLength(0);
+      expect(charges?.[0]).toMatchObject({ structureId });
+    } finally {
+      if (client) {
+        await disconnectClient(client);
+      }
+      await harness.close();
+    }
+  });
+
+  it('propagates pipeline failures as deterministic transport errors', async () => {
+    let world = createDemoWorld();
+    const context: EngineRunContext = {};
+    const pipeline = createEngineCommandPipeline({
+      world: {
+        get: () => world,
+        set(nextWorld) {
+          world = nextWorld;
+        },
+      },
+      context,
+    });
+
+    const harness = await createTransportHarness((intent) => pipeline.handle(intent));
+    let client: Awaited<ReturnType<typeof createNamespaceClient>> | null = null;
+
+    try {
+      client = await createNamespaceClient(harness, '/intents');
+
+      const ack = await new Promise<TransportAck>((resolve) => {
+        client.emit(INTENT_EVENT, { type: 'hiring.market.scan' }, (response: TransportAck) => {
+          resolve(response);
+        });
+      });
+
+      expect(ack.ok).toBe(false);
+      expect(ack.error?.code).toBe(SOCKET_ERROR_CODES.INTENT_HANDLER_ERROR);
+      expect(ack.error?.message).toMatch(/validation/i);
+    } finally {
+      if (client) {
+        await disconnectClient(client);
+      }
+      await harness.close();
+    }
+  });
+});
+

--- a/packages/facade/tests/unit/transport/engineCommandPipeline.test.ts
+++ b/packages/facade/tests/unit/transport/engineCommandPipeline.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+/* eslint-disable wb-sim/no-ts-import-js-extension */
+
+import { DEFAULT_WORKFORCE_CONFIG } from '@/backend/src/config/workforce.ts';
+import { consumeWorkforceMarketCharges } from '@/backend/src/engine/pipeline/applyWorkforce.ts';
+import { createDemoWorld } from '@/backend/src/engine/testHarness.ts';
+
+import { createEngineCommandPipeline } from '../../../src/transport/engineCommandPipeline.js';
+
+describe('createEngineCommandPipeline', () => {
+  it('queues hiring market intents and advances the engine world', async () => {
+    const initialWorld = createDemoWorld();
+    let world = initialWorld;
+
+    const pipeline = createEngineCommandPipeline({
+      world: {
+        get: () => world,
+        set(nextWorld) {
+          world = nextWorld;
+        },
+      },
+    });
+
+    const structureId = initialWorld.company.structures[0]?.id;
+    if (!structureId) {
+      throw new Error('Demo world did not include a structure id for hiring intents.');
+    }
+
+    await pipeline.handle({ type: 'hiring.market.scan', structureId });
+
+    const charges = consumeWorkforceMarketCharges(pipeline.context);
+    expect(charges).toBeDefined();
+    expect(charges).not.toHaveLength(0);
+    expect(charges?.[0]).toMatchObject({
+      structureId,
+      amountCc: DEFAULT_WORKFORCE_CONFIG.market.scanCost_cc,
+    });
+
+    expect(world.workforce.market.structures).not.toEqual(
+      initialWorld.workforce.market.structures,
+    );
+  });
+
+  it('rejects unsupported intent types', async () => {
+    const initialWorld = createDemoWorld();
+    const pipeline = createEngineCommandPipeline({
+      world: {
+        get: () => initialWorld,
+        set() {
+          throw new Error('set should not be called for unsupported intents');
+        },
+      },
+    });
+
+    await expect(
+      pipeline.handle({ type: 'unknown.intent', attempt: true }),
+    ).rejects.toThrow(/Unsupported intent type/i);
+  });
+
+  it('rejects malformed workforce payloads with validation errors', async () => {
+    let world = createDemoWorld();
+    const pipeline = createEngineCommandPipeline({
+      world: {
+        get: () => world,
+        set(next) {
+          world = next;
+        },
+      },
+    });
+
+    await expect(
+      pipeline.handle({ type: 'hiring.market.scan' }),
+    ).rejects.toThrow(/failed validation/i);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add an engine-backed command pipeline that normalises transport intents and advances the simulation each submission
- hook the transport dev server to the new pipeline so intents forward deterministically
- add transport forwarding unit/integration coverage and document the updated behaviour in the dev stack guide

## Testing
- pnpm --filter @wb/facade test

------
https://chatgpt.com/codex/tasks/task_e_68f1b976f6f48325b6d634b8add25616