### PR TITLE
feat: wire economy snapshot to read-model store

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,14 @@
   background helpers (`packages/ui/src/design/tokens.ts`,
   `packages/ui/tailwind.config.ts`).
 
+- HOTFIX-061: Replaced the stubbed economy snapshot hook with a selector backed
+  by the read-model Zustand store so dashboard components render real balances
+  once `configureReadModelClient` and `refreshReadModels` complete, while keeping
+  override support for storybook/dev tooling. Added focused coverage ensuring the
+  hook reflects store updates and override merges
+  (`packages/ui/src/state/economy.ts`,
+  `packages/ui/src/state/__tests__/economySnapshot.test.tsx`).
+
 - Task 0071: Added a façade helper that composes the UI `ReadModelSnapshot`
   contract, exposed a `GET /api/read-models` endpoint validated by the shared
   guard, updated the dev server to publish the aggregated snapshot for local

--- a/packages/ui/src/state/__tests__/economySnapshot.test.tsx
+++ b/packages/ui/src/state/__tests__/economySnapshot.test.tsx
@@ -1,0 +1,86 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useEconomySnapshot } from "@ui/state/economy";
+import {
+  applyReadModelSnapshot,
+  resetReadModelStore
+} from "@ui/state/readModels";
+import type { EconomySnapshotOverrides } from "@ui/state/economy";
+import type { ReadModelSnapshot } from "@ui/state/readModels.types";
+import { deterministicReadModelSnapshot } from "@ui/test-utils/readModelFixtures";
+
+describe("useEconomySnapshot", () => {
+  beforeEach(() => {
+    resetReadModelStore();
+  });
+
+  it("returns the live economy snapshot by default", () => {
+    const { result } = renderHook(() => useEconomySnapshot());
+
+    expect(result.current).toEqual({
+      balance: deterministicReadModelSnapshot.economy.balance,
+      deltaPerHour: deterministicReadModelSnapshot.economy.deltaPerHour
+    });
+  });
+
+  it("reflects read-model updates", () => {
+    const { result } = renderHook(() => useEconomySnapshot());
+
+    const updatedSnapshot = structuredClone(
+      deterministicReadModelSnapshot
+    ) as ReadModelSnapshot;
+    updatedSnapshot.economy.balance = updatedSnapshot.economy.balance + 5000;
+    updatedSnapshot.economy.deltaPerHour =
+      updatedSnapshot.economy.deltaPerHour - 275;
+
+    act(() => {
+      applyReadModelSnapshot(updatedSnapshot);
+    });
+
+    expect(result.current).toEqual({
+      balance: updatedSnapshot.economy.balance,
+      deltaPerHour: updatedSnapshot.economy.deltaPerHour
+    });
+  });
+
+  it("merges overrides with the live snapshot", () => {
+    const baseEconomy = deterministicReadModelSnapshot.economy;
+    const initialOverrides: EconomySnapshotOverrides = {
+      balance: baseEconomy.balance + 2500
+    };
+
+    const { result, rerender } = renderHook(
+      ({ overrides }: { overrides: EconomySnapshotOverrides | undefined }) =>
+        useEconomySnapshot(overrides),
+      { initialProps: { overrides: initialOverrides } }
+    );
+
+    expect(result.current).toEqual({
+      balance: initialOverrides.balance!,
+      deltaPerHour: baseEconomy.deltaPerHour
+    });
+
+    const refreshedSnapshot = structuredClone(
+      deterministicReadModelSnapshot
+    ) as ReadModelSnapshot;
+    refreshedSnapshot.economy.balance = refreshedSnapshot.economy.balance - 1250;
+    refreshedSnapshot.economy.deltaPerHour =
+      refreshedSnapshot.economy.deltaPerHour + 180;
+
+    act(() => {
+      applyReadModelSnapshot(refreshedSnapshot);
+    });
+
+    expect(result.current).toEqual({
+      balance: initialOverrides.balance!,
+      deltaPerHour: refreshedSnapshot.economy.deltaPerHour
+    });
+
+    rerender({ overrides: undefined });
+
+    expect(result.current).toEqual({
+      balance: refreshedSnapshot.economy.balance,
+      deltaPerHour: refreshedSnapshot.economy.deltaPerHour
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- replace the UI economy snapshot stub with a hook that reads the live read-model Zustand store while preserving overrides
- add focused coverage to ensure the economy hook tracks store updates and merges overrides, and log the change in the changelog

## Testing
- pnpm --filter @wb/ui test -- packages/ui/src/state/__tests__/economySnapshot.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68f1bcf5a7cc8325a5b1ef073940c992