### PR TITLE
feat(task:4100): Read-Model Store Live Fetch

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,11 @@
     on live data wiring.
   - Recorded this milestone in the changelog to keep SEC/DD/TDD traceability aligned for UI documentation updates.
 
+- 2025-02-20 — Task 4100 Read-model Store Live Fetch:
+  - Upgraded the UI read-model store to expose `status` (`loading|ready|error`) and `lastError` metadata, orchestrate deterministic retry scheduling, and honour fixture fallbacks when no transport is configured (`packages/ui/src/state/readModels.ts`).
+  - Replaced the manual bootstrap call in `App.tsx` with store-driven initialisation so the first fetch automatically respects `VITE_TRANSPORT_BASE_URL`.
+  - Added fetch-backed unit coverage for success, failure, and transport-less scenarios plus updated hook expectations for the new status contract (`packages/ui/src/state/__tests__/readModelsStore.test.ts`, `packages/ui/src/lib/__tests__/readModelHooks.test.tsx`).
+
 - Task 0130: Added a simulation control contract checklist to TDD §6a and linked SEC §11 to the new guardrails so playback intents, acknowledgements, and telemetry expectations stay aligned with follow-up tasks 3100–3130 and 4140 (docs/TDD.md, docs/SEC.md).
 - Task 3110: Enabled environment adjustment intents for zone lighting/climate by extending the façade command pipeline with cultivation-method temperature validation, lighting coverage guards, and deterministic acknowledgement payloads (`packages/facade/src/transport/engineCommandPipeline.ts`, `packages/facade/tests/unit/transport/engineCommandPipeline.test.ts`). Updated the Socket.IO transport adapter and façade server contract so intent handlers can return success overlays consumed by acknowledgements (`packages/transport-sio/src/adapter.ts`, `packages/facade/src/transport/server.ts`).
 - Task 3120: Implemented workforce HR assignment, pest mitigation, and maintenance intent handlers with capacity guardrails and acknowledgement overlays, extending the engine scheduler plus façade parsing to surface deterministic roster deltas (`packages/engine/src/backend/src/workforce/index.ts`, `packages/engine/src/backend/src/domain/workforce/intents.ts`, `packages/facade/src/transport/engineCommandPipeline.ts`, `packages/engine/tests/unit/workforce/intents.test.ts`).

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from "react";
 import { RouterProvider, createBrowserRouter } from "react-router-dom";
 import { IntentClientProvider, createIntentClient, createTelemetryBinder, createReadModelClient } from "@ui/transport";
 import { workspaceRoutes } from "@ui/routes/workspaceRoutes";
-import { configureReadModelClient, refreshReadModels } from "@ui/state/readModels";
+import { configureReadModelClient } from "@ui/state/readModels";
 
 const runtimeBaseUrl = (() => {
   const configured = import.meta.env.VITE_TRANSPORT_BASE_URL as string | undefined;
@@ -36,10 +36,6 @@ if (telemetryBinder) {
 
 if (readModelClient) {
   configureReadModelClient(readModelClient);
-  void refreshReadModels().catch((error: unknown) => {
-    const message = error instanceof Error ? error.message : String(error);
-    console.warn("Read-model bootstrap failed", { message });
-  });
 } else {
   console.warn("Read-model client initialisation skipped: transport base URL was not configured.");
 }

--- a/packages/ui/src/lib/__tests__/readModelHooks.test.tsx
+++ b/packages/ui/src/lib/__tests__/readModelHooks.test.tsx
@@ -104,7 +104,9 @@ describe("readModel hooks", () => {
 
   it("updates status and data after a successful refresh", async () => {
     const refreshedSnapshot = createAlteredReadModelSnapshot();
-    configureReadModelClient(new StaticReadModelClient(refreshedSnapshot));
+    configureReadModelClient(new StaticReadModelClient(refreshedSnapshot), {
+      immediateRefresh: false
+    });
 
     await act(async () => {
       await refreshReadModels();
@@ -113,7 +115,7 @@ describe("readModel hooks", () => {
     const { result: statusResult } = renderHook(() => useReadModelStatus());
     expect(statusResult.current).toEqual({
       status: "ready",
-      error: null,
+      lastError: null,
       lastUpdatedSimTimeHours: refreshedSnapshot.simulation.simTimeHours,
       isRefreshing: false
     });

--- a/packages/ui/src/state/readModels.types.ts
+++ b/packages/ui/src/state/readModels.types.ts
@@ -340,11 +340,11 @@ export interface ReadModelSnapshot {
 
 export type FrozenReadModelSnapshot = ReadModelSnapshot;
 
-export type ReadModelStatus = "idle" | "loading" | "ready" | "error";
+export type ReadModelStatus = "loading" | "ready" | "error";
 
 export interface ReadModelStoreStatus {
   readonly status: ReadModelStatus;
-  readonly error: string | null;
+  readonly lastError: string | null;
   readonly lastUpdatedSimTimeHours: number | null;
   readonly isRefreshing: boolean;
 }


### PR DESCRIPTION
## Summary
- extend the UI read-model store with loading/error status, deterministic retry scheduling, and fixture fallback aligned with SEC §4 data transport and TDD §4 read-model store guidance
- wire the store to bootstrap automatically from the configured transport client in App.tsx
- refresh the unit suites to cover success, failure, and transport-less fetch paths while documenting the change in the changelog

## Testing
- `pnpm -r test`
- `pnpm -r lint`
- `pnpm -r build`


------
https://chatgpt.com/codex/tasks/task_e_68f3a4c94c588325b50b44928d46a04b