### PR TITLE
feat(task:2130): Telemetry Schema Docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -123,6 +123,12 @@
   `packages/facade/src/transport/devServer.ts`,
   `packages/facade/tests/integration/transport/playbackLoop.integration.test.ts`).
 
+- 2025-02-19 — Task 2130 Telemetry Schema Docs:
+  - Documented the Socket.IO telemetry topics backing UI Tasks 4100–4130 in `docs/tools/telemetry-schemas.md`, added schema guards in `packages/transport-sio/src/contracts/events.ts`, and extended unit coverage in `packages/transport-sio/tests/unit/telemetrySchemas.test.ts` so frontend consumers can validate payloads without backend spelunking.
+  - Quick reference (Tasks 4100–4130): `telemetry.tick.completed.v1` — `simTimeHours` plus per-hour cost rollups (`targetTicksPerHour`, `operatingCostPerHour`, `labourCostPerHour`, `utilitiesCostPerHour`). Sample `{"simTimeHours":72,"targetTicksPerHour":1,"operatingCostPerHour":125.5,"labourCostPerHour":82.25,"utilitiesCostPerHour":43.25}`.
+    `telemetry.zone.snapshot.v1` — zone climate slice with `ppfd`, `dli_incremental`, `temp_c`, `relativeHumidity01`, and warning envelopes. Sample `{"zoneId":"zone-001","simTime":72,"ppfd":650,"dli_incremental":35.2,"temp_c":24.5,"relativeHumidity01":0.6,"co2_ppm":900,"ach":12,"warnings":[{"code":"humidity-high","message":"Relative humidity trending above target.","severity":"warning"}]}`.
+    `telemetry.workforce.kpi.v1` — workforce snapshot spanning queue depth, utilisation, and morale metrics. Sample `{"snapshot":{"simTimeHours":72,"tasksCompleted":18,"queueDepth":2,"laborHoursCommitted":24,"utilization01":0.58,"maintenanceBacklog":3,"averageMorale01":0.74,"averageFatigue01":0.41}}`.
+
 - Task 6000: Replaced the workforce KPI shell with the HR directory, activity
   timeline, task queues, capacity snapshot, and action panel. Introduced
   workforce filter state via Zustand, wired the HR route to the new intent

