### PR TITLE
docs: author frontend live data task plan

### DIFF
--- a/docs/tasks/frontend/frontend-001-contracts-alignment.md
+++ b/docs/tasks/frontend/frontend-001-contracts-alignment.md
@@ -1,0 +1,30 @@
+# Align Frontend Contracts with SEC/DD
+
+**ID:** FRONT-001
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** frontend, documentation, planning
+
+## Rationale
+The UI still renders deterministic fixtures and lacks a verified mapping against the Simulation Engine Contract. We need an authoritative checklist so subsequent wiring work lands against the correct read-model, telemetry, and intent shapes.
+
+## Scope
+- In: Review SEC/DD/TDD for required frontend data and intents; document deltas versus current UI; enumerate missing endpoints or schema fields.
+- Out: Implementing schema or code changes; modifying backend adapters; updating UI components beyond documentation.
+
+## Deliverables
+- Updated contract notes in `docs/tasks/frontend/FRONT-001` subfolder (create if needed) summarising required read-model, telemetry, and intent payloads.
+- Issues or follow-up tickets created for any SEC gaps found (link them in the task notes).
+- CHANGELOG/DD annotations only if new decisions are made.
+
+## Acceptance Criteria
+- Inventory lists each required contract element with status (implemented vs missing) and cites source clauses.
+- Risks/unknowns escalated via linked follow-up tasks or ADR stubs.
+- Review signed off by tech lead or product counterpart.
+
+## References
+- SEC §§1–3, §7.5
+- DD §§2–4
+- TDD §1 (transport expectations)
+- Root `AGENTS.md` (documentation requirements)

--- a/docs/tasks/frontend/frontend-002-demo-world-upgrade.md
+++ b/docs/tasks/frontend/frontend-002-demo-world-upgrade.md
@@ -1,0 +1,30 @@
+# Build Deterministic Multi-Structure Demo World
+
+**ID:** FRONT-002
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** backend, read-models, data-prep
+
+## Rationale
+Current dev transports spawn an almost empty `SimulationWorld`, so even with live wiring the UI would surface blanks. We need a richer deterministic seed to exercise structures, rooms, zones, devices, and workforce flows.
+
+## Scope
+- In: Replace or extend the demo world loader to assemble multiple structures with populated rooms/zones, device placements, and workforce roster using existing blueprints/fixtures.
+- In: Ensure economics (tariffs, price maps) and cultivation methods are populated per SEC requirements.
+- Out: Changes to real production data importers; modifying UI fetch logic; altering blueprint JSON schemas.
+
+## Deliverables
+- Updated backend/demo loader code (e.g. `packages/transport/src/demo/**`) producing deterministic, SEC-compliant entities.
+- Unit snapshot or golden test covering the new world shape.
+- Documentation note in `docs/tasks/frontend/FRONT-002` summarising the scenario contents.
+
+## Acceptance Criteria
+- Demo world includes at least two structures, multiple growrooms with zones, and a staffed workforce roster.
+- All entities validate against SEC invariants (room purposes, cultivation methods, device placement scopes).
+- Running the transport server emits non-empty read-model payloads reflecting the new world.
+
+## References
+- SEC §§1–2, §5, §7.5
+- DD §3 (scenario expectations)
+- Root `AGENTS.md` invariants #2–#5

--- a/docs/tasks/frontend/frontend-003-read-model-hydration.md
+++ b/docs/tasks/frontend/frontend-003-read-model-hydration.md
@@ -1,0 +1,30 @@
+# Hydrate Facade Read Models with Live Metrics
+
+**ID:** FRONT-003
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** backend, read-models, telemetry
+
+## Rationale
+Facade read-model providers currently emit zeroed KPIs and empty collections, leaving the UI stuck on placeholders even if data exists. We must compute real structure/room/zone, economy, and HR metrics from the enriched demo world.
+
+## Scope
+- In: Update read-model composition modules to derive structure dashboards, room climate snapshots, zone KPIs/tasks, economy totals, HR directories, and catalogs from engine state.
+- In: Add schema validators/TypeScript types for any new fields required by SEC/DD.
+- Out: Frontend store changes; transport protocol changes beyond read-model HTTP payloads; telemetry streaming.
+
+## Deliverables
+- Modified provider modules (e.g. `packages/transport/src/readModels/**`) with tests covering new metrics.
+- Updated shared types consumed by the UI (likely in `packages/types` or similar).
+- Documentation note summarising new fields and their SEC alignment.
+
+## Acceptance Criteria
+- `/api/read-models` returns populated dashboards for structures, rooms, zones, workforce, economy, and catalogs.
+- Unit tests/assertions confirm non-empty payloads and deterministic values given the demo seed.
+- Breaking changes to schemas are documented and versioned per DD guidance.
+
+## References
+- SEC §§1–3, §6, §7.5
+- DD §4 (read-model expectations)
+- TDD §2 (transport payload contracts)

--- a/docs/tasks/frontend/frontend-004-telemetry-bridge.md
+++ b/docs/tasks/frontend/frontend-004-telemetry-bridge.md
@@ -1,0 +1,30 @@
+# Restore Live Telemetry Playback Bridge
+
+**ID:** FRONT-004
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** telemetry, backend, socket.io
+
+## Rationale
+Console logs show repeated Socket.IO timeouts because the telemetry bridge never establishes a live feed. The transport server must publish engine tick/zone/workforce events so UI dashboards receive updates.
+
+## Scope
+- In: Connect the simulation run loop to the transport telemetry binder, ensuring tick progression and event streams propagate over Socket.IO.
+- In: Audit emitted topics to match UI subscribers (structure, room, zone, workforce, harvest).
+- Out: Frontend state handling; intent command routing; non-Socket.IO transports.
+
+## Deliverables
+- Updated telemetry binder (e.g. `packages/transport/src/telemetry/**`) wired to engine playback.
+- Automated test or harness confirming events flow over a test client.
+- Troubleshooting notes in `docs/tasks/frontend/FRONT-004` for reconnect/backoff behaviour.
+
+## Acceptance Criteria
+- Telemetry server establishes a WebSocket connection without timeouts under default dev config.
+- Tick, zone, and workforce events emit at expected cadence and payload matches schema.
+- UI (or test client) receives updates when simulation state changes.
+
+## References
+- SEC §0.1 (transport adapter), §6 (tick pipeline)
+- TDD §3 (telemetry topics)
+- Root `AGENTS.md` §4 (telemetry read-only)

--- a/docs/tasks/frontend/frontend-005-intent-pipeline.md
+++ b/docs/tasks/frontend/frontend-005-intent-pipeline.md
@@ -1,0 +1,30 @@
+# Implement Live Intent Pipeline Coverage
+
+**ID:** FRONT-005
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** intents, backend, api
+
+## Rationale
+UI intent handlers currently log "stub" messages, so users cannot rename zones, adjust climate, or control simulation playback. Completing the intent pipeline is essential before switching off fixtures.
+
+## Scope
+- In: Extend façade command handlers to support rename/move, climate/lighting adjustments, HR actions, pest/maintenance tasks, and simulation controls per proposal expectations.
+- In: Ensure acknowledgements propagate back to the UI and update Zustand mirrors only on success.
+- Out: Frontend UI redesign; telemetry emissions unrelated to intents; scenario content changes.
+
+## Deliverables
+- Updated intent routing modules (e.g. `packages/transport/src/intents/**`) with coverage for documented actions.
+- Contract tests verifying commands mutate the simulation world and return success/failure responses deterministically.
+- Documentation updates outlining available intents and error semantics.
+
+## Acceptance Criteria
+- Each documented UI action triggers a real backend mutation and returns an acknowledgement payload.
+- Failed intents surface descriptive errors without crashing the transport server.
+- Tests confirm determinism across repeated runs (same seed ⇒ same outcome).
+
+## References
+- SEC §§4–5 (intent semantics)
+- DD §5 (control workflows)
+- Root `AGENTS.md` §4 (command vs telemetry separation)

