### PR TITLE
Expose telemetry publishing on façade transport dev server

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -72,6 +72,14 @@
   `packages/facade/tests/unit/transport/engineCommandPipeline.test.ts`,
   `packages/facade/tests/integration/transport/intentForwarding.integration.test.ts`,
   `docs/tools/dev-stack.md`).
+- Transport dev server: Exposed a `publishTelemetry` helper on the façade Socket.IO
+  server and bridged it through the dev command pipeline context so engine telemetry
+  envelopes forward to `/telemetry` subscribers. Added an integration test that boots
+  the dev server, drives a harvest tick via the intent namespace, and asserts the
+  emitted `telemetry:event` payload matches the deterministic harvest topic contract
+  (`packages/facade/src/transport/server.ts`,
+  `packages/facade/src/transport/devServer.ts`,
+  `packages/facade/tests/integration/transport/devServerTelemetry.integration.test.ts`).
 
 - Task 6000: Replaced the workforce KPI shell with the HR directory, activity
   timeline, task queues, capacity snapshot, and action panel. Introduced

--- a/packages/facade/src/transport/devServer.ts
+++ b/packages/facade/src/transport/devServer.ts
@@ -1,27 +1,70 @@
 import process from 'node:process';
+import { pathToFileURL } from 'node:url';
 /* eslint-disable wb-sim/no-ts-import-js-extension */
 
 import { type EngineRunContext } from '@/backend/src/engine/Engine.ts';
 import { createDemoWorld } from '@/backend/src/engine/testHarness.ts';
 
-import { createEngineCommandPipeline } from './engineCommandPipeline.js';
-import { createTransportServer, type TransportServer } from './server.js';
+import {
+  createEngineCommandPipeline,
+  type EngineCommandPipeline,
+} from './engineCommandPipeline.js';
+import {
+  createTransportServer,
+  type TransportCorsOptions,
+  type TransportServer,
+} from './server.js';
 
-const host = process.env.FACADE_TRANSPORT_HOST ?? '127.0.0.1';
-const port = Number.parseInt(process.env.FACADE_TRANSPORT_PORT ?? '7101', 10);
-const corsOrigin = process.env.FACADE_TRANSPORT_CORS_ORIGIN ?? 'http://localhost:5173';
+const DEFAULT_HOST = '127.0.0.1';
+const DEFAULT_PORT = 7101;
+const DEFAULT_CORS_ORIGIN = 'http://localhost:5173';
 