--- a/docs/tools/telemetry-schemas.md
+++ b/docs/tools/telemetry-schemas.md
@@ -1,0 +1,110 @@
+# Socket.IO Telemetry Schemas
+
+Task 2130 documents the Socket.IO telemetry topics the UI consumes for Tasks 4100–4130. These schemas mirror the façade contracts and
+align with SEC §4 (telemetry) and DD §4 (data interchange). Each topic lists required and optional fields plus a deterministic sample
+payload developers can replay in Storybook or local tools.
+
+> All values follow per-hour economy units and canonical [0,1] scaling for quality/morale as defined in SEC v0.2.1.
+
+## `telemetry.tick.completed.v1`
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `simTimeHours` | ✅ | Integer simulation hour counter. |
+| `targetTicksPerHour` | ➖ | Expected tick cadence; useful for detecting slowdowns. |
+| `actualTicksPerHour` | ➖ | Observed cadence over the last wall-clock window. |
+| `operatingCostPerHour` | ➖ | Total operating expenditure per in-game hour. |
+| `labourCostPerHour` | ➖ | Workforce spend per in-game hour. |
+| `utilitiesCostPerHour` | ➖ | Aggregate utilities cost per in-game hour. |
+| `energyKwhPerDay` | ➖ | Dailyised energy usage derived from per-hour draw. |
+| `energyCostPerHour` | ➖ | Per-hour electricity cost (post tariff resolution). |
+| `waterCubicMetersPerDay` | ➖ | Dailyised water usage derived from per-hour consumption. |
+| `waterCostPerHour` | ➖ | Per-hour water cost (post tariff resolution). |
+
+```json
+{
+  "simTimeHours": 72,
+  "targetTicksPerHour": 1,
+  "operatingCostPerHour": 125.5,
+  "labourCostPerHour": 82.25,
+  "utilitiesCostPerHour": 43.25
+}
+```
+
+## `telemetry.zone.snapshot.v1`
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `zoneId` | ✅ | Zone identifier (UUID or deterministic slug). |
+| `simTime` | ✅ | Tick number when the snapshot was captured. |
+| `ppfd` | ✅ | Photosynthetic photon flux density (µmol/m²/s). |
+| `dli_incremental` | ✅ | Delta daily light integral accumulated this tick. |
+| `temp_c` | ✅ | Zone temperature in °C. |
+| `relativeHumidity01` | ✅ | Relative humidity on [0,1] scale. |
+| `co2_ppm` | ✅ | CO₂ concentration (ppm). |
+| `ach` | ✅ | Air changes per hour. |
+| `warnings` | ➖ | Array of warning envelopes (`code`, `message`, `severity ∈ {'info','warning','critical'}`). |
+
+```json
+{
+  "zoneId": "zone-001",
+  "simTime": 72,
+  "ppfd": 650,
+  "dli_incremental": 35.2,
+  "temp_c": 24.5,
+  "relativeHumidity01": 0.6,
+  "co2_ppm": 900,
+  "ach": 12,
+  "warnings": [
+    {
+      "code": "humidity-high",
+      "message": "Relative humidity trending above target.",
+      "severity": "warning"
+    }
+  ]
+}
+```
+
+## `telemetry.workforce.kpi.v1`
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `snapshot.simTimeHours` | ✅ | Simulation hour when KPIs were sampled. |
+| `snapshot.tasksCompleted` | ✅ | Tasks completed during the sampled window. |
+| `snapshot.queueDepth` | ✅ | Outstanding task queue depth. |
+| `snapshot.laborHoursCommitted` | ✅ | Total labour hours scheduled. |
+| `snapshot.overtimeHoursCommitted` | ✅ | Overtime hours currently planned. |
+| `snapshot.overtimeMinutes` | ✅ | Overtime minutes (redundant convenience metric). |
+| `snapshot.p95WaitTimeHours` | ✅ | 95th percentile wait time for pending tasks (hours). |
+| `snapshot.maintenanceBacklog` | ✅ | Outstanding maintenance task count. |
+| `snapshot.utilization01` | ✅ | Workforce utilisation on [0,1]. |
+| `snapshot.averageMorale01` | ✅ | Average morale [0,1]. |
+| `snapshot.averageFatigue01` | ✅ | Average fatigue [0,1]. |
+
+```json
+{
+  "snapshot": {
+    "simTimeHours": 72,
+    "tasksCompleted": 18,
+    "queueDepth": 2,
+    "laborHoursCommitted": 24,
+    "overtimeHoursCommitted": 1.5,
+    "overtimeMinutes": 90,
+    "p95WaitTimeHours": 1.25,
+    "maintenanceBacklog": 3,
+    "utilization01": 0.58,
+    "averageMorale01": 0.74,
+    "averageFatigue01": 0.41
+  }
+}
+```
+
+### Frontend Integration Notes (Tasks 4100–4130)
+
+- Task 4100: Bind the dashboard telemetry widgets to the tick topic to drive live clock, cost rollups, and utilisation baselines.
+- Task 4110: Use the `zoneId` and climate fields to select the active zone card and derive deviation badges.
+- Task 4120: Hydrate the zone dashboard charts by combining `ppfd`, `dli_incremental`, and warning severities.
+- Task 4130: Feed the workforce dashboard KPIs from the snapshot payload. Normalise `[0,1]` fields to percentages for display.
+
+For deterministic tests, reuse the schema metadata in `packages/transport-sio/src/contracts/events.ts` and the Vitest samples under
+`packages/transport-sio/tests/unit/telemetrySchemas.test.ts`.

