### PR TITLE
Add transport playback scheduler and expose simulation controls

### DIFF
--- a/docs/ADR/ADR-0026-simulation-playback-controls.md
+++ b/docs/ADR/ADR-0026-simulation-playback-controls.md
@@ -1,0 +1,33 @@
+# ADR-0026 — Simulation Playback Controls over Transport
+
+## Status
+Accepted — 2025-03-05
+
+## Context
+- The façade previously advanced the engine only when a gameplay intent arrived, so idle
+  sessions or play/pause toggles in the UI could not drive ticks without mutating local state.
+- SEC/TDD require deterministic tick cadence and explicit state carriers; scheduling ticks in
+  ad-hoc UI timers risks divergence across clients and breaks transport-driven orchestration.
+- Operators need remotely accessible controls (play, pause, step, speed) that translate into
+  deterministic engine actions without bypassing the transport contract.
+
+## Decision
+- Introduce a façade-level playback controller that schedules `runTick` whenever a `playing`
+  flag is enabled, exposes `play`, `pause`, `step`, and `setSpeed` hooks, and keeps tick speed
+  configurable without leaking timers across modules.
+- Extend the Socket.IO transport namespace with `simulation.control.play`, `.pause`, `.step`,
+  and `.speed` intents that delegate to the playback controller while workforce intents remain
+  queued for the next scheduled tick.
+- Update the React UI control bar to dispatch the new intents via the existing intent client
+  instead of mutating local state, ensuring acknowledgements gate UI state transitions.
+- Capture the behaviour with façade playback integration tests and refreshed UI tests so the
+  scheduler contract is enforced in CI.
+
+## Consequences
+- Simulation playback semantics now live centrally in the façade, guaranteeing deterministic
+  tick cadence even when no gameplay intents arrive and preventing UI-local timers from
+  diverging from engine state.
+- Transport clients must issue the new `simulation.control.*` intents to drive playback; the
+  façade remains the single authority coordinating tick execution and speed adjustments.
+- Additional tests cover scheduler behaviour, increasing confidence but adding a small runtime
+  cost to the façade/ui test suites.

--- a/docs/ADR/INDEX.md
+++ b/docs/ADR/INDEX.md
@@ -2,6 +2,7 @@
 
 | ADR-ID   | Title                                                                   | Status     | Supersedes | Affects                      | Binding? | Link                                                               |
 | -------- | ----------------------------------------------------------------------- | ---------- | ---------- | ---------------------------- | -------- | ------------------------------------------------------------------ |