--- a/docs/tasks/frontend/frontend-006-read-model-store.md
+++ b/docs/tasks/frontend/frontend-006-read-model-store.md
@@ -1,0 +1,30 @@
+# Replace Frontend Fixture Store with Live Fetch
+
+**ID:** FRONT-006
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** frontend, state-management, transport
+
+## Rationale
+The frontend Zustand store boots with `deterministicReadModelSnapshot` and never fetches the façade endpoint, so UI components cannot display live data even if the backend is ready. We need a loading/error-aware fetch flow.
+
+## Scope
+- In: Initialize the store in loading state, fetch `/api/read-models` when `VITE_TRANSPORT_BASE_URL` is defined, and expose retry/error state to consumers.
+- In: Preserve deterministic fallback only when no transport is configured, with clear console warnings.
+- Out: Component-level replacements of fixture selectors; telemetry or intent handling beyond store bootstrap.
+
+## Deliverables
+- Updated store module (likely `packages/ui/src/stores/readModelStore.ts`) with TypeScript types aligned to live payloads.
+- Unit tests covering initial load, success, failure, and fallback behaviours.
+- Developer docs describing environment variables and error surfaces.
+
+## Acceptance Criteria
+- Store fetches live read models and transitions through loading → ready → error states deterministically.
+- Missing/invalid `VITE_TRANSPORT_BASE_URL` falls back to fixtures with a single warning.
+- Components consuming the store receive unchanged selectors/signatures aside from new status fields.
+
+## References
+- SEC §0.1 (transport adapter expectations)
+- TDD §2 (read-model endpoint contract)
+- Root `AGENTS.md` (UI deterministic fixtures guidance)

--- a/docs/tasks/frontend/frontend-007-structure-room-zone-ui.md
+++ b/docs/tasks/frontend/frontend-007-structure-room-zone-ui.md
@@ -1,0 +1,30 @@
+# Swap Structure/Room/Zone UI to Live Data
+
+**ID:** FRONT-007
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** frontend, ui, read-models
+
+## Rationale
+Navigation, dashboard metrics, and structure/room/zone feature hooks still rely on hard-coded fixtures, blocking parity with backend metrics and warnings. Once the store fetches live payloads we must update components to consume them.
+
+## Scope
+- In: Update navigation builders, dashboard cards, and structure/room/zone hooks to read from live selectors and remove deterministic fixtures.
+- In: Surface backend-provided warnings, tasks, compatibility hints, and tariffs with graceful empty states.
+- Out: Workforce or HR surfaces; strain catalog UI; telemetry-driven animations (handled elsewhere).
+
+## Deliverables
+- Updated UI modules (e.g. `packages/ui/src/features/structures/**`, `packages/ui/src/components/dashboard/**`).
+- Component/unit tests adjusted to mock live selectors.
+- Storybook or docs snippets showing live-data-driven cards.
+
+## Acceptance Criteria
+- Navigational tree reflects live read-model IDs without hard-coded arrays.
+- Dashboards display backend KPIs and warnings; no fixture constants remain in targeted files.
+- Tests verify selectors/rendering when backend returns populated and empty payloads.
+
+## References
+- SEC §§1–3 (structure hierarchy, economy KPIs)
+- DD §4 (UI read-model mapping)
+- Root `AGENTS.md` (UI contract guidance)

--- a/docs/tasks/frontend/frontend-008-workforce-strains.md
+++ b/docs/tasks/frontend/frontend-008-workforce-strains.md
@@ -1,0 +1,30 @@
+# Move Workforce & Strain Surfaces to Live Data
+
+**ID:** FRONT-008
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** frontend, hr, catalog
+
+## Rationale
+Workforce summaries and strain catalog pages are currently synthetic, preventing HR analytics and cultivar metadata from reflecting backend data. After live read models are available we must hook these surfaces up.
+
+## Scope
+- In: Refactor workforce selectors/components to consume HR read models and telemetry-backed utilization/warning data.
+- In: Build strain catalog views using façade-provided catalogs (or newly added read models) with search/filter support.
+- Out: Structural navigation (handled in FRONT-007); intent submission UI; pricing or logistics beyond data binding.
+
+## Deliverables
+- Updated HR-related components (`packages/ui/src/features/workforce/**`) and strain catalog modules (`packages/ui/src/features/strains/**`).
+- Tests verifying rendering with populated and empty datasets.
+- Documentation snippet describing data sources and fallback behaviours.
+
+## Acceptance Criteria
+- Workforce page shows real headcount, assignments, warnings, and queues from the backend.
+- Strain catalog lists live cultivar metadata with loading/empty/error states handled gracefully.
+- No deterministic fixtures remain in targeted modules.
+
+## References
+- SEC §3 (catalog data) & §7.5 (cultivation methods)
+- DD §4 (HR & strain UX requirements)
+- Root `AGENTS.md` (documentation + determinism)

--- a/docs/tasks/frontend/frontend-009-validation-docs.md
+++ b/docs/tasks/frontend/frontend-009-validation-docs.md
@@ -1,0 +1,30 @@
+# Validate Live Wiring & Update Documentation
+
+**ID:** FRONT-009
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** testing, documentation, qa
+
+## Rationale
+Switching from fixtures to live data introduces regression risk. We need a focused validation task to cover automated tests, manual smoke plans, and required documentation updates (CHANGELOG, ADR) once wiring is complete.
+
+## Scope
+- In: Add end-to-end and unit tests for read-model hydration, telemetry streaming, intent handling, and UI selectors.
+- In: Draft or update ADRs/CHANGELOG entries capturing the shift to live data and any contract decisions.
+- Out: Implementing fixes beyond what's needed to make tests pass; creating new product features.
+
+## Deliverables
+- Test suites or scripts (e.g. `packages/ui/tests/**`, `packages/transport/tests/**`) covering the live data flows.
+- Manual QA checklist recorded in task notes.
+- Updated `docs/CHANGELOG.md` and ADR entry documenting the live wiring milestone.
+
+## Acceptance Criteria
+- Automated test runs cover critical live data paths and pass deterministically in CI.
+- Manual smoke checklist executed against dev stack with results logged.
+- Documentation updated and linked in the task completion notes.
+
+## References
+- SEC §0.1 (deterministic requirements)
+- TDD §4 (testing expectations)
+- Root `AGENTS.md` §15 (acceptance criteria)

