### PR TITLE
feat(task:1120): Room & Zone Snapshots

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,8 @@
 
 - Task 1100: Introduced a deterministic world loader that assembles company, structure, zone, device, and workforce fixtures from blueprint and price catalogs, updated the façade dev servers to seed from it, and shipped unit coverage ensuring stable seeds and blueprint integration (`packages/facade/src/backend/deterministicWorldLoader.ts`, `packages/facade/src/transport/devServer.ts`, `packages/facade/src/server/devServer.ts`, `packages/facade/tests/unit/backend/deterministicWorldLoader.test.ts`).
 - Task 1110: Hydrated structure read-model coverage, KPI, and economy aggregates using the deterministic world loader, deep-froze façade snapshots before transport, and added unit coverage asserting seeded metrics and freeze behaviour (`packages/facade/src/server/readModelProviders.ts`, `packages/facade/tests/unit/server/readModelProviders.test.ts`).
+- Task 1120: Hydrated room and zone snapshots with deterministic climate metrics, compatibility joins, and price-book catalogs derived from the façade deterministic world, and added unit coverage for climate aggregation, compatibility wiring, and zone task mapping (`packages/facade/src/server/readModelProviders.ts`, `packages/facade/tests/unit/server/readModelProviders.test.ts`).
+  - Normalised zone telemetry humidity to the canonical [0,1] scale and updated façade/UI consumers to convert to presentation units where needed (`packages/engine/src/backend/src/engine/pipeline/updateEnvironment.ts`, `packages/engine/src/backend/src/telemetry/topics.ts`, `packages/ui/src/pages/zoneDetailHooks.ts`, `packages/ui/src/state/telemetry.ts`).
 
 - Task 0110: Added the SEC gap register (entry 0110-RM) summarising the pending
   read-model live data handshake, linked DD/TDD cross-references to the register,

--- a/packages/engine/src/backend/src/engine/pipeline/updateEnvironment.ts
+++ b/packages/engine/src/backend/src/engine/pipeline/updateEnvironment.ts
@@ -13,14 +13,6 @@ function isFiniteNumber(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value);
 }
 