--- a/packages/transport-sio/src/contracts/events.ts
+++ b/packages/transport-sio/src/contracts/events.ts
@@ -12,6 +12,65 @@ export interface TelemetryEvent {
   readonly payload: unknown;
 }
 
+export const TELEMETRY_TICK_COMPLETED_TOPIC = 'telemetry.tick.completed.v1' as const;
+export const TELEMETRY_ZONE_SNAPSHOT_TOPIC = 'telemetry.zone.snapshot.v1' as const;
+export const TELEMETRY_WORKFORCE_KPI_TOPIC = 'telemetry.workforce.kpi.v1' as const;
+
+export type TelemetryTopic =
+  | typeof TELEMETRY_TICK_COMPLETED_TOPIC
+  | typeof TELEMETRY_ZONE_SNAPSHOT_TOPIC
+  | typeof TELEMETRY_WORKFORCE_KPI_TOPIC;
+
+export interface TelemetryNestedFieldSpec {
+  readonly key: string;
+  readonly kind: 'object' | 'array';
+  readonly required: readonly string[];
+  readonly optional?: readonly string[];
+  readonly bounded01?: readonly string[];
+  readonly enumValues?: Record<string, readonly string[]>;
+}
+
+export interface TelemetryTopicSchema {
+  readonly topic: TelemetryTopic;
+  readonly required: readonly string[];
+  readonly optional?: readonly string[];
+  readonly bounded01?: readonly string[];
+  readonly nested?: readonly TelemetryNestedFieldSpec[];
+}
+
+export const TELEMETRY_TOPIC_SCHEMAS: readonly TelemetryTopicSchema[] = [
+  {
+    topic: TELEMETRY_TICK_COMPLETED_TOPIC,
+    required: ['simTimeHours'],
+    optional: ['targetTicksPerHour', 'actualTicksPerHour', 'operatingCostPerHour', 'labourCostPerHour', 'utilitiesCostPerHour', 'energyKwhPerDay', 'energyCostPerHour', 'waterCubicMetersPerDay', 'waterCostPerHour']
+  },
+  {
+    topic: TELEMETRY_ZONE_SNAPSHOT_TOPIC,
+    required: ['zoneId', 'simTime', 'ppfd', 'dli_incremental', 'temp_c', 'relativeHumidity01', 'co2_ppm', 'ach'],
+    bounded01: ['relativeHumidity01'],
+    nested: [
+      {
+        key: 'warnings',
+        kind: 'array',
+        required: ['code', 'message', 'severity'],
+        enumValues: { severity: ['info', 'warning', 'critical'] }
+      }
+    ]
+  },
+  {
+    topic: TELEMETRY_WORKFORCE_KPI_TOPIC,
+    required: ['snapshot'],
+    nested: [
+      {
+        key: 'snapshot',
+        kind: 'object',
+        required: ['simTimeHours', 'tasksCompleted', 'queueDepth', 'laborHoursCommitted', 'overtimeHoursCommitted', 'overtimeMinutes', 'p95WaitTimeHours', 'maintenanceBacklog', 'utilization01', 'averageMorale01', 'averageFatigue01'],
+        bounded01: ['utilization01', 'averageMorale01', 'averageFatigue01']
+      }
+    ]
+  }
+];
+
 /**
  * Envelope describing an intent emitted by clients.
  */