--- a/docs/tasks/ui/0100-contracts-inventory-sync.md
+++ b/docs/tasks/ui/0100-contracts-inventory-sync.md
@@ -1,0 +1,35 @@
+# Contracts Inventory Sync
+
+**ID:** 0100
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** ui, contracts, documentation
+
+## Rationale
+A consolidated inventory of required read-model and intent fields is needed before wiring the UI to live data so execution tasks do not diverge from SEC and DD assumptions.
+
+## Scope
+- In: review SEC §3–§7, DD §§2–4, TDD §2 to list all structure/room/zone, HR, and sim-control data/intent fields required for the UI.
+- In: capture discovered contract gaps or ambiguities as TODO notes inside relevant SEC/DD/TDD files without changing semantics.
+- Out: no schema/code modifications beyond documentation notes.
+- Out: no dependency or tooling adjustments.
+- Rollback: delete newly added notes if the contract review proves invalid.
+
+## Deliverables
+- Updated SEC/DD/TDD markdown sections annotated with "Pending live data" notes where gaps exist.
+- Table or bullet summary appended to docs/tasks/ui/_plan/0000-plan-index.md references if required by follow-up tasks.
+- No code changes outside documentation.
+
+## Acceptance Criteria
+- Documentation updates touch no more than 3 files and <=150 diff lines.
+- Notes explicitly cite the missing or to-be-confirmed fields per hierarchy level and intent.
+- Added notes include responsible follow-up task IDs from this plan.
+- Changes render without markdown lint errors (run `pnpm lint:docs` when available).
+- Tests to add/modify: none (documentation-only).
+
+## References
+- SEC §3, §5, §7
+- DD §2.1, §3.2
+- TDD §2.4
+- Root AGENTS.md (sections 0–5)

--- a/docs/tasks/ui/0110-sec-gap-register.md
+++ b/docs/tasks/ui/0110-sec-gap-register.md
@@ -1,0 +1,35 @@
+# SEC Gap Register
+
+**ID:** 0110
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** ui, documentation, governance
+
+## Rationale
+Tracking unresolved contract gaps in a dedicated register ensures downstream tasks have a single reference for pending schema clarifications before backend wiring starts.
+
+## Scope
+- In: create or update a gap register section within docs/SEC.md summarising unresolved items and linking to follow-up tasks.
+- In: annotate DD and TDD with cross-references to the new register entries where those documents defer decisions.
+- Out: no modifications to engine code, schemas, or transport implementations.
+- Out: no updates to CHANGELOG beyond referencing the register entry.
+- Rollback: remove the new register section and associated cross-references.
+
+## Deliverables
+- Gap register subsection in docs/SEC.md with enumerated entries keyed by this plan’s task IDs.
+- Cross-reference notes in DD and TDD pointing to the register entry identifiers.
+- Optional addition to docs/CHANGELOG.md noting the documentation update.
+
+## Acceptance Criteria
+- Total touched files ≤3 with combined diff ≤150 lines.
+- Each register entry states the affected contract area, expected resolution owner, and linked execution task ID.
+- CHANGELOG entry (if added) follows existing format and cites the register.
+- Markdown passes lint/formatting (run `pnpm lint:docs` when available).
+- Tests to add/modify: none.
+
+## References
+- SEC §0–§1 guidance on precedence
+- DD §1 overview
+- TDD §1 governance
+- Root AGENTS.md Purpose & Acceptance Criteria

--- a/docs/tasks/ui/0120-tracker-and-adr-alignment.md
+++ b/docs/tasks/ui/0120-tracker-and-adr-alignment.md
@@ -1,0 +1,35 @@
+# Tracker and ADR Alignment
+
+**ID:** 0120
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P2
+**Tags:** ui, documentation, adr
+
+## Rationale
+The UI task tracker, CHANGELOG, and ADR stubs must flag the transition away from fixtures so later feature work references authoritative documentation.
+
+## Scope
+- In: update docs/tasks/ui/_plan/0000-plan-index.md references, docs/CHANGELOG.md, and any relevant ADR placeholders to reflect the live-data wiring initiative.
+- In: ensure UI Task tracker entries identify this plan’s tasks and successors.
+- Out: no code or schema modifications; documentation only.
+- Out: no restructuring of existing ADR decisions beyond annotations.
+- Rollback: revert documentation edits to previous state if alignment is rejected.
+
+## Deliverables
+- Annotated CHANGELOG entry under current date describing the planning milestone.
+- ADR note (existing or new placeholder) referencing the fixture-to-live migration with links to execution tasks.
+- Updated tracker references (e.g., docs/tasks/ui/_plan assets) reflecting ownership.
+
+## Acceptance Criteria
+- Documentation edits span ≤3 files and ≤150 diff lines total.
+- CHANGELOG entry uses established format and includes references to SEC/DD alignment work.
+- ADR note clearly states status (e.g., “Pending execution via Task 1100+”) and links to plan index.
+- Markdown lint passes (`pnpm lint:docs` if available).
+- Tests to add/modify: none.
+
+## References
+- Root AGENTS.md §15 (Acceptance Criteria)
+- SEC Preface (documentation precedence)
+- DD §0 documentation governance
+- Existing ADR contribution guidelines

--- a/docs/tasks/ui/0130-sim-control-contract-checklist.md
+++ b/docs/tasks/ui/0130-sim-control-contract-checklist.md
@@ -1,0 +1,32 @@
+# Sim Control Contract Checklist
+
+**ID:** 0130
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P2
+**Tags:** ui, simulation, documentation
+
+## Rationale
+Simulation controls require precise transport and acknowledgement semantics; documenting these before implementation prevents inconsistent handling across backend and frontend tasks.
+
+## Scope
+- In: produce a checklist within docs/TDD.md covering play/pause/step/speed and telemetry coupling expectations for the UI.
+- In: annotate SEC or DD where current guidance is silent on control acknowledgement sequencing.
+- Out: no modifications to transport code or store implementations.
+- Out: no addition of new control features beyond documentation.
+- Rollback: remove the checklist additions if later superseded by an ADR.
+
+## Deliverables
+- Checklist table or bullet list inserted into docs/TDD.md summarising control contract requirements and referencing follow-up tasks.
+- Optional note in docs/SEC.md pointing to the new checklist for implementation guidance.
+
+## Acceptance Criteria
+- ≤3 documentation files touched; ≤150 diff lines total.
+- Checklist explicitly lists required telemetry events, intent payloads, and acknowledgement timing with references to tasks 3100–3130.
+- Document builds without lint errors (`pnpm lint:docs` if available).
+- Tests to add/modify: none.
+
+## References
+- SEC §5 telemetry guidance
+- TDD §3 simulation controls
+- Root AGENTS.md §4 (Telemetry vs Intent)

--- a/docs/tasks/ui/1100-deterministic-world-loader.md
+++ b/docs/tasks/ui/1100-deterministic-world-loader.md
@@ -1,0 +1,34 @@
+# Deterministic World Loader
+
+**ID:** 1100
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** backend, read-model, data
+
+## Rationale
+Replacing the placeholder demo harness with a deterministic loader seeded from real blueprints and fixtures is essential for exercising live read-model hydration across subsequent tasks.
+
+## Scope
+- In: implement a new deterministic content loader that composes SimulationWorld data from parseCompanyWorld, blueprint catalogs, price maps, and workforce fixtures.
+- In: ensure loader seeding is configurable (seed string) and produces repeatable world snapshots for tests.
+- Out: no UI changes; backend-only modifications.
+- Out: no mutation of blueprint JSON in /data at runtime.
+- Rollback: reinstate the previous demo harness and remove loader registrations.
+
+## Deliverables
+- New loader module under packages/façade or equivalent backend path, replacing createDemoWorld usage.
+- Unit tests validating deterministic outputs for at least two seed values.
+- Documentation comment in docs/CHANGELOG.md noting loader introduction.
+
+## Acceptance Criteria
+- Max 3 source files touched (excluding tests) and ≤150 diff lines overall.
+- Loader assembles at least two structures with multiple rooms/zones/devices/workforce members per SEC §2 hierarchy.
+- Vitest unit tests (`pnpm test --filter loader`) verifying deterministic snapshots (hash or deep equality) for fixed seeds; 1–3 tests added.
+- No new external dependencies introduced.
+- Tests to add/modify: 2 unit tests covering seed determinism and blueprint integration.
+
+## References
+- SEC §2 hierarchy rules, §5 economics
+- TDD §2 world loading
+- Root AGENTS.md §2 (Determinism) & §5 (Blueprint handling)

