### PR TITLE
Fix UI transport alias to use client bundle

### DIFF
--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
       "@/backend": path.resolve(__dirname, "../engine/src/backend"),
       "@wb/engine": path.resolve(__dirname, "../engine/src"),
       "@wb/facade": path.resolve(__dirname, "../facade/src"),
-      "@wb/transport-sio": path.resolve(__dirname, "../transport-sio/src/index.ts")
+      "@wb/transport-sio": path.resolve(__dirname, "../transport-sio/src/client.ts")
     }
   },
   test: {


### PR DESCRIPTION
## Summary
- point the UI Vite alias for @wb/transport-sio to the browser-oriented client entry to avoid bundling server modules

## Testing
- pnpm --filter @wb/ui test *(fails: missing @vitejs/plugin-react-swc in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f4d30873208325a89ae262a8da8132