-function ensureError(candidate: unknown): Error {
-  return candidate instanceof Error ? candidate : new Error(String(candidate));
+type TelemetryEnvelope = Parameters<TransportServer['publishTelemetry']>[0];
+
+export interface StartFacadeDevServerOptions {
+  readonly host?: string;
+  readonly port?: number;
+  readonly cors?: TransportCorsOptions;
+  readonly corsOrigin?: string;
+  readonly world?: ReturnType<typeof createDemoWorld>;
+  readonly context?: EngineRunContext;
 }
 
-async function main(): Promise<void> {
-  if (!Number.isInteger(port) || port <= 0) {
-    throw new Error('FACADE_TRANSPORT_PORT must be a positive integer.');
-  }
+export interface FacadeDevServerInstance {
+  readonly server: TransportServer;
+  readonly pipeline: EngineCommandPipeline;
+  readonly context: EngineRunContext;
+  stop(): Promise<void>;
+}
 
-  let world = createDemoWorld();
-  const context: EngineRunContext = {};
+export async function startFacadeDevServer(
+  options: StartFacadeDevServerOptions = {}
+): Promise<FacadeDevServerInstance> {
+  let world = options.world ?? createDemoWorld();
+  const baseContext: EngineRunContext = options.context ?? {};
+  const upstreamTelemetry = baseContext.telemetry;
+  const pendingTelemetry: TelemetryEnvelope[] = [];
+  let publisher: TransportServer['publishTelemetry'] | null = null;
+
+  const telemetryBridge: EngineRunContext['telemetry'] = {
+    emit(topic, payload) {
+      const envelope: TelemetryEnvelope = { topic, payload };
+
+      if (publisher) {
+        publisher(envelope);
+      } else {
+        pendingTelemetry.push(envelope);
+      }
+
+      upstreamTelemetry?.emit(topic, payload);
+    },
+  } satisfies EngineRunContext['telemetry'];
+
+  const context: EngineRunContext = {
+    ...baseContext,
+    telemetry: telemetryBridge,
+  } satisfies EngineRunContext;
+
   const pipeline = createEngineCommandPipeline({
     world: {
       get: () => world,
@@ -32,14 +75,57 @@ async function main(): Promise<void> {
     context,
   });
 
-  const server: TransportServer = await createTransportServer({
-    host,
-    port,
-    cors: { origin: corsOrigin },
+  const cors: TransportCorsOptions | undefined = options.cors ?? {
+    origin: options.corsOrigin ?? DEFAULT_CORS_ORIGIN,
+  };
+
+  const server = await createTransportServer({
+    host: options.host ?? DEFAULT_HOST,
+    port: options.port ?? DEFAULT_PORT,
+    cors,
     onIntent(intent) {
       return pipeline.handle(intent);
     },
   });
+
+  publisher = server.publishTelemetry;
+
+  while (pendingTelemetry.length > 0) {
+    const event = pendingTelemetry.shift();
+
+    if (event) {
+      publisher(event);
+    }
+  }
+
+  return {
+    server,
+    pipeline,
+    context,
+    async stop() {
+      await server.close();
+    },
+  } satisfies FacadeDevServerInstance;
+}
+
+function ensureError(candidate: unknown): Error {
+  return candidate instanceof Error ? candidate : new Error(String(candidate));
+}
+
+async function main(): Promise<void> {
+  const envPort = Number.parseInt(process.env.FACADE_TRANSPORT_PORT ?? String(DEFAULT_PORT), 10);
+
+  if (!Number.isInteger(envPort) || envPort <= 0) {
+    throw new Error('FACADE_TRANSPORT_PORT must be a positive integer.');
+  }
+
+  const instance = await startFacadeDevServer({
+    host: process.env.FACADE_TRANSPORT_HOST ?? DEFAULT_HOST,
+    port: envPort,
+    corsOrigin: process.env.FACADE_TRANSPORT_CORS_ORIGIN ?? DEFAULT_CORS_ORIGIN,
+  });
+
+  const { server } = instance;
 
   console.info('Facade transport server listening on %s', server.url);
   console.info('Health endpoint available at %s/healthz', server.url);
@@ -49,7 +135,7 @@ async function main(): Promise<void> {
 
     void (async () => {
       try {
-        await server.close();
+        await instance.stop();
         process.exit(0);
       } catch (error) {
         const normalisedError = ensureError(error);
@@ -63,10 +149,12 @@ async function main(): Promise<void> {
   process.once('SIGTERM', initiateShutdown);
 }
 
-main().catch((error: unknown) => {
-  const normalisedError = ensureError(error);
-  console.error('Failed to start transport server:', normalisedError);
-  process.exit(1);
-});
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  main().catch((error: unknown) => {
+    const normalisedError = ensureError(error);
+    console.error('Failed to start transport server:', normalisedError);
+    process.exit(1);
+  });
+}
 
 

--- a/packages/facade/src/transport/server.ts
+++ b/packages/facade/src/transport/server.ts
@@ -9,6 +9,7 @@ import {
   createSocketTransportAdapter,
   type SocketTransportAdapter,
   type SocketTransportAdapterOptions,
+  type TelemetryEvent,
   type TransportIntentEnvelope,
 } from './adapter.js';
 
@@ -53,6 +54,8 @@ export interface TransportServer {
   readonly url: string;
   /** Bound Socket.IO namespaces. */
   readonly namespaces: SocketTransportAdapter['namespaces'];
+  /** Broadcasts telemetry envelopes to subscribed clients. */
+  publishTelemetry(event: TelemetryEvent): void;
   /** Closes the Socket.IO adapter and HTTP listener. */
   close(): Promise<void>;
 }
@@ -288,6 +291,9 @@ export async function createTransportServer(options: TransportServerOptions): Pr
     port: resolvedPort,
     url,
     namespaces: adapter.namespaces,
+    publishTelemetry(event) {
+      adapter.publishTelemetry(event);
+    },
     async close() {
       await adapter.close();
       await closeHttpServer(httpServer);

--- a/packages/facade/tests/integration/transport/devServerTelemetry.integration.test.ts
+++ b/packages/facade/tests/integration/transport/devServerTelemetry.integration.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+import { io as createClient, type Socket } from 'socket.io-client';
+
+/* eslint-disable wb-sim/no-ts-import-js-extension */
+
+import { createDemoWorld } from '@/backend/src/engine/testHarness.ts';
+import { TELEMETRY_HARVEST_CREATED_V1 } from '@/backend/src/telemetry/topics.ts';
+import type { Plant, Room, Zone } from '@/backend/src/domain/world.ts';
+
+import {
+  INTENT_EVENT,
+  TELEMETRY_EVENT,
+  type TelemetryEvent,
+  type TransportAck,
+} from '../../../src/transport/adapter.ts';
+import { startFacadeDevServer } from '../../../src/transport/devServer.ts';
+import { onceConnected, disconnectClient } from './helpers.ts';
+
+type Mutable<T> = { -readonly [K in keyof T]: T[K] };
+
+function prepareHarvestReadyWorld(): ReturnType<typeof createDemoWorld> {
+  const world = createDemoWorld();
+  const structure = (world.company.structures[0] ?? null) as Mutable<
+    ReturnType<typeof createDemoWorld>['company']['structures'][0]
+  > | null;
+
+  if (!structure) {
+    throw new Error('Demo world missing base structure.');
+  }
+
+  const growRoom = structure.rooms.find((room) => room.purpose === 'growroom') as Mutable<Room> | undefined;
+
+  if (!growRoom) {
+    throw new Error('Demo world missing growroom.');
+  }
+
+  const zone = (growRoom.zones[0] ?? null) as Mutable<Zone> | null;
+
+  if (!zone) {
+    throw new Error('Demo world missing cultivation zone.');
+  }
+
+  const harvestReadyPlant: Plant = {
+    id: '00000000-0000-4000-8000-000000000010' as Plant['id'],
+    name: 'Demo Harvest Plant',
+    slug: 'demo-harvest-plant',
+    strainId: '550e8400-e29b-41d4-a716-446655440001' as Plant['strainId'],
+    lifecycleStage: 'harvest-ready',
+    ageHours: 0,
+    health01: 0.88,
+    biomass_g: 480,
+    containerId: zone.containerId,
+    substrateId: zone.substrateId,
+    readyForHarvest: true,
+    status: 'active',
+    moisture01: 0.6,
+    quality01: 0.85,
+  } satisfies Plant;
+
+  zone.plants = [harvestReadyPlant];
+
+  return world;
+}
+
+async function createClientForNamespace(serverUrl: string, namespace: string): Promise<Socket> {
+  const socket = createClient(`${serverUrl}${namespace}`, {
+    transports: ['websocket'],
+    forceNew: true,
+  });
+
+  await onceConnected(socket);
+
+  return socket;
+}
+
+describe('facade transport dev server telemetry bridge', () => {
+  it('forwards engine telemetry envelopes to connected clients', async () => {
+    const world = prepareHarvestReadyWorld();
+    const structure = world.company.structures[0];
+    const growRoom = structure.rooms.find((room) => room.purpose === 'growroom');
+    const storageRoom = structure.rooms.find((room) => room.purpose === 'storageroom');
+    const zone = growRoom?.zones[0];
+
+    if (!structure || !growRoom || !storageRoom || !zone) {
+      throw new Error('Demo world preparation failed: missing required geometry.');
+    }
+
+    const plantId = zone.plants[0]?.id;
+    if (!plantId) {
+      throw new Error('Prepared harvest plant is missing an id.');
+    }
+
+    const devServer = await startFacadeDevServer({
+      host: '127.0.0.1',
+      port: 0,
+      world,
+    });
+
+    let telemetryClient: Socket | null = null;
+    let intentsClient: Socket | null = null;
+
+    try {
+      telemetryClient = await createClientForNamespace(devServer.server.url, '/telemetry');
+      intentsClient = await createClientForNamespace(devServer.server.url, '/intents');
+
+      const telemetryEventPromise = new Promise<TelemetryEvent>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          telemetryClient?.off(TELEMETRY_EVENT, handleTelemetryEvent);
+          reject(new Error('Timed out waiting for telemetry:event payload.'));
+        }, 5000);
+
+        function handleTelemetryEvent(event: TelemetryEvent) {
+          if (event.topic !== TELEMETRY_HARVEST_CREATED_V1) {
+            return;
+          }
+
+          telemetryClient?.off(TELEMETRY_EVENT, handleTelemetryEvent);
+          clearTimeout(timeout);
+          resolve(event);
+        }
+
+        telemetryClient?.on(TELEMETRY_EVENT, handleTelemetryEvent);
+
+        telemetryClient?.once('connect_error', (error) => {
+          telemetryClient?.off(TELEMETRY_EVENT, handleTelemetryEvent);
+          clearTimeout(timeout);
+          reject(error instanceof Error ? error : new Error(String(error)));
+        });
+      });
+
+      const ackPromise = new Promise<TransportAck>((resolve) => {
+        intentsClient?.emit(
+          INTENT_EVENT,
+          { type: 'hiring.market.scan', structureId: structure.id },
+          (response: TransportAck) => {
+            resolve(response);
+          },
+        );
+      });
+
+      const [telemetryEvent, ack] = await Promise.all([telemetryEventPromise, ackPromise]);
+
+      expect(ack).toEqual({ ok: true });
+      expect(telemetryEvent.topic).toBe(TELEMETRY_HARVEST_CREATED_V1);
+
+      const payload = telemetryEvent.payload as Record<string, unknown>;
+
+      expect(payload).toMatchObject({
+        structureId: structure.id,
+        roomId: storageRoom.id,
+        zoneId: zone.id,
+        plantId,
+        createdAt_tick: 0,
+        freshWeight_kg: 0.48,
+        moisture01: 0.6,
+        quality01: 0.85,
+      });
+
+      expect(typeof payload.lotId).toBe('string');
+    } finally {
+      if (intentsClient) {
+        await disconnectClient(intentsClient);
+      }
+
+      if (telemetryClient) {
+        await disconnectClient(telemetryClient);
+      }
+
+      await devServer.stop();
+    }
+  });
+});
+


### PR DESCRIPTION
## Summary
- add a `publishTelemetry` helper on the façade transport server so callers can relay Socket.IO telemetry envelopes
- bridge the dev server run context to that helper, expose a `startFacadeDevServer` bootstrap for tests, and document the change in the changelog
- add an integration test that boots the dev server, drives a harvest tick, and asserts `/telemetry` clients receive the expected envelope

## Testing
- pnpm --filter facade test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68f1c147478c8325969b461ce90645b7