--- a/docs/tasks/ui/1110-structure-read-model-coverage.md
+++ b/docs/tasks/ui/1110-structure-read-model-coverage.md
@@ -1,0 +1,34 @@
+# Structure Read-Model Coverage
+
+**ID:** 1110
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** backend, read-model
+
+## Rationale
+Live dashboards require read-model providers that compute real coverage, KPIs, climate snapshots, and economy totals instead of zeroed placeholders.
+
+## Scope
+- In: extend createReadModelProviders (or equivalent) to derive structure-level metrics (coverage, KPIs, economy aggregates) from the deterministic world loader.
+- In: include normalization/deep-freeze of the enriched payload prior to transport exposure.
+- Out: no UI store modifications.
+- Out: no telemetry publishing changes (handled in Phase 2 tasks).
+- Rollback: revert provider changes and restore placeholder metrics if regressions appear.
+
+## Deliverables
+- Updated provider module computing structure KPIs using engine subsystems.
+- Unit tests validating computed metrics for at least one deterministic world snapshot.
+- CHANGELOG note referencing metric hydration.
+
+## Acceptance Criteria
+- ≤3 source files edited (plus test file) and ≤150 diff lines.
+- Provider returns non-zero coverage, KPI, and economy data consistent with deterministic loader outputs.
+- Tests (1–3) assert expected numeric results with tolerance per SEC (EPS_REL 1e-6).
+- No new dependencies introduced.
+- Tests to add/modify: 2 unit tests verifying KPIs and normalization.
+
+## References
+- SEC §2 hierarchy, §5 economy
+- TDD §4 read-model normalization
+- Root AGENTS.md §2 determinism, §15 acceptance criteria

--- a/docs/tasks/ui/1120-room-zone-snapshots.md
+++ b/docs/tasks/ui/1120-room-zone-snapshots.md
@@ -1,0 +1,34 @@
+# Room & Zone Snapshots
+
+**ID:** 1120
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** backend, read-model, climate
+
+## Rationale
+Room and zone dashboards require climate, cultivation, and compatibility data derived from engine subsystems rather than static fixtures.
+
+## Scope
+- In: extend read-model providers to compute room climate snapshots, cultivation method metadata, and zone-level KPIs/tasks.
+- In: include compatibility and price-book joins needed for UI selectors.
+- Out: no HR/workforce data adjustments (handled separately).
+- Out: telemetry publishing (Phase 2).
+- Rollback: restore previous placeholder snapshot logic.
+
+## Deliverables
+- Updated provider logic for room and zone sections, including compatibility arrays.
+- Unit tests covering climate snapshot outputs and compatibility filtering.
+- Documentation note in CHANGELOG referencing room/zone hydration.
+
+## Acceptance Criteria
+- ≤3 source files (plus tests) modified with ≤150 diff lines.
+- Room snapshots expose temperature/humidity/lighting metrics consistent with engine data.
+- Zone KPIs include cultivation method IDs, compatibility lists, and pending tasks per deterministic world.
+- Tests (1–3) assert expected snapshot fields and compatibility filtering.
+- Tests to add/modify: 3 unit tests (climate snapshot, compatibility join, zone task list).
+
+## References
+- SEC §6 device power/heat coupling, §7 cultivation methods
+- TDD §4 room/zone read-models
+- Root AGENTS.md §§4–6 (telemetry, device placement, cultivation)

--- a/docs/tasks/ui/1130-hr-economy-hydration.md
+++ b/docs/tasks/ui/1130-hr-economy-hydration.md
@@ -1,0 +1,34 @@
+# HR & Economy Hydration
+
+**ID:** 1130
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P2
+**Tags:** backend, workforce, economy
+
+## Rationale
+Workforce and finance surfaces need real rosters, utilization, and balance data derived from the deterministic world to replace synthetic placeholders.
+
+## Scope
+- In: extend read-model providers to populate workforce directory, assignment timelines, and economy balance/delta fields.
+- In: compute strain catalog endpoint if required to support Phase 4 UI work.
+- Out: telemetry event publishing (Phase 2) and UI selectors (Phase 4).
+- Out: introduction of new external dependencies.
+- Rollback: revert provider changes and associated endpoints.
+
+## Deliverables
+- Updated provider modules for workforce/economy plus optional strain catalog endpoint definitions.
+- Unit tests validating workforce counts, utilization percentages, and balance calculations.
+- CHANGELOG entry referencing workforce/economy hydration.
+
+## Acceptance Criteria
+- ≤3 source files (plus tests) modified with ≤150 diff lines.
+- Workforce read model includes roster with assignments, warnings, and utilization derived from deterministic world data.
+- Economy read model exposes balance, daily delta, and tariff references consistent with SEC §3.
+- Strain catalog (if added) returns deterministic cultivar metadata.
+- Tests to add/modify: 3 unit tests (workforce roster, economy totals, optional strain endpoint).
+
+## References
+- SEC §3 economy, §7 workforce tasks
+- DD §3 workforce modelling
+- Root AGENTS.md §§5, 6a (interface stacking) & §15

--- a/docs/tasks/ui/2100-telemetry-loop-integration.md
+++ b/docs/tasks/ui/2100-telemetry-loop-integration.md
@@ -1,0 +1,34 @@
+# Telemetry Loop Integration
+
+**ID:** 2100
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** backend, telemetry, playback
+
+## Rationale
+The engine run loop must drive the transport playback controller to emit live telemetry, replacing the stubbed socket reconnect errors observed today.
+
+## Scope
+- In: connect engine tick progression to the transport playback controller, ensuring deterministic scheduling.
+- In: validate playback loop respects pause/resume controls exposed via intents.
+- Out: frontend store updates (Phase 4) and intent handlers (Phase 3).
+- Out: changes to telemetry payload schemas (covered by other tasks).
+- Rollback: restore previous loop wiring and disable new hooks.
+
+## Deliverables
+- Updated playback controller wiring linking engine ticks to transport emission.
+- Unit/integration tests verifying tick advancement triggers telemetry dispatch.
+- CHANGELOG note summarising telemetry loop integration.
+
+## Acceptance Criteria
+- ≤3 source files (plus tests) modified; total diff ≤150 lines.
+- Playback controller receives deterministic tick cadence (1 tick = 1 in-game hour) and respects pause state.
+- Tests (1–3) confirm telemetry dispatch occurs within one iteration after tick advancement.
+- No new dependencies introduced; use existing scheduler utilities.
+- Tests to add/modify: 2 integration tests around playback loop.
+
+## References
+- SEC §1 tick pipeline, §4 telemetry
+- TDD §5 transport playback
+- Root AGENTS.md §2 determinism, §4 telemetry bus guidance

