### PR TITLE
Align dev stack façade defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,11 @@ simulation world, and exposes live company tree, tariff, workforce, and
 aggregated snapshots through the Fastify HTTP endpoints. Restart the stack
 after modifying engine bootstrap data to refresh the published payloads.
 
-> Ensure `packages/ui/.env.local` (or your shell env) sets both
-> `VITE_FACADE_HTTP_BASE_URL` (for the Fastify read-model endpoint) and
-> `VITE_FACADE_TRANSPORT_BASE_URL` (for the Socket.IO transport), e.g.
-> `http://localhost:7100` and `http://localhost:7101`, before starting the stack.
+The script injects façade defaults into the Vite dev server when no overrides
+are present: `http://localhost:3333` for the Fastify read-model endpoint and
+`http://localhost:7101` for the Socket.IO transport. Persist custom values by
+copying `packages/ui/.env.example` to `.env.local` (or exporting them in your
+shell) before starting the stack.
 
 ### Quick Local Simulation (example)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,16 @@
 
 ### Unreleased — Hotfix Batch 03
 
+- 2025-03-?? — Dev stack façade defaults alignment:
+  - Wrapped the UI dev server in a helper script so `pnpm run dev:stack`
+    automatically injects `http://localhost:3333` (Fastify read models) and
+    `http://localhost:7101` (Socket.IO transport) unless contributors override
+    them (`tools/scripts/run-ui-dev-with-facade-env.mjs`, `package.json`).
+  - Added `packages/ui/.env.example` so developers can persist façade base URL
+    overrides without retyping them between sessions.
+  - Updated the README and dev stack tooling guide to document the twin façade
+    endpoints and the new workflow (`README.md`, `docs/tools/dev-stack.md`).
+
 - 2025-03-?? — Transport Bootstrap Env Split:
   - Separated the façade environment contract so read-model HTTP requests bind to
     `VITE_FACADE_HTTP_BASE_URL` while Socket.IO transport/intent traffic binds to

--- a/docs/tools/dev-stack.md
+++ b/docs/tools/dev-stack.md
@@ -15,6 +15,19 @@ pnpm --filter @wb/facade test:contract
 Keep workspace scripts aligned with these commands so CI matches the workflow
 documented in TDD §2.
 
+## Façade Read-Model Server Bootstrap
+
+The façade's Fastify server publishes read models for the UI and tooling.
+Launch it locally with:
+
+```bash
+pnpm --filter @wb/facade dev:server
+```
+
+The server listens on `0.0.0.0:3333` by default and logs the public URL as
+`http://localhost:3333`. Override the port with `FACADE_HTTP_PORT` before
+starting the process.
+
 ## Façade Transport Server Bootstrap
 
 The façade exposes a Socket.IO transport server that brokers telemetry and intent
@@ -40,3 +53,12 @@ deterministic tick, and acknowledge with `{ ok: true }`. Payload validation
 failures or unsupported intent types reject with
 `WB_INTENT_HANDLER_ERROR` acknowledgements, mirroring the Socket.IO contract
 described in SEC/TDD. Shutdown is triggered via `SIGINT`/`SIGTERM`.
+
+## UI Dev Server Configuration
+
+`pnpm run dev:stack` now injects façade defaults into the Vite dev server when
+the corresponding `VITE_*` variables are absent: `http://localhost:3333` for the
+read-model HTTP base and `http://localhost:7101` for the Socket.IO transport.
+Persist custom endpoints by copying `packages/ui/.env.example` to
+`packages/ui/.env.local` (or exporting values in your shell) before launching the
+stack.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "dev": "pnpm -r --parallel dev",
-    "dev:stack": "pnpm exec concurrently --kill-others --restart-tries 0 --names \"facade-rm,facade-transport,ui\" --prefix-colors \"cyan.bold,magenta.bold,green.bold\" \"pnpm --filter @wb/facade dev:server\" \"pnpm --filter @wb/facade transport:dev\" \"pnpm --filter @wb/ui dev\"",
+    "dev:stack": "pnpm exec concurrently --kill-others --restart-tries 0 --names \"facade-rm,facade-transport,ui\" --prefix-colors \"cyan.bold,magenta.bold,green.bold\" \"pnpm --filter @wb/facade dev:server\" \"pnpm --filter @wb/facade transport:dev\" \"node ./tools/scripts/run-ui-dev-with-facade-env.mjs\"",
     "build": "pnpm -r build",
     "typecheck": "pnpm -w tsc -p packages/engine/tsconfig.spec.json --noEmit",
     "lint": "pnpm exec eslint \"packages/**/*.{ts,tsx}\"",

--- a/packages/ui/.env.example
+++ b/packages/ui/.env.example
@@ -1,0 +1,3 @@
+# Default façade endpoints for the dev stack.
+VITE_FACADE_HTTP_BASE_URL=http://localhost:3333
+VITE_FACADE_TRANSPORT_BASE_URL=http://localhost:7101

--- a/tools/scripts/run-ui-dev-with-facade-env.mjs
+++ b/tools/scripts/run-ui-dev-with-facade-env.mjs
@@ -1,0 +1,41 @@
+import { spawn } from 'node:child_process';
+
+const DEFAULT_HTTP_BASE = 'http://localhost:3333';
+const DEFAULT_TRANSPORT_BASE = 'http://localhost:7101';
+
+const env = { ...process.env };
+
+if (!env.VITE_FACADE_HTTP_BASE_URL) {
+  env.VITE_FACADE_HTTP_BASE_URL = DEFAULT_HTTP_BASE;
+  console.log(
+    `[dev:stack] Defaulting VITE_FACADE_HTTP_BASE_URL to ${DEFAULT_HTTP_BASE}.`,
+  );
+}
+
+if (!env.VITE_FACADE_TRANSPORT_BASE_URL) {
+  env.VITE_FACADE_TRANSPORT_BASE_URL = DEFAULT_TRANSPORT_BASE;
+  console.log(
+    `[dev:stack] Defaulting VITE_FACADE_TRANSPORT_BASE_URL to ${DEFAULT_TRANSPORT_BASE}.`,
+  );
+}
+
+const pnpmCommand = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+
+const child = spawn(pnpmCommand, ['--filter', '@wb/ui', 'dev'], {
+  env,
+  stdio: 'inherit',
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.exit(0);
+    return;
+  }
+
+  process.exit(code ?? 0);
+});
+
+child.on('error', (error) => {
+  console.error('Failed to launch @wb/ui dev server:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- ensure the `pnpm run dev:stack` helper injects the façade Fastify and Socket.IO defaults into the UI process when overrides are absent
- add a checked-in `.env.example` for the UI package so contributors can persist façade base URLs locally
- document the new workflow and defaults in the README, dev stack tooling guide, and changelog

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f522e88e3c8325bb84dff46be3341b