--- a/packages/transport-sio/tests/unit/telemetrySchemas.test.ts
+++ b/packages/transport-sio/tests/unit/telemetrySchemas.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  TELEMETRY_TICK_COMPLETED_TOPIC,
+  TELEMETRY_TOPIC_SCHEMAS,
+  TELEMETRY_WORKFORCE_KPI_TOPIC,
+  TELEMETRY_ZONE_SNAPSHOT_TOPIC,
+} from '../../src/contracts/events.ts';
+
+const SAMPLES: Record<string, unknown> = {
+  [TELEMETRY_TICK_COMPLETED_TOPIC]: {
+    simTimeHours: 72,
+    targetTicksPerHour: 1,
+    operatingCostPerHour: 125.5,
+    labourCostPerHour: 82.25,
+    utilitiesCostPerHour: 43.25,
+  },
+  [TELEMETRY_ZONE_SNAPSHOT_TOPIC]: {
+    zoneId: 'zone-001',
+    simTime: 72,
+    ppfd: 650,
+    dli_incremental: 35.2,
+    temp_c: 24.5,
+    relativeHumidity01: 0.6,
+    co2_ppm: 900,
+    ach: 12,
+    warnings: [
+      {
+        code: 'humidity-high',
+        message: 'Relative humidity trending above target.',
+        severity: 'warning',
+      },
+    ],
+  },
+  [TELEMETRY_WORKFORCE_KPI_TOPIC]: {
+    snapshot: {
+      simTimeHours: 72,
+      tasksCompleted: 18,
+      queueDepth: 2,
+      laborHoursCommitted: 24,
+      overtimeHoursCommitted: 1.5,
+      overtimeMinutes: 90,
+      p95WaitTimeHours: 1.25,
+      maintenanceBacklog: 3,
+      utilization01: 0.58,
+      averageMorale01: 0.74,
+      averageFatigue01: 0.41,
+    },
+  },
+};
+
+const isBounded01 = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1;
+
+describe('TELEMETRY_TOPIC_SCHEMAS', () => {
+  it('aligns canonical samples with documented field sets', () => {
+    for (const schema of TELEMETRY_TOPIC_SCHEMAS) {
+      const record = SAMPLES[schema.topic] as Record<string, unknown> | undefined;
+      expect(record, `Missing sample for ${schema.topic}`).toBeDefined();
+
+      for (const field of schema.required) {
+        expect(record?.[field]).toBeDefined();
+      }
+      if (schema.bounded01) {
+        for (const field of schema.bounded01) {
+          expect(isBounded01(record?.[field])).toBe(true);
+        }
+      }
+
+      schema.nested?.forEach((nested) => {
+        const value = record?.[nested.key];
+
+        if (nested.kind === 'object') {
+          const obj = value as Record<string, unknown> | undefined;
+          expect(obj).toBeDefined();
+          for (const field of nested.required) {
+            expect(obj?.[field]).toBeDefined();
+          }
+          if (nested.bounded01) {
+            for (const field of nested.bounded01) {
+              expect(isBounded01(obj?.[field])).toBe(true);
+            }
+          }
+        } else {
+          const entries = value as readonly Record<string, unknown>[] | undefined;
+          expect(Array.isArray(entries)).toBe(true);
+          entries?.forEach((entry) => {
+            for (const field of nested.required) {
+              expect(entry[field]).toBeDefined();
+            }
+            if (nested.enumValues) {
+              for (const [field, allowed] of Object.entries(nested.enumValues)) {
+                expect(allowed).toContain(entry[field]);
+              }
+            }
+          });
+        }
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Document the Socket.IO telemetry topic schemas for UI Tasks 4100–4130, referencing SEC §4 and DD §4 with required fields, optional metadata, and canonical samples in `docs/tools/telemetry-schemas.md`
- Publish structured schema metadata for tick, zone, and workforce telemetry topics in the transport contract, flagging bounded `[0,1]` fields and nested specs
- Add Vitest coverage that validates the documented schemas against canonical fixtures and capture the deliverable in the changelog

## Testing
- `pnpm i`
- `pnpm -r test`
- `pnpm --filter @wb/transport-sio test`
- `pnpm --filter @wb/transport-sio lint`
- `pnpm -r lint` *(fails: existing @wb/facade lint violations around non-null assertions and unnecessary conditionals)*
- `pnpm -r build` *(fails: known @wb/engine TypeScript configuration error with `allowImportingTsExtensions`)*

------
https://chatgpt.com/codex/tasks/task_e_68f32b512a088325a86ab380d2c00204