--- a/docs/tasks/ui/2110-socket-topic-audit.md
+++ b/docs/tasks/ui/2110-socket-topic-audit.md
@@ -1,0 +1,34 @@
+# Socket Topic Audit
+
+**ID:** 2110
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** backend, telemetry, qa
+
+## Rationale
+Ensuring Socket.IO namespaces emit the full set of telemetry topics (tick, zone, workforce, harvest) prevents UI regressions and reconnect loops.
+
+## Scope
+- In: audit current telemetry topics and expand the publisher to include missing tick/zone/workforce/harvest events.
+- In: document topic schemas and register them in a schema validation utility.
+- Out: frontend subscription updates (Phase 4).
+- Out: intent acknowledgement changes (Phase 3).
+- Rollback: revert topic registration changes and restore previous publisher state.
+
+## Deliverables
+- Updated telemetry publisher module emitting required topics with schema validation.
+- Unit tests asserting emission of each topic on deterministic tick data.
+- Documentation update referencing topic coverage (CHANGELOG or docs/telemetry).
+
+## Acceptance Criteria
+- ≤3 source files (plus tests) modified; total diff ≤150 lines.
+- Publisher emits deterministic payloads validated against schema definitions.
+- Tests (1–3) confirm each topic fires when expected and fails if schema violated.
+- No new dependencies added.
+- Tests to add/modify: 3 unit tests (tick, zone, workforce topics).
+
+## References
+- SEC §4 telemetry topics
+- TDD §5 transport telemetry
+- Root AGENTS.md §4 telemetry bus guidance

--- a/docs/tasks/ui/2120-telemetry-buffer-drain.md
+++ b/docs/tasks/ui/2120-telemetry-buffer-drain.md
@@ -1,0 +1,34 @@
+# Telemetry Buffer Drain
+
+**ID:** 2120
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P2
+**Tags:** backend, telemetry
+
+## Rationale
+Pending telemetry buffers should flush deterministically to avoid memory leaks and delayed UI updates once live playback is enabled.
+
+## Scope
+- In: audit pendingTelemetry handling and ensure buffers drain on connection establishment and reconnection.
+- In: add metrics/logging hooks for buffer length under debug builds.
+- Out: frontend socket handling (Phase 4) and intent logic (Phase 3).
+- Out: addition of observability infrastructure beyond simple logging counters.
+- Rollback: revert buffer management changes to previous behavior.
+
+## Deliverables
+- Updated telemetry binder/controller logic ensuring buffers flush within one tick post connection.
+- Unit tests verifying buffer drain on initial connect and reconnect scenarios.
+- CHANGELOG note summarizing buffer drain fix.
+
+## Acceptance Criteria
+- ≤3 source files (plus tests) modified; ≤150 diff lines.
+- Buffer length is zero after connect/reconnect in deterministic tests.
+- Added logging guarded by debug flag to avoid noisy production output.
+- Tests to add/modify: 2 unit tests (initial connect, reconnect flush).
+- No new dependencies introduced.
+
+## References
+- SEC §4 telemetry bus behavior
+- TDD §5 telemetry buffering
+- Root AGENTS.md §4 telemetry guidance

--- a/docs/tasks/ui/2130-telemetry-schema-docs.md
+++ b/docs/tasks/ui/2130-telemetry-schema-docs.md
@@ -1,0 +1,34 @@
+# Telemetry Schema Docs
+
+**ID:** 2130
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P2
+**Tags:** telemetry, documentation
+
+## Rationale
+Documenting telemetry schemas and sample payloads ensures frontend developers can subscribe and validate events consistently with backend expectations.
+
+## Scope
+- In: document telemetry topic schemas and sample payloads in docs/tools or equivalent documentation section.
+- In: add JSON schema or TypeScript type definitions under transport package for validation.
+- Out: runtime schema enforcement beyond compile-time or test validation.
+- Out: frontend subscription implementation.
+- Rollback: remove newly added documentation and schema files.
+
+## Deliverables
+- Documentation page detailing telemetry topics, payload fields, and sample JSON.
+- TypeScript schema definitions or JSON schema files for each topic, referenced in tests.
+- CHANGELOG note referencing telemetry schema documentation.
+
+## Acceptance Criteria
+- ≤3 files touched (docs + schema + test) and ≤150 diff lines.
+- Documentation references tasks 4100–4130 for frontend consumption guidance.
+- Tests (1–3) validate schema definitions against sample payload fixtures.
+- No new dependencies added.
+- Tests to add/modify: 1 unit test verifying schema validation.
+
+## References
+- SEC §4 telemetry
+- DD §4 data interchange
+- Root AGENTS.md §4 telemetry guidance

--- a/docs/tasks/ui/3100-intent-pipeline-core.md
+++ b/docs/tasks/ui/3100-intent-pipeline-core.md
@@ -1,0 +1,34 @@
+# Intent Pipeline Core
+
+**ID:** 3100
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** backend, intents
+
+## Rationale
+The façade must handle rename and movement intents end-to-end so UI interactions stop logging stub messages.
+
+## Scope
+- In: implement rename/move intents (structures, rooms, zones, devices) through the façade command pipeline with deterministic validation.
+- In: ensure acknowledgements return success/failure envelopes consistent with TDD.
+- Out: climate/lighting adjustments (other tasks).
+- Out: frontend store updates (Phase 4).
+- Rollback: revert command handlers and restore stub responses.
+
+## Deliverables
+- Updated command handler modules supporting rename/move intents.
+- Unit tests covering success and failure cases with deterministic seeds.
+- CHANGELOG entry referencing intent pipeline expansion.
+
+## Acceptance Criteria
+- ≤3 source files (plus tests) modified; ≤150 diff lines.
+- Handlers validate placementScope and roomPurpose per SEC before applying moves.
+- Acknowledgements include correlation IDs and status per contract.
+- Tests (1–3) cover rename success, move validation failure, and success path.
+- Tests to add/modify: 3 unit tests.
+
+## References
+- SEC §4 intent contracts, §4.2 placement
+- TDD §6 command handling
+- Root AGENTS.md §§4–5, §13 Do & Don’t

--- a/docs/tasks/ui/3110-environment-adjust-intents.md
+++ b/docs/tasks/ui/3110-environment-adjust-intents.md
@@ -1,0 +1,34 @@
+# Environment Adjust Intents
+
+**ID:** 3110
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** backend, intents, climate
+
+## Rationale
+Lighting and climate adjustments must flow through the façade pipeline to control devices with acknowledgements that mirror SEC expectations.
+
+## Scope
+- In: implement lighting/climate adjustment intents (setpoints, schedules) for rooms/zones with validation against device capacity and cultivation methods.
+- In: ensure acknowledgements include resulting target state and command correlation.
+- Out: HR/pest/maintenance intents (other tasks).
+- Out: frontend UI updates.
+- Rollback: remove new intent handlers and revert to stub responses.
+
+## Deliverables
+- Command handler updates enabling climate/lighting adjustments.
+- Unit tests verifying validation failures (capacity breach) and success responses.
+- CHANGELOG note documenting environment intent support.
+
+## Acceptance Criteria
+- ≤3 source files (plus tests) modified; ≤150 diff lines.
+- Handlers enforce SEC §6 power/heat coupling constraints when calculating new setpoints.
+- Tests (1–3) include success case and failure due to incompatible cultivation method/device.
+- Acknowledgements return deterministic payloads consumed by Phase 4 tasks.
+- Tests to add/modify: 3 unit tests.
+
+## References
+- SEC §6 power & climate, §7 cultivation
+- TDD §6 command handling
+- Root AGENTS.md §§6, 13