+| ADR-0026 | Simulation playback controls over transport                            | Accepted   | —          | SEC, DD, TDD, AGENTS         | Yes      | [ADR-0026](./ADR-0026-simulation-playback-controls.md)             |
 | ADR-0025 | CI Gates & Developer Command Contracts                                 | Accepted   | —          | SEC, DD, TDD, AGENTS         | Yes      | [ADR-0025](./ADR-0025-ci-gates-and-dev-commands.md)               |
 | ADR-0024 | Conformance Golden Scenario Modularization                             | Accepted   | —          | SEC, DD, TDD, AGENTS         | Yes      | [ADR-0024](./ADR-0024-golden-scenario-modularization.md)           |
 | ADR-0023 | Workforce Pipeline Modularization & Telemetry Isolation                 | Accepted   | —          | SEC, DD, TDD, VISION, AGENTS | Yes      | [ADR-0023](./ADR-0023-workforce-pipeline-modularization.md)         |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1237,6 +1237,20 @@ migrate:classes`, `npm run migrate:blueprints`), and documented the taxonomy upd
 
 All notable changes to this repository will be documented in this file.
 
+### #07 Simulation playback controls over transport
+
+- Added a façade playback controller that schedules deterministic engine ticks while
+  exposing play, pause, step, and speed hooks so simulation time advances without
+  requiring intent traffic (`packages/facade/src/transport/playbackController.ts`).
+- Wired the dev transport server to accept `simulation.control.*` intents, updating
+  tick scheduling and speed through the playback controller while keeping workforce
+  intents queued for the next tick (`packages/facade/src/transport/devServer.ts`).
+- Updated the UI simulation controls to dispatch the new transport intents and
+  asserted the behaviour with playback integration tests and refreshed control bar
+  coverage (`packages/ui/src/state/simulationControls.ts`,
+  `packages/ui/src/components/layout/__tests__/SimControlBar.test.tsx`,
+  `packages/facade/src/transport/__tests__/playbackController.test.ts`).
+
 ### #06 Currency-neutral terminology enforcement
 
 - Clarified across SEC, DD, TDD, and Vision Scope that monetary identifiers and UI copy must remain currency-neutral, forbidding baked-in codes/symbols (EUR, USD, GBP, etc.).

--- a/packages/facade/src/transport/playbackController.ts
+++ b/packages/facade/src/transport/playbackController.ts
@@ -1,0 +1,117 @@
+/* eslint-disable wb-sim/no-ts-import-js-extension */
+
+import { type EngineCommandPipeline } from './engineCommandPipeline.js';
+
+const DEFAULT_BASE_INTERVAL_MS = 1000;
+const DEFAULT_INITIAL_SPEED = 1;
+
+export interface PlaybackControllerState {
+  readonly isPlaying: boolean;
+  readonly speedMultiplier: number;
+}
+
+export interface PlaybackControllerOptions {
+  readonly pipeline: Pick<EngineCommandPipeline, 'advanceTick'>;
+  readonly baseIntervalMs?: number;
+  readonly initialSpeedMultiplier?: number;
+  readonly autoStart?: boolean;
+}
+
+export interface PlaybackController {
+  getState(): PlaybackControllerState;
+  play(): void;
+  pause(): void;
+  step(): void;
+  setSpeed(multiplier: number): void;
+  dispose(): void;
+}
+
+function assertPositiveFinite(value: number, label: string): void {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${label} must be a positive, finite number.`);
+  }
+}
+
+export function createPlaybackController(options: PlaybackControllerOptions): PlaybackController {
+  const pipeline = options.pipeline;
+  const baseIntervalMs = options.baseIntervalMs ?? DEFAULT_BASE_INTERVAL_MS;
+  const autoStart = options.autoStart ?? true;
+
+  assertPositiveFinite(baseIntervalMs, 'baseIntervalMs');
+
+  let speedMultiplier = options.initialSpeedMultiplier ?? DEFAULT_INITIAL_SPEED;
+  assertPositiveFinite(speedMultiplier, 'initialSpeedMultiplier');
+
+  let isPlaying = Boolean(autoStart);
+  let scheduledTick: NodeJS.Timeout | null = null;
+
+  const scheduleNextTick = () => {
+    if (!isPlaying) {
+      return;
+    }
+
+    if (scheduledTick) {
+      clearTimeout(scheduledTick);
+      scheduledTick = null;
+    }
+
+    const delayMs = baseIntervalMs / speedMultiplier;
+
+    scheduledTick = setTimeout(() => {
+      scheduledTick = null;
+      pipeline.advanceTick();
+      scheduleNextTick();
+    }, delayMs);
+  };
+
+  const clearScheduledTick = () => {
+    if (!scheduledTick) {
+      return;
+    }
+
+    clearTimeout(scheduledTick);
+    scheduledTick = null;
+  };
+
+  if (isPlaying) {
+    scheduleNextTick();
+  }
+
+  return {
+    getState(): PlaybackControllerState {
+      return { isPlaying, speedMultiplier } satisfies PlaybackControllerState;
+    },
+    play(): void {
+      if (isPlaying) {
+        return;
+      }
+
+      isPlaying = true;
+      scheduleNextTick();
+    },
+    pause(): void {
+      if (!isPlaying) {
+        return;
+      }
+
+      isPlaying = false;
+      clearScheduledTick();
+    },
+    step(): void {
+      pipeline.advanceTick();
+    },
+    setSpeed(multiplier: number): void {
+      assertPositiveFinite(multiplier, 'speedMultiplier');
+      speedMultiplier = multiplier;
+
+      if (isPlaying) {
+        scheduleNextTick();
+      }
+    },
+    dispose(): void {
+      isPlaying = false;
+      clearScheduledTick();
+    },
+  } satisfies PlaybackController;
+}
+

