### PR TITLE
feat(task:0120): Tracker and ADR Alignment

### DIFF
--- a/docs/ADR/ADR-0016-ui-component-stack.md
+++ b/docs/ADR/ADR-0016-ui-component-stack.md
@@ -40,3 +40,7 @@ Adopt **shadcn/ui**, which copies unstyled components into the repository and co
 - SEC §0.1 Platform Baseline (Tailwind as styling choice)
 - DD §1/§15 guardrails referencing UI boundaries
 - AGENTS §1 platform stack
+- **Status Note (2025-02-14):** Pending execution via [Task 1100 Deterministic World Loader](../tasks/ui/1100-deterministic-world-loader.md)
+  and successors documented in the [Frontend Live Data Wiring Plan Index](../tasks/ui/_plan/0000-plan-index.md). Phase 0
+  documentation alignment (Task 0120) keeps this ADR as the authoritative reference for UI stack assumptions while the
+  fixture-to-live migration lands.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,13 @@
 
 ### Unreleased — Hotfix Batch 03
 
+- 2025-02-14 — Task 0120 Tracker and ADR Alignment:
+  - Documented Phase 0 ownership in the live-data plan index so SEC Preface and DD §0 documentation precedence can reference a
+    single tracker for fixture-to-live execution (docs/tasks/ui/_plan/0000-plan-index.md).
+  - Added ADR status notes pointing future engineering work to Phases 1–5 delivery tasks while clearly marking the dependency
+    on live data wiring.
+  - Recorded this milestone in the changelog to keep SEC/DD/TDD traceability aligned for UI documentation updates.
+
 - Task 0110: Added the SEC gap register (entry 0110-RM) summarising the pending
   read-model live data handshake, linked DD/TDD cross-references to the register,
   and captured ownership plus follow-up tasks for traceability (docs/SEC.md,

--- a/docs/tasks/ui/_plan/0000-plan-index.md
+++ b/docs/tasks/ui/_plan/0000-plan-index.md
@@ -32,6 +32,13 @@ This plan decomposes the frontend live-data wiring initiative (Phases 0–5) int
 | 5170 | Intent Regression Suite | 5 | ≤3 files, ≤150 diff lines, 1–3 tests |
 | 5180 | Docs and ADR Finalization | 5 | ≤3 files, ≤150 diff lines, 0 tests |
 
+## Status Notes (2025-02-14)
+- [Task 0120](../0120-tracker-and-adr-alignment.md) finalises Phase 0 documentation alignment so future PRs can reference a
+  single source of truth for the fixture-to-live migration.
+- Execution ownership shifts to Phase 1 delivery tasks starting with
+  [Task 1100](../1100-deterministic-world-loader.md) and cascades through Phases 2–5 for telemetry, intent, UI binding, and
+  validation closure.
+
 ## How to Run
 ```
 Program: Execute Task


### PR DESCRIPTION
## Summary
- Annotated the UI live-data plan index with Phase 0 ownership and links into the execution backlog.
- Logged the documentation milestone in the changelog to surface the fixture-to-live migration hand-off.
- Added an ADR status note pointing engineers from the component stack decision to the live-data plan index and Phase 1 tasks.

## Contract References
- SEC Preface — documentation precedence
- DD §0 — documentation governance

## Testing
- `pnpm i`
- `pnpm -r test`
- `pnpm -r lint`
- `pnpm -r build`

## Deviations
- None.


------
https://chatgpt.com/codex/tasks/task_e_68f1f90511408325951abb9b15a719c7