--- a/docs/tasks/ui/3120-workforce-maintenance-intents.md
+++ b/docs/tasks/ui/3120-workforce-maintenance-intents.md
@@ -1,0 +1,33 @@
+# Workforce & Maintenance Intents
+
+**ID:** 3120
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P2
+**Tags:** backend, intents, workforce
+
+## Rationale
+HR, pest, and maintenance workflows must issue intents that adjust assignments and task queues to reflect live simulation state.
+
+## Scope
+- In: implement HR assignment, pest mitigation, and maintenance scheduling intents with validation against workforce capacity and SEC policies.
+- In: ensure acknowledgements return updated queue summaries and warnings.
+- Out: UI workforce panel updates (Phase 4).
+- Out: telemetry publishing (Phase 2 already handles events).
+- Rollback: remove new intent handlers if instability arises.
+
+## Deliverables
+- Command handlers for HR/pest/maintenance intents.
+- Unit tests covering assignment success, capacity overflow failure, and pest mitigation scheduling.
+- CHANGELOG entry referencing workforce intent support.
+
+## Acceptance Criteria
+- ≤3 source files (plus tests) modified; ≤150 diff lines.
+- Handlers enforce workforce utilization caps and SEC §7 task policies.
+- Acknowledgements include deterministic roster deltas for UI consumption.
+- Tests to add/modify: 3 unit tests (assignment success, overflow failure, pest scheduling).
+
+## References
+- SEC §7 workforce tasks
+- DD §3 workforce operations
+- Root AGENTS.md §6a interface stacking

--- a/docs/tasks/ui/3130-simulation-control-acks.md
+++ b/docs/tasks/ui/3130-simulation-control-acks.md
@@ -1,0 +1,33 @@
+# Simulation Control ACKs
+
+**ID:** 3130
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** backend, intents, simulation
+
+## Rationale
+Simulation control intents (play, pause, step, speed) must propagate acknowledgements that reflect actual playback state to keep frontend stores consistent.
+
+## Scope
+- In: implement command handlers that mutate playback state and respond with deterministic acknowledgements.
+- In: ensure state mirrors update only after successful backend confirmation, coordinating with telemetry loop.
+- Out: frontend store wiring (Phase 4) and telemetry loop (Phase 2 already handles ticking).
+- Out: additional control types beyond play/pause/step/speed.
+- Rollback: restore previous stubbed control responses.
+
+## Deliverables
+- Updated playback command handlers with acknowledgement payloads.
+- Unit tests ensuring each control intent results in expected playback state transitions.
+- CHANGELOG note referencing control acknowledgement support.
+
+## Acceptance Criteria
+- ≤3 source files (plus tests) modified; ≤150 diff lines.
+- Acknowledgements include new state (`running`, `paused`, `speedMultiplier`) and correlation IDs.
+- Tests (1–3) cover play→pause transition, single step behavior, and speed change validation.
+- Tests to add/modify: 3 unit tests.
+
+## References
+- SEC §1 tick standard, §4 telemetry vs command
+- TDD §3 simulation controls
+- Root AGENTS.md §4 telemetry separation, §15 acceptance

--- a/docs/tasks/ui/4100-read-model-store-live-fetch.md
+++ b/docs/tasks/ui/4100-read-model-store-live-fetch.md
@@ -1,0 +1,33 @@
+# Read-Model Store Live Fetch
+
+**ID:** 4100
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** frontend, state, data
+
+## Rationale
+The frontend store must fetch live read models from the façade, handling loading/error states and falling back to fixtures only when transport is absent.
+
+## Scope
+- In: update Zustand read-model store to fetch `/api/read-models` on init, manage loading/error states, and respect VITE_TRANSPORT_BASE_URL.
+- In: add retry/backoff hooks with deterministic timing for tests.
+- Out: component consumption changes (handled by other tasks).
+- Out: telemetry subscriptions (separate tasks).
+- Rollback: restore previous deterministic snapshot seeding.
+
+## Deliverables
+- Updated store implementation handling live fetch, loading, and error states.
+- Unit tests covering successful fetch, error fallback, and fixture-only mode.
+- CHANGELOG note referencing live fetch behavior.
+
+## Acceptance Criteria
+- ≤3 source files (plus tests) modified; ≤150 diff lines.
+- Store exposes `status: 'loading'|'ready'|'error'` and `lastError` fields used by downstream hooks.
+- Tests (1–3) simulate fetch success, network failure, and no-transport configuration via mocked fetch.
+- Tests to add/modify: 3 unit tests using Vitest/MSW or fetch mocks.
+
+## References
+- SEC §4 data transport
+- TDD §4 read-model store
+- Root AGENTS.md §2 determinism, §4 telemetry separation

--- a/docs/tasks/ui/4110-navigation-live-ids.md
+++ b/docs/tasks/ui/4110-navigation-live-ids.md
@@ -1,0 +1,33 @@
+# Navigation Live IDs
+
+**ID:** 4110
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** frontend, navigation
+
+## Rationale
+Navigation and breadcrumb helpers must derive their structure/room/zone lists from live read models to avoid stale fixture IDs.
+
+## Scope
+- In: refactor navigation hooks to consume selectors sourced from the live read-model store.
+- In: update resolver helpers to handle missing IDs gracefully and sync with deterministic loader IDs.
+- Out: UI styling changes.
+- Out: modifications to read-model fetching (handled in Task 4100).
+- Rollback: reinstate previous deterministic fixtures for navigation.
+
+## Deliverables
+- Updated hooks/utilities deriving navigation data from live store state.
+- Component test validating navigation renders correct structure/room/zone list from mocked store.
+- CHANGELOG entry referencing navigation live data wiring.
+
+## Acceptance Criteria
+- ≤3 source/component files (plus tests) modified; ≤150 diff lines.
+- Hooks fallback to fixture data only when store reports `status: 'error'` and no transport configured.
+- Tests (1–3) cover success path (live data) and fallback path (error to fixtures).
+- Tests to add/modify: 2 component/unit tests.
+
+## References
+- SEC §2 hierarchy
+- TDD §4 navigation hooks
+- Root AGENTS.md §2 determinism, §5 hierarchy invariants

--- a/docs/tasks/ui/4120-dashboard-telemetry-binding.md
+++ b/docs/tasks/ui/4120-dashboard-telemetry-binding.md
@@ -1,0 +1,33 @@
+# Dashboard Telemetry Binding
+
+**ID:** 4120
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** frontend, dashboard, telemetry
+
+## Rationale
+Dashboard KPIs must reflect live telemetry and economy read models rather than hard-coded numbers.
+
+## Scope
+- In: wire dashboard components to live telemetry streams and read-model selectors, replacing placeholder values.
+- In: add derived formatting utilities with deterministic rounding consistent with SEC tolerances.
+- Out: workforce/strains panels (other tasks).
+- Out: introduction of new chart libraries.
+- Rollback: revert dashboard components to placeholder values.
+
+## Deliverables
+- Updated dashboard components/hooks consuming live data.
+- Component tests verifying KPIs update when telemetry emits tick/zone events.
+- CHANGELOG entry referencing dashboard telemetry wiring.
+
+## Acceptance Criteria
+- ≤3 component/hook files (plus tests) modified; ≤150 diff lines.
+- Dashboard updates within one tick of telemetry event and displays correct economy deltas from read model.
+- Tests (1–3) simulate telemetry events via mocked socket client verifying UI updates.
+- Tests to add/modify: 3 component tests using testing-library and mocked telemetry provider.
+
+## References
+- SEC §4 telemetry, §5 economy
+- TDD §5 dashboard binding
+- Root AGENTS.md §4 telemetry guidance