-function toPercent(value: number): number {
-  if (!isFiniteNumber(value)) {
-    return 0;
-  }
-
-  return value * 100;
-}
-
 function createZoneWarnings(
   zone: Zone,
   ach: number,
@@ -47,6 +39,22 @@ function createZoneWarnings(
   return warnings;
 }
 
+function clampFraction(value: number | undefined): number {
+  if (!isFiniteNumber(value)) {
+    return 0;
+  }
+
+  if (value < 0) {
+    return 0;
+  }
+
+  if (value > 1) {
+    return 1;
+  }
+
+  return value;
+}
+
 function createZoneSnapshot(
   zone: Zone,
   simTime: number,
@@ -62,7 +70,7 @@ function createZoneSnapshot(
     ppfd: isFiniteNumber(zone.ppfd_umol_m2s) ? zone.ppfd_umol_m2s : 0,
     dli_incremental: isFiniteNumber(zone.dli_mol_m2d_inc) ? zone.dli_mol_m2d_inc : 0,
     temp_c: isFiniteNumber(environment.airTemperatureC) ? environment.airTemperatureC : 0,
-    rh: toPercent(environment.relativeHumidity01),
+    relativeHumidity01: clampFraction(environment.relativeHumidity01),
     co2_ppm: isFiniteNumber(environment.co2_ppm) ? environment.co2_ppm : 0,
     ach: isFiniteNumber(ach) ? ach : 0,
     warnings,

--- a/packages/engine/src/backend/src/telemetry/topics.ts
+++ b/packages/engine/src/backend/src/telemetry/topics.ts
@@ -24,7 +24,7 @@ export interface TelemetryZoneSnapshotPayload {
   readonly ppfd: number;
   readonly dli_incremental: number;
   readonly temp_c: number;
-  readonly rh: number;
+  readonly relativeHumidity01: number;
   readonly co2_ppm: number;
   readonly ach: number;
   readonly warnings: readonly TelemetryZoneSnapshotWarning[];

--- a/packages/facade/tests/unit/server/readModelProviders.test.ts
+++ b/packages/facade/tests/unit/server/readModelProviders.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { initializeFacade } from '../../../src/index.ts';
 import { createReadModelProviders } from '../../../src/server/readModelProviders.ts';
 import { createDemoWorld } from '@/backend/src/engine/testHarness.ts';
+import { computeVpd_kPa } from '@/backend/src/physiology/vpd.ts';
 import { createDeterministicWorld } from '@wb/facade/backend/deterministicWorldLoader';
 import type {
   Employee,
@@ -165,6 +166,149 @@ describe('createReadModelProviders', () => {
     expect(beta.kpis.labourHoursPerDay).toBeCloseTo(41.22619, 6);
     expect(beta.kpis.maintenanceCostPerHour).toBeCloseTo(0.004, 6);
     expect(beta.coverage.warnings).toHaveLength(3);
+  });
+
+  it('hydrates room and zone climate snapshots using deterministic world state', async () => {
+    const { world, companyWorld } = createDeterministicWorld();
+    const { engineConfig } = initializeFacade({
+      scenarioId: 'deterministic',
+      verbose: false,
+      world: companyWorld
+    });
+
+    const providers = createReadModelProviders({ world, companyWorld, config: engineConfig });
+    const snapshot = await providers.readModels();
+
+    const alpha = snapshot.structures.find((structure) => structure.name === 'Small Warehouse Alpha');
+    expect(alpha).toBeDefined();
+    if (!alpha) {
+      throw new Error('Small Warehouse Alpha not found');
+    }
+
+    const growRoom = alpha.rooms.find((room) => room.purpose === 'growroom');
+    expect(growRoom).toBeDefined();
+    if (!growRoom) {
+      throw new Error('Growroom snapshot missing');
+    }
+
+    const firstZone = growRoom.zones[0];
+    expect(firstZone.climateSnapshot.temperature_C).toBeCloseTo(24, 6);
+    expect(firstZone.climateSnapshot.relativeHumidity_percent).toBe(58);
+    expect(firstZone.climateSnapshot.vpd_kPa).toBeCloseTo(computeVpd_kPa(24, 0.58), 6);
+
+    const expectedAchZoneOne = 350 / (180 * 3);
+    expect(firstZone.climateSnapshot.ach_measured).toBeCloseTo(expectedAchZoneOne, 6);
+    expect(firstZone.coverageWarnings).not.toHaveLength(0);
+
+    const expectedAchZoneTwo = 170 / (140 * 3);
+    const expectedRoomAch = (expectedAchZoneOne + expectedAchZoneTwo) / 2;
+    expect(growRoom.climateSnapshot.ach).toBeCloseTo(expectedRoomAch, 6);
+    expect(growRoom.coverage.achCurrent).toBeCloseTo(expectedRoomAch, 6);
+    expect(growRoom.coverage.climateWarnings).not.toHaveLength(0);
+  });
+
+  it('exposes compatibility maps and price book entries for deterministic blueprints', async () => {
+    const { world, companyWorld } = createDeterministicWorld();
+    const { engineConfig } = initializeFacade({
+      scenarioId: 'deterministic',
+      verbose: false,
+      world: companyWorld
+    });
+
+    const providers = createReadModelProviders({ world, companyWorld, config: engineConfig });
+    const snapshot = await providers.readModels();
+
+    const firstStructure = world.company.structures[0];
+    const firstZone = firstStructure.rooms[0]?.zones[0];
+    const secondZone = firstStructure.rooms[0]?.zones[1];
+    if (!firstZone || !secondZone) {
+      throw new Error('Deterministic zones missing');
+    }
+
+    const irrigationMap = snapshot.compatibility.cultivationToIrrigation[firstZone.cultivationMethodId];
+    expect(irrigationMap).toBeDefined();
+    expect(irrigationMap?.[firstZone.irrigationMethodId]).toBe('ok');
+    expect(irrigationMap?.[secondZone.irrigationMethodId]).toBe('warn');
+
+    const containerEntry = snapshot.priceBook.containers.find(
+      (entry) => entry.containerId === firstZone.containerId
+    );
+    expect(containerEntry).toBeDefined();
+    expect(containerEntry?.pricePerUnit).toBeGreaterThan(0);
+
+    const deviceSlug = firstZone.devices[0]?.slug;
+    const deviceEntry = snapshot.priceBook.devices.find((entry) => entry.deviceSlug === deviceSlug);
+    expect(deviceEntry).toBeDefined();
+    expect(deviceEntry?.capitalExpenditure).toBeGreaterThan(0);
+  });
+
+  it('maps workforce zone tasks from the active queue', async () => {
+    const { world, companyWorld } = createDeterministicWorld();
+    const targetStructure = world.company.structures[0];
+    const targetZone = targetStructure.rooms[0]?.zones[0];
+    if (!targetZone) {
+      throw new Error('Expected deterministic zone');
+    }
+
+    const employeeId = world.workforce.employees[0]?.id ?? ('00000000-0000-4000-8000-000000000021' as Uuid);
+
+    world.workforce = {
+      ...world.workforce,
+      taskQueue: [
+        {
+          id: '00000000-0000-4000-8000-000000000099' as Uuid,
+          taskCode: 'harvest_plants',
+          status: 'queued',
+          createdAtTick: 12,
+          dueTick: 24,
+          assignedEmployeeId: employeeId,
+          context: { zoneId: targetZone.id }
+        }
+      ]
+    } as typeof world.workforce;
+
+    const { engineConfig } = initializeFacade({
+      scenarioId: 'deterministic',
+      verbose: false,
+      world: companyWorld
+    });
+
+    const providers = createReadModelProviders({ world, companyWorld, config: engineConfig });
+    const snapshot = await providers.readModels();
+
+    const structureSnapshot = snapshot.structures.find((structure) => structure.id === targetStructure.id);
+    expect(structureSnapshot).toBeDefined();
+    if (!structureSnapshot) {
+      throw new Error('Structure snapshot missing');
+    }
+
+    const targetGrowRoom = targetStructure.rooms.find((room) => room.purpose === 'growroom');
+    expect(targetGrowRoom).toBeDefined();
+    if (!targetGrowRoom) {
+      throw new Error('Target grow room missing');
+    }
+    const roomSnapshot = structureSnapshot.rooms.find((room) => room.id === targetGrowRoom.id);
+    expect(roomSnapshot).toBeDefined();
+    if (!roomSnapshot) {
+      throw new Error('Room snapshot missing');
+    }
+
+    const zoneSnapshot = roomSnapshot.zones.find((zone) => zone.id === targetZone.id);
+    expect(zoneSnapshot).toBeDefined();
+    if (!zoneSnapshot) {
+      throw new Error('Zone snapshot missing');
+    }
+
+    expect(zoneSnapshot.tasks).toEqual([
+      {
+        id: '00000000-0000-4000-8000-000000000099',
+        type: 'harvest',
+        status: 'queued',
+        assigneeId: employeeId,
+        scheduledTick: 24,
+        targetZoneId: targetZone.id
+      }
+    ]);
   });
 
   it('freezes read-model snapshots and aggregates economy costs', async () => {

--- a/packages/transport-sio/tests/client.exports.test.ts
+++ b/packages/transport-sio/tests/client.exports.test.ts
@@ -20,6 +20,8 @@ describe('client entry point', () => {
   });
 
   it('provides the transport acknowledgement guard', () => {
-    expect(() => assertTransportAck({ ok: true })).not.toThrow();
+    expect(() => {
+      assertTransportAck({ ok: true });
+    }).not.toThrow();
   });
 });

--- a/packages/ui/src/pages/zoneDetailHooks.ts
+++ b/packages/ui/src/pages/zoneDetailHooks.ts
@@ -761,7 +761,9 @@ function buildZoneClimateControl(
 ): ZoneClimateControlSnapshot {
   const baseline = selectStageBaseline(zone, room);
   const measuredTemperature = telemetry?.temp_c ?? zone.climateSnapshot.temperature_C;
-  const measuredHumidity = telemetry?.rh ?? zone.climateSnapshot.relativeHumidity_percent;
+  const measuredHumidity = telemetry
+    ? telemetry.relativeHumidity01 * 100
+    : zone.climateSnapshot.relativeHumidity_percent;
   const measuredCo2 = telemetry?.co2_ppm ?? zone.climateSnapshot.co2_ppm;
   const measuredAch = telemetry?.ach ?? zone.climateSnapshot.ach_measured;
 

--- a/packages/ui/src/state/__tests__/telemetryStore.test.ts
+++ b/packages/ui/src/state/__tests__/telemetryStore.test.ts
@@ -20,7 +20,7 @@ const SAMPLE_ZONE_SIM_TIME = 42;
 const SAMPLE_PPFD = 520;
 const SAMPLE_DLI = 32;
 const SAMPLE_TEMPERATURE = 24.5;
-const SAMPLE_RELATIVE_HUMIDITY = 58;
+const SAMPLE_RELATIVE_HUMIDITY = 0.58;
 const SAMPLE_CO2 = 810;
 const SAMPLE_ACH = 5.6;
 const SAMPLE_TASKS_COMPLETED = 18;
@@ -55,7 +55,7 @@ function createSampleZoneSnapshot() {
     ppfd: SAMPLE_PPFD,
     dli_incremental: SAMPLE_DLI,
     temp_c: SAMPLE_TEMPERATURE,
-    rh: SAMPLE_RELATIVE_HUMIDITY,
+    relativeHumidity01: SAMPLE_RELATIVE_HUMIDITY,
     co2_ppm: SAMPLE_CO2,
     ach: SAMPLE_ACH,
     warnings: [

--- a/packages/ui/src/state/telemetry.ts
+++ b/packages/ui/src/state/telemetry.ts
@@ -27,7 +27,7 @@ export interface TelemetryZoneSnapshotPayload {
   readonly ppfd: number;
   readonly dli_incremental: number;
   readonly temp_c: number;
-  readonly rh: number;
+  readonly relativeHumidity01: number;
   readonly co2_ppm: number;
   readonly ach: number;
   readonly warnings: readonly TelemetryZoneSnapshotWarning[];


### PR DESCRIPTION
## Summary
- normalize engine zone telemetry to expose relativeHumidity01 on the canonical [0,1] scale and clamp invalid samples before emission (SEC §6)
- update telemetry payload contracts, façade/UI consumers, and supporting unit tests to convert humidity fractions into presentation units (TDD §4)
- document the telemetry contract adjustment in the Task 1120 changelog entry

## Testing
- `pnpm i`
- `pnpm -r test`
- `pnpm -r lint` *(fails: existing type-safety violations throughout packages/facade/src/server/readModelProviders.ts and related tests)*
- `pnpm -r build` *(fails: TypeScript error TS5096 in packages/engine/tsconfig.json requiring allowImportingTsExtensions without emit)*

## Deviations
- Lint and build remain red for the reasons noted above; scope limited to Task 1120 telemetry updates while pre-existing facade/engine issues are triaged separately.

------
https://chatgpt.com/codex/tasks/task_e_68f2804fd0a48325a77e9e8f5b3fae78