--- a/packages/facade/tests/integration/transport/intentForwarding.integration.test.ts
+++ b/packages/facade/tests/integration/transport/intentForwarding.integration.test.ts
@@ -37,7 +37,10 @@ describe('transport intent forwarding', () => {
       throw new Error('Demo world missing structure id for hiring market scan intent.');
     }
 
-    const harness = await createTransportHarness((intent) => pipeline.handle(intent));
+    const harness = await createTransportHarness(async (intent) => {
+      await pipeline.handle(intent);
+      pipeline.advanceTick();
+    });
     let client: Awaited<ReturnType<typeof createNamespaceClient>> | null = null;
 
     try {
@@ -80,7 +83,10 @@ describe('transport intent forwarding', () => {
       context,
     });
 
-    const harness = await createTransportHarness((intent) => pipeline.handle(intent));
+    const harness = await createTransportHarness(async (intent) => {
+      await pipeline.handle(intent);
+      pipeline.advanceTick();
+    });
     let client: Awaited<ReturnType<typeof createNamespaceClient>> | null = null;
 
     try {

--- a/packages/facade/tests/unit/transport/engineCommandPipeline.test.ts
+++ b/packages/facade/tests/unit/transport/engineCommandPipeline.test.ts
@@ -28,6 +28,7 @@ describe('createEngineCommandPipeline', () => {
     }
 
     await pipeline.handle({ type: 'hiring.market.scan', structureId });
+    pipeline.advanceTick();
 
     const charges = consumeWorkforceMarketCharges(pipeline.context);
     expect(charges).toBeDefined();

--- a/packages/facade/tests/unit/transport/playbackController.test.ts
+++ b/packages/facade/tests/unit/transport/playbackController.test.ts
@@ -1,0 +1,103 @@
+/* eslint-disable wb-sim/no-ts-import-js-extension */
+
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createDemoWorld } from '@/backend/src/engine/testHarness.ts';
+
+import { createEngineCommandPipeline } from '../../../src/transport/engineCommandPipeline.js';
+import { createPlaybackController } from '../../../src/transport/playbackController.js';
+
+function createPipelineHarness() {
+  let world = createDemoWorld();
+  const pipeline = createEngineCommandPipeline({
+    world: {
+      get: () => world,
+      set(nextWorld) {
+        world = nextWorld;
+      },
+    },
+    context: {},
+  });
+
+  return {
+    pipeline,
+    getWorld: () => world,
+  } as const;
+}
+
+describe('createPlaybackController', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('advances ticks while playing and halts when paused', () => {
+    const { pipeline, getWorld } = createPipelineHarness();
+    const controller = createPlaybackController({
+      pipeline,
+      baseIntervalMs: 100,
+      autoStart: false,
+    });
+
+    expect(getWorld().simTimeHours).toBe(0);
+
+    controller.play();
+    vi.advanceTimersByTime(100);
+    expect(getWorld().simTimeHours).toBe(1);
+
+    vi.advanceTimersByTime(100);
+    expect(getWorld().simTimeHours).toBe(2);
+
+    controller.pause();
+    vi.advanceTimersByTime(400);
+    expect(getWorld().simTimeHours).toBe(2);
+
+    controller.dispose();
+  });
+
+  it('steps exactly once when requested while paused', () => {
+    const { pipeline, getWorld } = createPipelineHarness();
+    const controller = createPlaybackController({
+      pipeline,
+      baseIntervalMs: 100,
+      autoStart: false,
+    });
+
+    controller.pause();
+    controller.step();
+    expect(getWorld().simTimeHours).toBe(1);
+
+    controller.step();
+    expect(getWorld().simTimeHours).toBe(2);
+
+    controller.dispose();
+  });
+
+  it('re-schedules ticks according to the active speed multiplier', () => {
+    const { pipeline, getWorld } = createPipelineHarness();
+    const controller = createPlaybackController({
+      pipeline,
+      baseIntervalMs: 100,
+      autoStart: false,
+    });
+
+    controller.play();
+    vi.advanceTimersByTime(100);
+    expect(getWorld().simTimeHours).toBe(1);
+
+    controller.setSpeed(5);
+    vi.advanceTimersByTime(20);
+    expect(getWorld().simTimeHours).toBe(2);
+
+    controller.setSpeed(10);
+    vi.advanceTimersByTime(10);
+    expect(getWorld().simTimeHours).toBe(3);
+
+    controller.dispose();
+  });
+});
+

--- a/packages/ui/src/components/layout/__tests__/SimControlBar.test.tsx
+++ b/packages/ui/src/components/layout/__tests__/SimControlBar.test.tsx
@@ -4,18 +4,50 @@ import { SimControlBar } from "@ui/components/layout/SimControlBar";
 import { workspaceCopy } from "@ui/design/tokens";
 import * as localeModule from "@ui/lib/locale";
 import { SIM_SPEED_OPTIONS, useSimulationControlsStore } from "@ui/state/simulationControls";
+import { IntentClientProvider } from "@ui/transport";
+import type { IntentClient, IntentSubmissionSuccess } from "@ui/transport/intentClient";
 
 function resetSimulationControlsStore(): void {
   act(() => {
     useSimulationControlsStore.setState({
       isPlaying: true,
-      speed: SIM_SPEED_OPTIONS[0],
-      requestPlay: useSimulationControlsStore.getState().requestPlay,
-      requestPause: useSimulationControlsStore.getState().requestPause,
-      requestStep: useSimulationControlsStore.getState().requestStep,
-      requestSpeed: useSimulationControlsStore.getState().requestSpeed
+      speed: SIM_SPEED_OPTIONS[0]
     });
   });
+}
+
+function createMockIntentClient(): { client: IntentClient; submit: IntentClient["submit"]; disconnect: IntentClient["disconnect"]; } {
+  const submit = vi.fn(async (_intent, handlers) => {
+    const result: IntentSubmissionSuccess = { ok: true, ack: { ok: true } };
+    handlers?.onResult(result);
+    return result;
+  });
+
+  const disconnect = vi.fn(async () => {});
+
+  return {
+    client: {
+      submit,
+      disconnect
+    },
+    submit,
+    disconnect
+  } satisfies { client: IntentClient; submit: IntentClient["submit"]; disconnect: IntentClient["disconnect"]; };
+}
+
+async function clickAsync(element: HTMLElement): Promise<void> {
+  await act(async () => {
+    fireEvent.click(element);
+    await Promise.resolve();
+  });
+}
+
+function renderWithClient(client: IntentClient): void {
+  render(
+    <IntentClientProvider client={client}>
+      <SimControlBar />
+    </IntentClientProvider>
+  );
 }
 
 describe("SimControlBar", () => {
@@ -25,7 +57,7 @@ describe("SimControlBar", () => {
   });
 
   it("renders controls, metrics, and sticky positioning", () => {
-    render(<SimControlBar />);
+    renderWithClient(createMockIntentClient().client);
 
     const pauseButton = screen.getByRole("button", { name: workspaceCopy.simControlBar.pause });
     expect(pauseButton).toHaveAttribute("aria-pressed", "true");
@@ -39,26 +71,34 @@ describe("SimControlBar", () => {
     expect(controlSection).toHaveAttribute("data-position-desktop", "top");
   });
 
-  it("toggles play and pause state when the primary button is pressed", () => {
-    render(<SimControlBar />);
+  it("toggles play and pause state when the primary button is pressed", async () => {
+    const { client, submit } = createMockIntentClient();
+    renderWithClient(client);
 
     const pauseButton = screen.getByRole("button", { name: workspaceCopy.simControlBar.pause });
-    act(() => {
-      fireEvent.click(pauseButton);
-    });
+    await clickAsync(pauseButton);
+
+    expect(submit).toHaveBeenCalledWith(
+      { type: "simulation.control.pause" },
+      expect.objectContaining({ onResult: expect.any(Function) })
+    );
 
     const playButton = screen.getByRole("button", { name: workspaceCopy.simControlBar.play });
     expect(playButton).toHaveAttribute("aria-pressed", "false");
   });
 
-  it("updates the active speed chip when a different multiplier is selected", () => {
-    render(<SimControlBar />);
+  it("updates the active speed chip when a different multiplier is selected", async () => {
+    const { client, submit } = createMockIntentClient();
+    renderWithClient(client);
 
     const targetSpeed = 25;
     const speedButton = screen.getByRole("button", { name: `${String(targetSpeed)}×` });
-    act(() => {
-      fireEvent.click(speedButton);
-    });
+    await clickAsync(speedButton);
+
+    expect(submit).toHaveBeenCalledWith(
+      { type: "simulation.control.speed", multiplier: targetSpeed },
+      expect.objectContaining({ onResult: expect.any(Function) })
+    );
 
     expect(speedButton).toHaveAttribute("aria-pressed", "true");
 
@@ -69,7 +109,8 @@ describe("SimControlBar", () => {
   it("formats metrics according to the resolved shell locale", () => {
     const localeSpy = vi.spyOn(localeModule, "useShellLocale").mockReturnValue("de-DE");
 
-    render(<SimControlBar />);
+    const { client } = createMockIntentClient();
+    renderWithClient(client);
 
     expect(screen.getByText(/Tag 12 · 06:15/)).toBeInTheDocument();
     expect(screen.getByText(/1\.250\.000,50/)).toBeInTheDocument();

--- a/packages/ui/src/state/simulationControls.ts
+++ b/packages/ui/src/state/simulationControls.ts
@@ -1,4 +1,10 @@
+import { useCallback } from "react";
 import { create } from "zustand";
+
+import type { TransportIntentEnvelope } from "@wb/transport-sio";
+
+import type { IntentClient } from "@ui/transport/intentClient";
+import { useIntentClient } from "@ui/transport";
 
 /* eslint-disable-next-line @typescript-eslint/no-magic-numbers */
 export const SIM_SPEED_OPTIONS = [1, 5, 10, 25, 100] as const;
@@ -8,31 +14,51 @@ export type SimulationSpeedMultiplier = (typeof SIM_SPEED_OPTIONS)[number];
 interface SimulationControlState {
   readonly isPlaying: boolean;
   readonly speed: SimulationSpeedMultiplier;
-  readonly requestPlay: () => Promise<void>;
-  readonly requestPause: () => Promise<void>;
-  readonly requestStep: () => Promise<void>;
-  readonly requestSpeed: (speed: SimulationSpeedMultiplier) => Promise<void>;
+  readonly setPlaying: (isPlaying: boolean) => void;
+  readonly setSpeed: (speed: SimulationSpeedMultiplier) => void;
 }
-
-const createResolvedPromise = () => Promise.resolve();
 
 export const useSimulationControlsStore = create<SimulationControlState>((set) => ({
   isPlaying: true,
   speed: SIM_SPEED_OPTIONS[0],
-  requestPlay: () => {
-    set(() => ({ isPlaying: true }));
-    return createResolvedPromise();
+  setPlaying: (isPlaying) => {
+    set(() => ({ isPlaying }));
   },
-  requestPause: () => {
-    set(() => ({ isPlaying: false }));
-    return createResolvedPromise();
-  },
-  requestStep: () => createResolvedPromise(),
-  requestSpeed: (speed) => {
+  setSpeed: (speed) => {
     set(() => ({ speed }));
-    return createResolvedPromise();
   }
 }));
+
+function createControlIntent(type: string, extras: Record<string, unknown> = {}): TransportIntentEnvelope {
+  return { type, ...extras } satisfies TransportIntentEnvelope;
+}
+
+async function submitControlIntent(
+  client: IntentClient | null,
+  intent: TransportIntentEnvelope,
+  onSuccess: () => void
+): Promise<void> {
+  if (!client) {
+    onSuccess();
+    return;
+  }
+
+  try {
+    const result = await client.submit(intent, {
+      onResult(submissionResult) {
+        if (submissionResult.ok) {
+          onSuccess();
+        }
+      }
+    });
+
+    if (!result.ok) {
+      console.error("Simulation control intent rejected:", result.dictionary.title);
+    }
+  } catch (error) {
+    console.error("Failed to submit simulation control intent:", error);
+  }
+}
 
 export interface SimulationControlsSnapshot {
   readonly isPlaying: boolean;
@@ -44,12 +70,46 @@ export interface SimulationControlsSnapshot {
 }
 
 export function useSimulationControls(): SimulationControlsSnapshot {
-  return useSimulationControlsStore((state) => ({
-    isPlaying: state.isPlaying,
-    speed: state.speed,
-    requestPlay: state.requestPlay,
-    requestPause: state.requestPause,
-    requestStep: state.requestStep,
-    requestSpeed: state.requestSpeed
-  }));
+  const intentClient = useIntentClient();
+  const isPlaying = useSimulationControlsStore((state) => state.isPlaying);
+  const speed = useSimulationControlsStore((state) => state.speed);
+  const setPlaying = useSimulationControlsStore((state) => state.setPlaying);
+  const setSpeed = useSimulationControlsStore((state) => state.setSpeed);
+
+  const requestPlay = useCallback(async () => {
+    await submitControlIntent(intentClient, createControlIntent("simulation.control.play"), () => {
+      setPlaying(true);
+    });
+  }, [intentClient, setPlaying]);
+
+  const requestPause = useCallback(async () => {
+    await submitControlIntent(intentClient, createControlIntent("simulation.control.pause"), () => {
+      setPlaying(false);
+    });
+  }, [intentClient, setPlaying]);
+
+  const requestStep = useCallback(async () => {
+    await submitControlIntent(intentClient, createControlIntent("simulation.control.step"), () => {
+      // Intentionally no local state change; step preserves the play/pause flag.
+    });
+  }, [intentClient]);
+
+  const requestSpeed = useCallback(async (nextSpeed: SimulationSpeedMultiplier) => {
+    await submitControlIntent(
+      intentClient,
+      createControlIntent("simulation.control.speed", { multiplier: nextSpeed }),
+      () => {
+        setSpeed(nextSpeed);
+      }
+    );
+  }, [intentClient, setSpeed]);
+
+  return {
+    isPlaying,
+    speed,
+    requestPlay,
+    requestPause,
+    requestStep,
+    requestSpeed
+  } satisfies SimulationControlsSnapshot;
 }


### PR DESCRIPTION
## Summary
- introduce a playback controller in the façade that schedules deterministic ticks and expose simulation.control intents over transport
- update simulation control state/hooks in the UI to dispatch the new intents and keep local state in sync on acknowledgement
- expand façade and UI test coverage, add ADR entry, and document the new transport controls in the changelog

## Testing
- pnpm --filter @wb/facade test tests/integration/transport/devServerTelemetry.integration.test.ts tests/unit/transport/playbackController.test.ts tests/unit/transport/engineCommandPipeline.test.ts
- pnpm --filter @wb/ui test

------
https://chatgpt.com/codex/tasks/task_e_68f1cf390e088325bad80f451de07787