### PR TITLE
feat(task:1110): Structure Read-Model Coverage

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Task 0130: Added a simulation control contract checklist to TDD §6a and linked SEC §11 to the new guardrails so playback intents, acknowledgements, and telemetry expectations stay aligned with follow-up tasks 3100–3130 and 4140 (docs/TDD.md, docs/SEC.md).
 
 - Task 1100: Introduced a deterministic world loader that assembles company, structure, zone, device, and workforce fixtures from blueprint and price catalogs, updated the façade dev servers to seed from it, and shipped unit coverage ensuring stable seeds and blueprint integration (`packages/facade/src/backend/deterministicWorldLoader.ts`, `packages/facade/src/transport/devServer.ts`, `packages/facade/src/server/devServer.ts`, `packages/facade/tests/unit/backend/deterministicWorldLoader.test.ts`).
+- Task 1110: Hydrated structure read-model coverage, KPI, and economy aggregates using the deterministic world loader, deep-froze façade snapshots before transport, and added unit coverage asserting seeded metrics and freeze behaviour (`packages/facade/src/server/readModelProviders.ts`, `packages/facade/tests/unit/server/readModelProviders.test.ts`).
 
 - Task 0110: Added the SEC gap register (entry 0110-RM) summarising the pending
   read-model live data handshake, linked DD/TDD cross-references to the register,

--- a/packages/facade/src/server/readModelProviders.ts
+++ b/packages/facade/src/server/readModelProviders.ts
@@ -11,6 +11,23 @@ import type {
   WorkforceWarning,
   WorkforceState
 } from '@wb/engine';