--- a/docs/tasks/ui/4130-workforce-strain-ui-binding.md
+++ b/docs/tasks/ui/4130-workforce-strain-ui-binding.md
@@ -1,0 +1,34 @@
+# Workforce & Strain UI Binding
+
+**ID:** 4130
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P2
+**Tags:** frontend, workforce, strains
+
+## Rationale
+The workforce surface and strains catalog must pull from live read models to display roster utilization and cultivar metadata accurately.
+
+## Scope
+- In: update workforce UI selectors/components to consume hydrated read models and intent acknowledgements from Phase 3.
+- In: implement Strains page fetching strain catalog read model and rendering cultivar details.
+- Out: telemetry subscriptions for workforce events (already handled in Task 4120 testing).
+- Out: HR command issuance (handled elsewhere).
+- Rollback: revert UI components to fixture data usage.
+
+## Deliverables
+- Updated workforce components/hooks using live selectors and acknowledgements.
+- Strains page wired to strain catalog read model with deterministic ordering.
+- Component tests verifying roster utilization rendering and strain catalog display.
+- CHANGELOG entry referencing workforce/strain wiring.
+
+## Acceptance Criteria
+- ≤3 component/hook files (plus tests) modified; ≤150 diff lines.
+- Workforce UI reflects utilization percentages and warnings from read model within one tick of acknowledgement update.
+- Strains page renders deterministic cultivar list matching backend catalog IDs.
+- Tests to add/modify: 3 component tests (workforce roster, warning display, strain list).
+
+## References
+- SEC §7 workforce, §5 price separation (strain catalog)
+- TDD §4 workforce UI
+- Root AGENTS.md §§5, 6a

--- a/docs/tasks/ui/4140-sim-control-bar-live-state.md
+++ b/docs/tasks/ui/4140-sim-control-bar-live-state.md
@@ -1,0 +1,33 @@
+# Sim Control Bar Live State
+
+**ID:** 4140
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** frontend, simulation, controls
+
+## Rationale
+The simulation control bar must reflect live playback state, clock, and economy values sourced from telemetry and acknowledgements.
+
+## Scope
+- In: bind control bar components to telemetry tick clock, economy read model, and intent acknowledgement state from Phase 3.
+- In: ensure UI updates only after successful backend acknowledgements to maintain determinism.
+- Out: command dispatch refactors (existing hooks remain).
+- Out: styling changes.
+- Rollback: revert control bar to previous placeholder bindings.
+
+## Deliverables
+- Updated control bar hooks/components reading telemetry clock and economy balance/delta.
+- Component tests confirming state updates after simulated acknowledgement and telemetry events.
+- CHANGELOG note referencing control bar live state.
+
+## Acceptance Criteria
+- ≤3 files (plus tests) modified; ≤150 diff lines.
+- Control bar clock increments per telemetry tick and pauses when playback state ack indicates paused.
+- Economy balance and daily delta values originate from live read model without hard-coded numbers.
+- Tests to add/modify: 2 component tests (tick advance, pause state).
+
+## References
+- SEC §1 tick standard, §5 economy
+- TDD §3 simulation controls
+- Root AGENTS.md §§2, 4

--- a/docs/tasks/ui/5150-read-model-test-harness.md
+++ b/docs/tasks/ui/5150-read-model-test-harness.md
@@ -1,0 +1,33 @@
+# Read-Model Test Harness
+
+**ID:** 5150
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** testing, read-model
+
+## Rationale
+Automated tests must verify read-model hydration outputs and transport clients to prevent regressions once live data wiring is complete.
+
+## Scope
+- In: add unit/integration tests exercising read-model providers and transport clients using deterministic loader seeds.
+- In: include golden snapshots or hashes within tolerances defined by SEC.
+- Out: UI component tests (handled in Phase 4).
+- Out: new dependencies or CI pipelines.
+- Rollback: remove new tests and fixtures if instability arises.
+
+## Deliverables
+- Vitest suites covering structure/room/zone/workforce/economy read-model hydration.
+- Fixture data or serialized snapshots stored under tests/resources.
+- CHANGELOG note referencing test harness introduction.
+
+## Acceptance Criteria
+- ≤3 test files added/updated; ≤150 diff lines.
+- Tests cover at least two deterministic seeds and compare outputs within EPS_REL 1e-6.
+- Transport client mocked responses validated against schema definitions from Task 2130.
+- Tests to add/modify: 3 integration/unit tests.
+
+## References
+- SEC §2–§7 data expectations
+- TDD §4 read-model testing
+- Root AGENTS.md §2 determinism, §15 acceptance

--- a/docs/tasks/ui/5160-telemetry-e2e-suite.md
+++ b/docs/tasks/ui/5160-telemetry-e2e-suite.md
@@ -1,0 +1,33 @@
+# Telemetry E2E Suite
+
+**ID:** 5160
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** testing, telemetry
+
+## Rationale
+End-to-end telemetry tests ensure Socket.IO topics and UI bindings remain synchronized after live data wiring.
+
+## Scope
+- In: create e2e tests (Playwright or equivalent) that start façade + UI, simulate ticks, and verify dashboard updates.
+- In: reuse deterministic loader seed to keep outputs stable.
+- Out: performance/load testing.
+- Out: infrastructure changes beyond necessary scripts.
+- Rollback: remove e2e suite and revert scripts if failures occur.
+
+## Deliverables
+- E2E test script verifying telemetry topics (tick, zone, workforce) propagate to UI controls.
+- Supporting fixtures/scripts for launching façade and UI in test mode.
+- CHANGELOG note referencing telemetry e2e coverage.
+
+## Acceptance Criteria
+- ≤3 files touched (test script + config + doc) with ≤150 diff lines.
+- Test asserts telemetry-driven UI changes within deterministic tick count.
+- Test validates schema compliance using definitions from Task 2130.
+- Tests to add/modify: 1 e2e test.
+
+## References
+- SEC §4 telemetry
+- TDD §5 e2e coverage
+- Root AGENTS.md §4 telemetry guidance

--- a/docs/tasks/ui/5170-intent-regression-suite.md
+++ b/docs/tasks/ui/5170-intent-regression-suite.md
@@ -1,0 +1,33 @@
+# Intent Regression Suite
+
+**ID:** 5170
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P1
+**Tags:** testing, intents
+
+## Rationale
+Automated regression tests for intent flows ensure rename/move/environment/workforce commands remain stable and acknowledged correctly.
+
+## Scope
+- In: add unit/integration tests covering command handlers introduced in Phase 3 with deterministic seeds and mocked transport.
+- In: verify acknowledgements propagate expected payloads and errors.
+- Out: UI-level intent tests (handled elsewhere).
+- Out: new dependencies.
+- Rollback: remove regression tests and fixtures.
+
+## Deliverables
+- Vitest suites for rename/move, environment adjustments, workforce/maintenance, and simulation control intents.
+- Fixtures for sample intent payloads referencing deterministic world IDs.
+- CHANGELOG note referencing intent regression coverage.
+
+## Acceptance Criteria
+- ≤3 test files touched; ≤150 diff lines.
+- Tests cover success and failure cases for each intent category with deterministic assertions.
+- Tests assert acknowledgements include correlation IDs and status codes defined in TDD.
+- Tests to add/modify: 3 integration tests.
+
+## References
+- SEC §4 intent contracts
+- TDD §6 command handling tests
+- Root AGENTS.md §§4, 13

