### PR TITLE
Align transport ack contract with tick metadata

### DIFF
--- a/packages/transport-sio/src/adapter.ts
+++ b/packages/transport-sio/src/adapter.ts
@@ -52,7 +52,9 @@ function createIntentSuccessAck(metadata: AckMetadata): TransportAck {
     ok: true,
     intentId: metadata.intentId,
     correlationId: metadata.correlationId,
-    status: 'queued'
+    status: 'queued',
+    queuedTick: null,
+    appliedTick: null
   } satisfies TransportAck;
 }
 
@@ -131,7 +133,9 @@ function createTelemetryRejection(): TransportAck {
       message: 'Telemetry channel is read-only per SEC §1 invariant.'
     },
     ...NULL_METADATA,
-    status: 'rejected'
+    status: 'rejected',
+    queuedTick: null,
+    appliedTick: null
   };
 }
 
@@ -143,7 +147,9 @@ function createIntentChannelRejection(): TransportAck {
       message: 'Intents namespace only accepts intent submissions via intent:submit.'
     },
     ...NULL_METADATA,
-    status: 'rejected'
+    status: 'rejected',
+    queuedTick: null,
+    appliedTick: null
   };
 }
 
@@ -155,7 +161,9 @@ function createIntentValidationError(): TransportAck {
       message: 'Intent payload must be an object with a string type.'
     },
     ...NULL_METADATA,
-    status: 'rejected'
+    status: 'rejected',
+    queuedTick: null,
+    appliedTick: null
   };
 }
 
@@ -167,7 +175,9 @@ function createIntentHandlerError(message: string, metadata: AckMetadata): Trans
       message
     },
     ...metadata,
-    status: 'rejected'
+    status: 'rejected',
+    queuedTick: null,
+    appliedTick: null
   };
 }
 

--- a/packages/transport-sio/src/contracts/ack.ts
+++ b/packages/transport-sio/src/contracts/ack.ts
@@ -53,6 +53,12 @@ export interface TransportAck {
   readonly correlationId?: string | null;
   /** Deterministic status describing the acknowledgement lifecycle. */
   readonly status?: TransportAckStatus;
+  /** Tick when the intent entered the queue. */
+  readonly queuedTick?: number | null;
+  /** Tick when the intent effects were applied. */
+  readonly appliedTick?: number | null;
+  /** Deterministic state snapshot surfaced after intent processing. */
+  readonly stateAfter?: unknown;
 }
 
 function isAckStatus(value: unknown): value is TransportAckStatus {
@@ -61,6 +67,14 @@ function isAckStatus(value: unknown): value is TransportAckStatus {
 
 function isOptionalString(value: unknown): value is string | null | undefined {
   return value === undefined || value === null || typeof value === 'string';
+}
+
+function isOptionalNumber(value: unknown): value is number | null | undefined {
+  if (value === undefined || value === null) {
+    return true;
+  }
+
+  return typeof value === 'number' && Number.isFinite(value);
 }
 
 function isTransportAckError(value: unknown): value is TransportAckError {
@@ -99,6 +113,8 @@ export function assertTransportAck(payload: unknown): asserts payload is Transpo
   const intentId = record.intentId;
   const correlationId = record.correlationId;
   const status = record.status;
+  const queuedTick = record.queuedTick;
+  const appliedTick = record.appliedTick;
 
   if (!isOptionalString(intentId)) {
     throw new TypeError('Transport acknowledgement intentId must be a string or null when provided.');
@@ -110,6 +126,14 @@ export function assertTransportAck(payload: unknown): asserts payload is Transpo
 
   if (status !== undefined && !isAckStatus(status)) {
     throw new TypeError('Transport acknowledgement status must be queued, applied, or rejected when provided.');
+  }
+
+  if (!isOptionalNumber(queuedTick)) {
+    throw new TypeError('Transport acknowledgement queuedTick must be a finite number or null when provided.');
+  }
+
+  if (!isOptionalNumber(appliedTick)) {
+    throw new TypeError('Transport acknowledgement appliedTick must be a finite number or null when provided.');
   }
 
   if (ok) {


### PR DESCRIPTION
## Summary
- extend the Socket.IO transport acknowledgement contract so queued/applied tick metadata and state snapshots are always available
- propagate the new acknowledgement defaults through the adapter helpers so rejections surface the mandated tick fields

## Testing
- pnpm --filter @wb/transport-sio test

------
https://chatgpt.com/codex/tasks/task_e_68f4733bd9b88325926f99494de3c002