+import { HOURS_PER_DAY } from '@engine/constants/time.js';
+import {
+  parseCultivationMethodBlueprint
+} from '@/backend/src/domain/blueprints/cultivationMethodBlueprint.ts';
+import { parseContainerBlueprint } from '@/backend/src/domain/blueprints/containerBlueprint.ts';
+import { parseSubstrateBlueprint } from '@/backend/src/domain/blueprints/substrateBlueprint.ts';
+import { parseIrrigationBlueprint } from '@/backend/src/domain/blueprints/irrigationBlueprint.ts';
+import { estimateIrrigationCharge } from '@/backend/src/domain/irrigation/waterUsage.ts';
+import seaOfGreenJson from '../../../../data/blueprints/cultivation-method/sea-of-green.json' with { type: 'json' };
+import screenOfGreenJson from '../../../../data/blueprints/cultivation-method/screen-of-green.json' with { type: 'json' };
+import pot11Json from '../../../../data/blueprints/container/pot-11l.json' with { type: 'json' };
+import pot25Json from '../../../../data/blueprints/container/pot-25l.json' with { type: 'json' };
+import cocoCoirJson from '../../../../data/blueprints/substrate/coco-coir.json' with { type: 'json' };
+import soilMultiJson from '../../../../data/blueprints/substrate/soil-multi-cycle.json' with { type: 'json' };
+import soilSingleJson from '../../../../data/blueprints/substrate/soil-single-cycle.json' with { type: 'json' };
+import dripJson from '../../../../data/blueprints/irrigation/drip-inline-fertigation-basic.json' with { type: 'json' };
+import manualIrrigationJson from '../../../../data/blueprints/irrigation/manual-watering-can.json' with { type: 'json' };
 import {
   COMPANY_TREE_SCHEMA_VERSION,
   STRUCTURE_TARIFFS_SCHEMA_VERSION,
@@ -30,7 +47,8 @@ import {
   type SimulationReadModel,
   type HrReadModel,
   type PriceBookCatalog,
-  type CompatibilityMaps
+  type CompatibilityMaps,
+  type StructureWarning
 } from '../readModels/snapshot.js';
 import { structureTariffs as createStructureTariffsReadModel } from '@/backend/src/readmodels/economy/structureTariffs.ts';
 
@@ -38,6 +56,290 @@ interface EngineContext {
   readonly world: SimulationWorld;
   readonly companyWorld: ParsedCompanyWorld;
   readonly config: EngineBootstrapConfig;
+}
+
+const CULTIVATION_BLUEPRINTS = [
+  parseCultivationMethodBlueprint(seaOfGreenJson),
+  parseCultivationMethodBlueprint(screenOfGreenJson)
+] as const;
+const CULTIVATION_BY_ID = new Map(CULTIVATION_BLUEPRINTS.map((blueprint) => [blueprint.id, blueprint]));
+
+const CONTAINER_BLUEPRINTS = [
+  parseContainerBlueprint(pot11Json),
+  parseContainerBlueprint(pot25Json)
+] as const;
+const CONTAINER_BY_ID = new Map(CONTAINER_BLUEPRINTS.map((blueprint) => [blueprint.id, blueprint]));
+
+const SUBSTRATE_BLUEPRINTS = [
+  parseSubstrateBlueprint(cocoCoirJson),
+  parseSubstrateBlueprint(soilMultiJson),
+  parseSubstrateBlueprint(soilSingleJson)
+] as const;
+const SUBSTRATE_BY_ID = new Map(SUBSTRATE_BLUEPRINTS.map((blueprint) => [blueprint.id, blueprint]));
+const SUBSTRATE_SLUG_SET = new Set(SUBSTRATE_BLUEPRINTS.map((blueprint) => blueprint.slug));
+
+const IRRIGATION_BLUEPRINTS = [
+  parseIrrigationBlueprint(dripJson, { knownSubstrateSlugs: SUBSTRATE_SLUG_SET }),
+  parseIrrigationBlueprint(manualIrrigationJson, { knownSubstrateSlugs: SUBSTRATE_SLUG_SET })
+] as const;
+const IRRIGATION_BY_ID = new Map(IRRIGATION_BLUEPRINTS.map((blueprint) => [blueprint.id, blueprint]));
+
+const STRUCTURE_LIGHTING_TARGET = 1;
+const STRUCTURE_HVAC_TARGET = 1;
+const STRUCTURE_AIRFLOW_TARGET = 6;
+
+function clampFraction(value: number | undefined): number {
+  if (typeof value !== 'number' || Number.isNaN(value) || !Number.isFinite(value)) {
+    return 0;
+  }
+
+  if (value < 0) {
+    return 0;
+  }
+
+  if (value > 1) {
+    return 1;
+  }
+
+  return value;
+}
+
+function roundTo(value: number, digits = 6): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Number.parseFloat(value.toFixed(digits));
+}
+
+interface StructureMetrics {
+  readonly lightingCoverage01: number;
+  readonly hvacCapacity01: number;
+  readonly airflowAch: number;
+  readonly energyKwhPerDay: number;
+  readonly waterM3PerDay: number;
+  readonly labourHoursPerDay: number;
+  readonly maintenanceCostPerHour: number;
+  readonly coverageWarnings: readonly StructureWarning[];
+}
+
+interface DeviceContribution {
+  readonly lightingCoverage: number;
+  readonly hvacCoverage: number;
+  readonly airflow_m3_per_h: number;
+  readonly energyKwhPerDay: number;
+  readonly maintenanceCostPerHour: number;
+}
+
+function resolveCultivationMethod(id: string) {
+  return CULTIVATION_BY_ID.get(id);
+}
+
+function resolveContainer(id: string) {
+  return CONTAINER_BY_ID.get(id);
+}
+
+function resolveSubstrate(id: string) {
+  return SUBSTRATE_BY_ID.get(id);
+}
+
+function resolveIrrigation(id: string) {
+  return IRRIGATION_BY_ID.get(id);
+}
+
+function computePlantCount(zone: Zone): number {
+  const method = resolveCultivationMethod(zone.cultivationMethodId);
+  const areaPerPlant = method?.areaPerPlant_m2;
+
+  if (!Number.isFinite(areaPerPlant) || (areaPerPlant ?? 0) <= 0) {
+    return Math.max(1, Math.round(zone.floorArea_m2));
+  }
+
+  return Math.max(1, Math.floor(zone.floorArea_m2 / (areaPerPlant ?? 1)));
+}
+
+function computeCultivationLabourHours(zone: Zone, plantCount: number): number {
+  const method = resolveCultivationMethod(zone.cultivationMethodId);
+  const hoursPerPlantPerWeek = method?.laborProfile?.hoursPerPlantPerWeek;
+
+  if (!Number.isFinite(hoursPerPlantPerWeek) || (hoursPerPlantPerWeek ?? 0) <= 0) {
+    return 0;
+  }
+
+  return (hoursPerPlantPerWeek ?? 0) * plantCount / 7;
+}
+
+function computeIrrigationLabourHours(zone: Zone, plantCount: number): number {
+  const blueprint = resolveIrrigation(zone.irrigationMethodId) as
+    | { labor?: { basis?: string; minutes?: number } }
+    | undefined;
+  const labour = blueprint?.labor;
+  const minutes = labour?.minutes;
+
+  if (!Number.isFinite(minutes) || (minutes ?? 0) <= 0) {
+    return 0;
+  }
+
+  if (labour?.basis === 'perPlant') {
+    return ((minutes ?? 0) * plantCount) / 60;
+  }
+
+  return (minutes ?? 0) / 60;
+}
+
+function computeZoneWaterM3PerDay(zone: Zone, plantCount: number): number {
+  const container = resolveContainer(zone.containerId);
+  const substrate = resolveSubstrate(zone.substrateId);
+  const irrigation = resolveIrrigation(zone.irrigationMethodId) as
+    | { runoff?: { defaultFraction?: number } }
+    | undefined;
+
+  if (!container || !substrate) {
+    return 0;
+  }
+
+  const containerVolume = container.volumeInLiters;
+
+  if (!Number.isFinite(containerVolume) || containerVolume <= 0) {
+    return 0;
+  }
+
+  const runoffFraction = irrigation?.runoff?.defaultFraction;
+  const moistureTarget = clampFraction(zone.moisture01 ?? 0.5);
+
+  const estimate = estimateIrrigationCharge({
+    substrate: { densityFactor_L_per_kg: substrate.densityFactor_L_per_kg },
+    containerVolume_L: containerVolume,
+    plantCount,
+    targetMoistureFraction01: moistureTarget,
+    runoffFraction01:
+      typeof runoffFraction === 'number' && runoffFraction > 0 && runoffFraction < 1
+        ? runoffFraction
+        : undefined
+  });
+
+  return estimate.deliveredVolume_L / 1000;
+}
+
+function computeDeviceContribution(device: DeviceInstance, scheduleHours?: number): DeviceContribution {
+  const effects = Array.isArray(device.effects) ? device.effects : [];
+  const isLighting = effects.includes('lighting');
+  const isHvac = !isLighting && effects.some((effect) => effect === 'thermal' || effect === 'humidity' || effect === 'airflow');
+  const coverage = Number.isFinite(device.coverage_m2) && device.coverage_m2 > 0 ? device.coverage_m2 : 0;
+  const airflow = Number.isFinite(device.airflow_m3_per_h) && device.airflow_m3_per_h > 0 ? device.airflow_m3_per_h : 0;
+  const duty = clampFraction(device.dutyCycle01 ?? 1);
+  const powerDraw_W = Number.isFinite(device.powerDraw_W) && device.powerDraw_W > 0 ? device.powerDraw_W : 0;
+  const hours = isLighting && Number.isFinite(scheduleHours)
+    ? (scheduleHours as number)
+    : HOURS_PER_DAY;
+  const energyKwhPerDay = (powerDraw_W / 1000) * duty * hours;
+  const maintenanceCostPerHour = Number.isFinite(device.maintenance?.policy?.baseCostPerHourCc)
+    ? device.maintenance.policy.baseCostPerHourCc
+    : 0;
+
+  return {
+    lightingCoverage: isLighting ? coverage : 0,
+    hvacCoverage: isHvac ? coverage : 0,
+    airflow_m3_per_h: airflow,
+    energyKwhPerDay,
+    maintenanceCostPerHour
+  } satisfies DeviceContribution;
+}
+
+function computeStructureMetrics(structure: Structure): StructureMetrics {
+  let zoneAreaTotal = 0;
+  let zoneVolumeTotal = 0;
+  let lightingCoverageTotal = 0;
+  let hvacCoverageTotal = 0;
+  let airflowTotal = 0;
+  let energyKwhPerDay = 0;
+  let waterM3PerDay = 0;
+  let labourHoursPerDay = 0;
+  let maintenanceCostPerHour = 0;
+
+  for (const room of structure.rooms) {
+    for (const zone of room.zones) {
+      const plantCount = computePlantCount(zone);
+      const zoneArea = zone.floorArea_m2;
+      const zoneVolume = toVolume(zone.floorArea_m2, zone.height_m);
+
+      zoneAreaTotal += zoneArea;
+      zoneVolumeTotal += zoneVolume;
+      labourHoursPerDay += computeCultivationLabourHours(zone, plantCount);
+      labourHoursPerDay += computeIrrigationLabourHours(zone, plantCount);
+      waterM3PerDay += computeZoneWaterM3PerDay(zone, plantCount);
+
+      for (const device of zone.devices) {
+        const contribution = computeDeviceContribution(device, zone.lightSchedule?.onHours);
+        lightingCoverageTotal += contribution.lightingCoverage;
+        hvacCoverageTotal += contribution.hvacCoverage;
+        airflowTotal += contribution.airflow_m3_per_h;
+        energyKwhPerDay += contribution.energyKwhPerDay;
+        maintenanceCostPerHour += contribution.maintenanceCostPerHour;
+      }
+    }
+
+    for (const device of room.devices) {
+      const contribution = computeDeviceContribution(device);
+      lightingCoverageTotal += contribution.lightingCoverage;
+      hvacCoverageTotal += contribution.hvacCoverage;
+      airflowTotal += contribution.airflow_m3_per_h;
+      energyKwhPerDay += contribution.energyKwhPerDay;
+      maintenanceCostPerHour += contribution.maintenanceCostPerHour;
+    }
+  }
+
+  for (const device of structure.devices) {
+    const contribution = computeDeviceContribution(device);
+    lightingCoverageTotal += contribution.lightingCoverage;
+    hvacCoverageTotal += contribution.hvacCoverage;
+    airflowTotal += contribution.airflow_m3_per_h;
+    energyKwhPerDay += contribution.energyKwhPerDay;
+    maintenanceCostPerHour += contribution.maintenanceCostPerHour;
+  }
+
+  const lightingCoverage01 = zoneAreaTotal > 0 ? lightingCoverageTotal / zoneAreaTotal : 0;
+  const hvacCapacity01 = zoneAreaTotal > 0 ? hvacCoverageTotal / zoneAreaTotal : 0;
+  const airflowAch = zoneVolumeTotal > 0 ? airflowTotal / zoneVolumeTotal : 0;
+
+  const warnings: StructureWarning[] = [];
+
+  if (lightingCoverage01 < STRUCTURE_LIGHTING_TARGET) {
+    warnings.push({
+      id: `${structure.id}:lighting`,
+      message: `Lighting coverage at ${(lightingCoverage01 * 100).toFixed(2)}% of demand.`,
+      severity: 'warning'
+    });
+  }
+
+  if (hvacCapacity01 < STRUCTURE_HVAC_TARGET) {
+    warnings.push({
+      id: `${structure.id}:hvac`,
+      message: `HVAC coverage at ${(hvacCapacity01 * 100).toFixed(2)}% of demand.`,
+      severity: 'warning'
+    });
+  }
+
+  if (airflowAch < STRUCTURE_AIRFLOW_TARGET) {
+    warnings.push({
+      id: `${structure.id}:airflow`,
+      message: `Air changes at ${airflowAch.toFixed(2)} ACH (target ${STRUCTURE_AIRFLOW_TARGET}).`,
+      severity: 'warning'
+    });
+  }
+
+  warnings.sort((left, right) => left.id.localeCompare(right.id));
+
+  return {
+    lightingCoverage01: roundTo(lightingCoverage01),
+    hvacCapacity01: roundTo(hvacCapacity01),
+    airflowAch: roundTo(airflowAch),
+    energyKwhPerDay: roundTo(energyKwhPerDay),
+    waterM3PerDay: roundTo(waterM3PerDay),
+    labourHoursPerDay: roundTo(labourHoursPerDay),
+    maintenanceCostPerHour: roundTo(maintenanceCostPerHour),
+    coverageWarnings: warnings
+  } satisfies StructureMetrics;
 }
 
 function toVolume(area_m2: number, height_m: number): number {
@@ -170,7 +472,12 @@ function buildStructureLocation(structure: Structure, companyWorld: ParsedCompan
   return `${companyLocation.cityName}, ${companyLocation.countryName}`;
 }
 
-function mapStructure(structure: Structure, companyWorld: ParsedCompanyWorld, workforce: WorkforceState): StructureReadModel {
+function mapStructure(
+  structure: Structure,
+  companyWorld: ParsedCompanyWorld,
+  workforce: WorkforceState,
+  metrics: StructureMetrics
+): StructureReadModel {
   const rooms = structure.rooms.map((room) => mapRoom(structure.id, room));
   const structureZoneArea = rooms.reduce(
     (total, room) => total + room.capacity.areaUsed_m2,
@@ -201,16 +508,16 @@ function mapStructure(structure: Structure, companyWorld: ParsedCompanyWorld, wo
       volumeFree_m3: Number.parseFloat(volumeFree.toFixed(2))
     },
     coverage: {
-      lightingCoverage01: 0,
-      hvacCapacity01: 0,
-      airflowAch: 0,
-      warnings: []
+      lightingCoverage01: metrics.lightingCoverage01,
+      hvacCapacity01: metrics.hvacCapacity01,
+      airflowAch: metrics.airflowAch,
+      warnings: metrics.coverageWarnings
     },
     kpis: {
-      energyKwhPerDay: 0,
-      waterM3PerDay: 0,
-      labourHoursPerDay: 0,
-      maintenanceCostPerHour: 0
+      energyKwhPerDay: metrics.energyKwhPerDay,
+      waterM3PerDay: metrics.waterM3PerDay,
+      labourHoursPerDay: metrics.labourHoursPerDay,
+      maintenanceCostPerHour: metrics.maintenanceCostPerHour
     },
     devices: structure.devices.map(mapZoneDevice),
     rooms,
@@ -340,13 +647,42 @@ function mapSimulationReadModel(world: SimulationWorld): SimulationReadModel {
   } satisfies SimulationReadModel;
 }
 
-function mapEconomyReadModel(): EconomyReadModel {
+function sumLabourCostPerHour(workforce: WorkforceState): number {
+  return workforce.employees.reduce((total, employee) => {
+    const rate = employee.salaryExpectation_per_h;
+    if (!Number.isFinite(rate) || rate <= 0) {
+      return total;
+    }
+
+    return total + rate;
+  }, 0);
+}
+
+function mapEconomyReadModel(
+  structures: readonly StructureMetrics[],
+  workforce: WorkforceState,
+  tariffs: EngineBootstrapConfig['tariffs']
+): EconomyReadModel {
+  const totalEnergyPerDay = structures.reduce((sum, metrics) => sum + metrics.energyKwhPerDay, 0);
+  const totalWaterPerDay = structures.reduce((sum, metrics) => sum + metrics.waterM3PerDay, 0);
+  const energyPerHour = totalEnergyPerDay / HOURS_PER_DAY;
+  const waterPerHour = totalWaterPerDay / HOURS_PER_DAY;
+  const energyCostPerHour = energyPerHour * (tariffs.price_electricity ?? 0);
+  const waterCostPerHour = waterPerHour * (tariffs.price_water ?? 0);
+  const utilitiesCostPerHour = energyCostPerHour + waterCostPerHour;
+  const labourCostPerHour = sumLabourCostPerHour(workforce);
+  const maintenanceCostPerHour = structures.reduce(
+    (sum, metrics) => sum + metrics.maintenanceCostPerHour,
+    0
+  );
+  const operatingCostPerHour = labourCostPerHour + maintenanceCostPerHour + utilitiesCostPerHour;
+
   return {
     balance: 0,
-    deltaPerHour: 0,
-    operatingCostPerHour: 0,
-    labourCostPerHour: 0,
-    utilitiesCostPerHour: 0
+    deltaPerHour: roundTo(-operatingCostPerHour),
+    operatingCostPerHour: roundTo(operatingCostPerHour),
+    labourCostPerHour: roundTo(labourCostPerHour),
+    utilitiesCostPerHour: roundTo(utilitiesCostPerHour)
   } satisfies EconomyReadModel;
 }
 
@@ -392,6 +728,31 @@ function mapCompatibility(): CompatibilityMaps {
   } satisfies CompatibilityMaps;
 }
 
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+
+    if (!Object.isFrozen(value)) {
+      Object.freeze(value);
+    }
+
+    if (Array.isArray(value)) {
+      for (const element of value) {
+        deepFreeze(element);
+      }
+    } else {
+      for (const key of Object.keys(record)) {
+        const nested = record[key];
+        if (nested && typeof nested === 'object') {
+          deepFreeze(nested);
+        }
+      }
+    }
+  }
+
+  return value;
+}
+
 export function createReadModelProviders(context: EngineContext) {
   return {
     async companyTree(): Promise<CompanyTreeReadModel> {
@@ -405,15 +766,17 @@ export function createReadModelProviders(context: EngineContext) {
     },
     async readModels(): Promise<ReadModelSnapshot> {
       const simulation = mapSimulationReadModel(context.world);
-      const economy = mapEconomyReadModel();
-      const structures = context.world.company.structures.map((structure) =>
-        mapStructure(structure, context.companyWorld, context.world.workforce)
+      const rawStructures = context.world.company.structures;
+      const structureMetrics = rawStructures.map((structure) => computeStructureMetrics(structure));
+      const structures = rawStructures.map((structure, index) =>
+        mapStructure(structure, context.companyWorld, context.world.workforce, structureMetrics[index])
       );
+      const economy = mapEconomyReadModel(structureMetrics, context.world.workforce, context.config.tariffs);
       const hr = mapHrReadModel(context.world.workforce);
       const priceBook = mapPriceBook();
       const compatibility = mapCompatibility();
 
-      return composeReadModelSnapshot({
+      const snapshot = composeReadModelSnapshot({
         simulation,
         economy,
         structures,
@@ -421,6 +784,8 @@ export function createReadModelProviders(context: EngineContext) {
         priceBook,
         compatibility
       });
+
+      return deepFreeze(snapshot);
     }
   };
 }

--- a/packages/facade/tests/unit/server/readModelProviders.test.ts
+++ b/packages/facade/tests/unit/server/readModelProviders.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { initializeFacade } from '../../../src/index.ts';
 import { createReadModelProviders } from '../../../src/server/readModelProviders.ts';
 import { createDemoWorld } from '@/backend/src/engine/testHarness.ts';
+import { createDeterministicWorld } from '@wb/facade/backend/deterministicWorldLoader';
 import type {
   Employee,
   EmployeeRole,
@@ -120,5 +121,74 @@ describe('createReadModelProviders', () => {
     const snapshot = await providers.readModels();
     expect(snapshot.structures).toHaveLength(world.company.structures.length);
     expect(snapshot.simulation.simTimeHours).toBe(world.simTimeHours);
+  });
+
+  it('computes deterministic structure KPI metrics', async () => {
+    const { world, companyWorld } = createDeterministicWorld();
+    const { engineConfig } = initializeFacade({
+      scenarioId: 'deterministic',
+      verbose: false,
+      world: companyWorld
+    });
+
+    const providers = createReadModelProviders({ world, companyWorld, config: engineConfig });
+    const snapshot = await providers.readModels();
+
+    expect(snapshot.structures).toHaveLength(2);
+    const structuresByName = Object.fromEntries(
+      snapshot.structures.map((structure) => [structure.name, structure])
+    );
+    const alpha = structuresByName['Small Warehouse Alpha'];
+    const beta = structuresByName['Medium Warehouse Beta'];
+
+    expect(alpha).toBeDefined();
+    expect(beta).toBeDefined();
+
+    if (!alpha || !beta) {
+      throw new Error('Deterministic structures not found in snapshot');
+    }
+
+    expect(alpha.coverage.lightingCoverage01).toBeCloseTo(0.0075, 6);
+    expect(alpha.coverage.hvacCapacity01).toBeCloseTo(0.09375, 6);
+    expect(alpha.coverage.airflowAch).toBeCloseTo(0.541667, 6);
+    expect(alpha.kpis.energyKwhPerDay).toBeCloseTo(48, 6);
+    expect(alpha.kpis.waterM3PerDay).toBeCloseTo(2.164706, 6);
+    expect(alpha.kpis.labourHoursPerDay).toBeCloseTo(93.27381, 6);
+    expect(alpha.kpis.maintenanceCostPerHour).toBeCloseTo(0.0085, 6);
+    expect(alpha.coverage.warnings).toHaveLength(3);
+
+    expect(beta.coverage.lightingCoverage01).toBeCloseTo(0.005, 6);
+    expect(beta.coverage.hvacCapacity01).toBeCloseTo(0.034708, 6);
+    expect(beta.coverage.airflowAch).toBeCloseTo(0, 6);
+    expect(beta.kpis.energyKwhPerDay).toBeCloseTo(15.6, 6);
+    expect(beta.kpis.waterM3PerDay).toBeCloseTo(0.172549, 6);
+    expect(beta.kpis.labourHoursPerDay).toBeCloseTo(41.22619, 6);
+    expect(beta.kpis.maintenanceCostPerHour).toBeCloseTo(0.004, 6);
+    expect(beta.coverage.warnings).toHaveLength(3);
+  });
+
+  it('freezes read-model snapshots and aggregates economy costs', async () => {
+    const { world, companyWorld } = createDeterministicWorld();
+    const { engineConfig } = initializeFacade({
+      scenarioId: 'deterministic',
+      verbose: false,
+      world: companyWorld
+    });
+
+    const providers = createReadModelProviders({ world, companyWorld, config: engineConfig });
+    const snapshot = await providers.readModels();
+
+    expect(Object.isFrozen(snapshot)).toBe(true);
+    expect(Object.isFrozen(snapshot.structures)).toBe(true);
+
+    expect(snapshot.economy.labourCostPerHour).toBeCloseTo(64.6, 6);
+    expect(snapshot.economy.utilitiesCostPerHour).toBeCloseTo(1.122271, 6);
+    expect(snapshot.economy.operatingCostPerHour).toBeCloseTo(65.734771, 6);
+    expect(snapshot.economy.deltaPerHour).toBeCloseTo(-65.734771, 6);
+
+    expect(() => {
+      const first = snapshot.structures[0] as unknown as { coverage: { lightingCoverage01: number } };
+      first.coverage.lightingCoverage01 = 1;
+    }).toThrow(TypeError);
   });
 });


### PR DESCRIPTION
## Summary
- import deterministic cultivation, container, substrate, and irrigation blueprints to compute structure coverage, KPI, and economy metrics before composing the façade read-model snapshot.
- deep-freeze read-model payloads and reuse the derived structure metrics to drive hourly economy rollups before transport exposure.
- update deterministic KPI unit coverage to locate structures by name and assert seeded lighting, HVAC, airflow, labour, energy, and water values.

## References
- SEC §2 hierarchy, §5 economy
- TDD §4 read-model normalization

## Testing
- `pnpm i`
- `pnpm -r test`
- `pnpm --filter @wb/facade test`
- `pnpm -r lint` *(fails: @wb/engine lint errors in updateEnvironment.ts and telemetry spec)*
- `pnpm -r build` *(fails: @wb/engine build blocked by tsconfig allowImportingTsExtensions rule)*

## Deviations
- Lint command currently blocked by existing @wb/engine rule violations (no-engine-percent-identifiers and no-unnecessary-condition assertions). Did not modify engine package.
- Build command fails in @wb/engine due to tsconfig restriction on allowImportingTsExtensions without noEmit/emitDeclarationOnly. Kept build unchanged to avoid out-of-scope engine edits.

------
https://chatgpt.com/codex/tasks/task_e_68f212bfcda083259da19681478099cd