--- a/docs/tasks/ui/5180-docs-and-adr-finalization.md
+++ b/docs/tasks/ui/5180-docs-and-adr-finalization.md
@@ -1,0 +1,33 @@
+# Docs and ADR Finalization
+
+**ID:** 5180
+**Status:** Planned
+**Owner:** unassigned
+**Priority:** P2
+**Tags:** documentation, governance
+
+## Rationale
+Final documentation updates must reflect completion of live data wiring, ensuring ADRs, CHANGELOG, and plan artifacts remain authoritative.
+
+## Scope
+- In: update docs/CHANGELOG.md, relevant ADRs, and plan index/runbook to mark tasks as completed with links to implementation PRs.
+- In: document validation results and test suites executed.
+- Out: code changes.
+- Out: creation of new ADRs (annotations only).
+- Rollback: revert documentation updates if work is rolled back.
+
+## Deliverables
+- Finalized CHANGELOG entries summarizing live data wiring completion.
+- ADR updates noting final decision status and references to executed tasks.
+- Plan documents updated with completion notes and links to PRs/tests.
+
+## Acceptance Criteria
+- ≤3 documentation files modified; ≤150 diff lines.
+- CHANGELOG entry references SEC/DD/TDD compliance and lists executed test suites.
+- ADR annotations include status (Accepted) with task IDs and PR links.
+- Tests to add/modify: none.
+
+## References
+- Root AGENTS.md §15 acceptance
+- SEC Preface documentation precedence
+- DD documentation governance

--- a/docs/tasks/ui/_plan/0000-plan-index.md
+++ b/docs/tasks/ui/_plan/0000-plan-index.md
@@ -1,0 +1,40 @@
+# Frontend Live Data Wiring Plan Index
+
+## Purpose & Scope
+This plan decomposes the frontend live-data wiring initiative (Phases 0–5) into atomic, time-safe tasks that convert UI fixtures into authoritative backend-driven experiences while remaining compliant with SEC, DD, and TDD documentation priorities. The scope spans contract alignment, backend hydration, telemetry plumbing, intent handling, frontend wiring, and validation/documentation closure.
+
+## Task Table
+| ID | Title | Phase | Size Budget |
+| --- | --- | --- | --- |
+| 0100 | Contracts Inventory Sync | 0 | ≤3 files, ≤150 diff lines, 0 tests |
+| 0110 | SEC Gap Register | 0 | ≤3 files, ≤150 diff lines, 0 tests |
+| 0120 | Tracker and ADR Alignment | 0 | ≤3 files, ≤150 diff lines, 0 tests |
+| 0130 | Sim Control Contract Checklist | 0 | ≤3 files, ≤150 diff lines, 0 tests |
+| 1100 | Deterministic World Loader | 1 | ≤3 files, ≤150 diff lines, 1–3 tests |
+| 1110 | Structure Read-Model Coverage | 1 | ≤3 files, ≤150 diff lines, 1–3 tests |
+| 1120 | Room & Zone Snapshots | 1 | ≤3 files, ≤150 diff lines, 1–3 tests |
+| 1130 | HR & Economy Hydration | 1 | ≤3 files, ≤150 diff lines, 1–3 tests |
+| 2100 | Telemetry Loop Integration | 2 | ≤3 files, ≤150 diff lines, 1–3 tests |
+| 2110 | Socket Topic Audit | 2 | ≤3 files, ≤150 diff lines, 1–3 tests |
+| 2120 | Telemetry Buffer Drain | 2 | ≤3 files, ≤150 diff lines, 1–3 tests |
+| 2130 | Telemetry Schema Docs | 2 | ≤3 files, ≤150 diff lines, 1–3 tests |
+| 3100 | Intent Pipeline Core | 3 | ≤3 files, ≤150 diff lines, 1–3 tests |
+| 3110 | Environment Adjust Intents | 3 | ≤3 files, ≤150 diff lines, 1–3 tests |
+| 3120 | Workforce & Maintenance Intents | 3 | ≤3 files, ≤150 diff lines, 1–3 tests |
+| 3130 | Simulation Control ACKs | 3 | ≤3 files, ≤150 diff lines, 1–3 tests |
+| 4100 | Read-Model Store Live Fetch | 4 | ≤3 files, ≤150 diff lines, 1–3 tests |
+| 4110 | Navigation Live IDs | 4 | ≤3 files, ≤150 diff lines, 1–3 tests |
+| 4120 | Dashboard Telemetry Binding | 4 | ≤3 files, ≤150 diff lines, 1–3 tests |
+| 4130 | Workforce & Strain UI Binding | 4 | ≤3 files, ≤150 diff lines, 1–3 tests |
+| 4140 | Sim Control Bar Live State | 4 | ≤3 files, ≤150 diff lines, 1–3 tests |
+| 5150 | Read-Model Test Harness | 5 | ≤3 files, ≤150 diff lines, 1–3 tests |
+| 5160 | Telemetry E2E Suite | 5 | ≤3 files, ≤150 diff lines, 1–3 tests |
+| 5170 | Intent Regression Suite | 5 | ≤3 files, ≤150 diff lines, 1–3 tests |
+| 5180 | Docs and ADR Finalization | 5 | ≤3 files, ≤150 diff lines, 0 tests |
+
+## How to Run
+```
+Program: Execute Task
+Inputs:
+  TASK_FILE: <relative-path-to-task-md>
+```

--- a/docs/tasks/ui/_plan/0001-runbook.md
+++ b/docs/tasks/ui/_plan/0001-runbook.md
@@ -1,0 +1,31 @@
+# Frontend Live Data Wiring Runbook
+
+## Execution Order
+1. **Phase 0 – Contracts & Documentation**
+   - 0100 → 0110 → 0130 → 0120
+2. **Phase 1 – Backend Scenario & Hydration**
+   - 1100 → 1110 → 1120 → 1130
+3. **Phase 2 – Telemetry & Playback**
+   - 2100 → 2120 → 2110 → 2130
+4. **Phase 3 – Intent Coverage & Control Flows**
+   - 3100 → 3110 → 3120 → 3130
+5. **Phase 4 – Frontend Wiring to Live Data**
+   - 4100 → 4110 → 4120 → 4130 → 4140
+6. **Phase 5 – Validation & Documentation**
+   - 5150 → 5170 → 5160 → 5180
+
+## Pre-Flight Checklist
+- **General**: confirm Node.js 22 environment, install deps via `pnpm install`, ensure façade/backend dev servers idle.
+- **Documentation tasks (Phase 0 & 5)**: open SEC/DD/TDD/ADR files, gather task IDs for cross-references, prepare markdown lint (`pnpm lint:docs`).
+- **Loader/Hydration tasks (1100–1130)**: identify deterministic seed, collect blueprint and price-map fixture paths, note expected world hierarchy for assertions.
+- **Telemetry tasks (2100–2130)**: confirm playback controller entry point, existing Socket.IO namespaces, and schema validation utilities.
+- **Intent tasks (3100–3130)**: enumerate current stub handlers, correlation ID utilities, and validation helpers; prepare sample payload fixtures.
+- **Frontend wiring tasks (4100–4140)**: verify store modules, hook/component paths, and available mock utilities (testing-library, MSW) for deterministic tests.
+- **Testing & Docs closure (5150–5180)**: catalogue new/updated test suites, ensure deterministic seeds recorded, and update CHANGELOG/ADR templates.
+
+## Execute Task Prompt
+```
+Program: Execute Task
+Inputs:
+  TASK_FILE: docs/tasks/ui/<task-file-name>.md
+```


### PR DESCRIPTION
## Summary
- add a phase-by-phase plan index and runbook for wiring the frontend to live backend data
- author 25 atomic ui task briefs covering contracts, hydration, telemetry, intents, frontend wiring, and validation workstreams
- capture strict size/test budgets plus rollback guidance to keep future executions deterministic and SEC-aligned

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68f1d4624f7c832581c112ef11ac11fb